### PR TITLE
CI: publish to TestPyPI on releases and manual runs only

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -180,7 +180,9 @@ jobs:
     name: Upload to TestPyPI
     needs: [build_wheels]
     runs-on: ubuntu-latest
-    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    # Releases and manual runs only: pull requests keep their wheels as run artifacts, and
+    # publishing every PR's 20 dev wheels filled TestPyPI's 10 GB project quota.
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     environment:
       name: test-pypi
       url: https://test.pypi.org/p/zignal-processing


### PR DESCRIPTION
## Summary

The TestPyPI upload job ran for every same-repo pull request, publishing all 20 wheels as a new `0.x.0.devN` release (~69 MB per PR). TestPyPI's index for `zignal-processing` now holds 400 releases / 7686 files / 10.00 GiB — 389 of them dev releases — so uploads fail with `400 Project size too large`.

This limits `upload_test_pypi` to `release` and `workflow_dispatch`. PR builds still run the full wheel matrix and attach the wheels to the run as artifacts, which is what a PR needs; TestPyPI becomes an on-demand dry run.

The existing storage still has to be freed once (delete the TestPyPI project, or `pypi-cleanup` the `.dev` releases); after that this keeps it from filling again. Separately worth a look on a Mac: the macOS wheels are ~5.7 MiB against ~1.1 MiB for Linux, even though `build.zig` strips release builds.
