### PR TITLE
Lay text blocks out once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - **iTerm2 Inline Image Protocol**: Added `terminal.iterm2` — PNG-encodes and base64-wraps an image into the iTerm2 `OSC 1337` inline-image sequence, with the same aspect-preserving scaling as the kitty/sixel encoders. Wired into `DisplayFormat` (new `.iterm2` variant) and the `.auto` degradation chain (now kitty → iterm2 → sixel → sgr → braille), the CLI `--protocol iterm2`, and terminal detection (`terminal.isIterm2Supported`, via an XTVERSION probe matching iTerm2/WezTerm).
 
 ### Improvements
+- **Text blocks lay out once**: `drawTextBox` keeps the wrapped lines from a single pass instead of measuring the block first, and unwrapped lines are only measured when the alignment needs their width (`Lines.Line.width` is now optional, `Lines.width` measures on demand), so `drawText` no longer walks every line twice. Cached text draws ~20% faster, uncached ~9%.
 - **Direction-independent polygon antialiasing**: `Canvas.fillPolygon` in `.soft` mode previously only ramped alpha at the left/right ends of each scanline span, so near-horizontal edges rendered with hard stair-steps. It now samples each pixel row at 8 sub-scanlines with exact horizontal coverage, giving smooth edges in every direction. Affects `fillPolygon`, `fillSplinePolygon`, and thick `drawArc` in `.soft` mode; `.fast` output is unchanged.
 - **Single-Threaded Build Robustness**: Sixel's palette LUT cache skips its atomic spinlock under `builtin.single_threaded` (avoids a latent panic on `wasm32-freestanding`).
 

--- a/src/canvas/Canvas.zig
+++ b/src/canvas/Canvas.zig
@@ -108,6 +108,9 @@ pub fn Canvas(comptime T: type) type {
         const max_ring_profile = 64;
         /// Below this many edges the fast fill tests them all per row instead of bucketing.
         const few_edges = 64;
+        /// Stack scratch (bytes) for the lines of a text block: 64 lines, longer texts spill
+        /// to the heap.
+        const lines_scratch_size = 64 * @sizeOf(text_layout.Lines.Line);
         /// Stack scratch (bytes) for polygon fills: edges and crossings for 256 vertices, a
         /// 1024-pixel coverage row and a 12k-cell area accumulator (a 110x110 shape); larger
         /// inputs spill to the heap.
@@ -2320,24 +2323,33 @@ pub fn Canvas(comptime T: type) type {
         }
 
         /// Shared by every text entry point: breaks `text` into lines, places the block and
-        /// each line inside `box` per `layout`, and draws the lines.
+        /// each line inside `box` per `layout`, and draws the lines. The lines are kept from
+        /// the one wrapping pass, since placing the block needs their count first.
         fn renderText(self: Self, text: []const u8, box: Rectangle(f32), paint: Paint, font: Font, font_size: ?f32, layout: TextLayout, style: GlyphStyle, mode: DrawMode) !void {
             const px = font_size orelse font.defaultSize();
             if (px <= 0) return;
             const max_width: ?f32 = if (layout.wrap) box.width() else null;
-            const advance = text_layout.lineAdvance(font, px, layout);
-            var y = box.t;
-            if (layout.valign != .top) {
-                const block = text_layout.measure(font, text, px, max_width, layout).b;
-                y = if (layout.valign == .middle) box.t + (box.height() - block) / 2 else box.b - block;
-            }
-
             var lines: text_layout.Lines = .init(font, text, px, max_width, layout.letter_spacing);
-            while (lines.next()) |line| : (y += advance) {
+            var stack: [lines_scratch_size]u8 align(16) = undefined;
+            var buffer_first: std.heap.BufferFirstAllocator = .init(&stack, self.allocator);
+            const scratch = buffer_first.allocator();
+            var kept: std.ArrayList(text_layout.Lines.Line) = .empty;
+            defer kept.deinit(scratch);
+            while (lines.next()) |line| try kept.append(scratch, line);
+
+            const advance = text_layout.lineAdvance(font, px, layout);
+            const block = as(f32, kept.items.len) * advance;
+            const top: f32 = switch (layout.valign) {
+                .top => box.t,
+                .middle => box.t + (box.height() - block) / 2,
+                .bottom => box.b - block,
+            };
+            for (kept.items, 0..) |line, i| {
+                const y = top + as(f32, i) * advance;
                 const x: f32 = switch (layout.halign) {
                     .left => box.l,
-                    .center => box.l + (box.width() - line.width) / 2,
-                    .right => box.r - line.width,
+                    .center => box.l + (box.width() - lines.width(line)) / 2,
+                    .right => box.r - lines.width(line),
                 };
                 const position: Point(2, f32) = .init(.{ x, y });
                 switch (font) {

--- a/src/font/layout.zig
+++ b/src/font/layout.zig
@@ -103,8 +103,9 @@ pub fn lineAdvance(font: Font, size: f32, layout: TextLayout) f32 {
 pub const Lines = struct {
     pub const Line = struct {
         text: []const u8,
-        /// `lineWidth` of the text without trailing spaces.
-        width: f32,
+        /// `lineWidth` of the text without trailing spaces, known from wrapping; `Lines.width`
+        /// measures an unwrapped line on demand.
+        width: ?f32,
     };
 
     font: Font,
@@ -132,14 +133,15 @@ pub const Lines = struct {
             if (fitted.len < paragraph.len) consumed = fitted.consumed;
             line = .{ .text = paragraph[0..fitted.len], .width = fitted.width };
         } else {
-            line = .{ .text = paragraph, .width = self.width(std.mem.trimEnd(u8, paragraph, " ")) };
+            line = .{ .text = paragraph, .width = null };
         }
         self.pos += consumed;
         return line;
     }
 
-    fn width(self: Lines, slice: []const u8) f32 {
-        return lineWidth(self.font, slice, self.size, self.letter_spacing);
+    /// The line's width, measured now unless wrapping already did.
+    pub fn width(self: Lines, line: Line) f32 {
+        return line.width orelse lineWidth(self.font, std.mem.trimEnd(u8, line.text, " "), self.size, self.letter_spacing);
     }
 
     const Fit = struct { len: usize, consumed: usize, width: f32 };
@@ -198,7 +200,7 @@ pub fn measure(font: Font, text: []const u8, size: f32, max_width: ?f32, layout:
     var width: f32 = 0;
     var count: usize = 0;
     while (lines.next()) |line| {
-        width = @max(width, line.width);
+        width = @max(width, lines.width(line));
         count += 1;
     }
     return .{ .l = 0, .t = 0, .r = width, .b = @as(f32, @floatFromInt(count)) * lineAdvance(font, size, layout) };
@@ -213,7 +215,7 @@ fn expectLines(font: Font, text: []const u8, max_width: ?f32, expected: []const 
     for (expected) |want| {
         const line = lines.next() orelse return error.TestExpectedMoreLines;
         try testing.expectEqualStrings(want, line.text);
-        try testing.expectEqual(lineWidth(font, std.mem.trimEnd(u8, want, " "), 8, 0), line.width);
+        try testing.expectEqual(lineWidth(font, std.mem.trimEnd(u8, want, " "), 8, 0), lines.width(line));
     }
     try testing.expectEqual(null, lines.next());
 }


### PR DESCRIPTION
## Summary

Follow-up from the glyph-cache PR: with drawing cached, layout had become the floor of text cost, and `renderText` was walking the text more often than it needed to.

- **One wrapping pass.** `drawTextBox` with `valign` other than `top` used to run `measure` (a full wrap) to learn the block height, then wrap again to draw. `renderText` now keeps the lines from a single pass in a 64-line stack buffer (`BufferFirstAllocator`, longer texts spill to the heap) and takes the block height from their count.
- **Widths on demand.** `Lines.next` measured every unwrapped line's width — a glyph walk — even for left-aligned text that never reads it, i.e. every `drawText`. `Lines.Line.width` is now `?f32`: set when wrapping produced it for free, otherwise `Lines.width(line)` measures it; `renderText` only asks for centred/right alignment, `measure` always does.

Line positions are unchanged, so every regression fixture stays put.

## Benchmark (ReleaseFast, min of 3, 18 px, master → this branch)

| case | TrueType (DejaVu Sans) | CFF (FreeSerif) |
|---|---|---|
| drawTextBox wrapped+centred paragraph, cached | 64 → 52 µs (−19%) | 64 → 52 µs |
| drawText, five lines, cached | 35 → 30 µs | 36 → 28 µs |
| drawTextBox paragraph, uncached | 491 → 447 µs | 1135 → 1044 µs |

## Verification

`zig build test` (32/32, 4560 tests, MD5 fixtures unchanged), `zig fmt --check`, wasm32-freestanding examples check, `zig build python` + `uv run pytest` (173 passed).
