### PR TITLE
refactor(font): one glyph map, one bitmap pen, shared loaders and searches

### DIFF
--- a/src/canvas/Canvas.zig
+++ b/src/canvas/Canvas.zig
@@ -2156,16 +2156,6 @@ pub fn Canvas(comptime T: type) type {
             };
         }
 
-        /// Helper function to get a bit value from glyph bitmap data.
-        /// Returns 1 if the bit is set, 0 otherwise.
-        inline fn getGlyphBit(char_data: []const u8, row: usize, col: usize, bytes_per_row: u32) u1 {
-            const byte_idx = col / 8;
-            const bit_idx = col % 8;
-            const row_byte_offset = row * bytes_per_row + byte_idx;
-            if (row_byte_offset >= char_data.len) return 0;
-            return @intCast((char_data[row_byte_offset] >> @intCast(bit_idx)) & 1);
-        }
-
         /// Draws `text` with its top-left corner at `position`, at `font_size` pixels: the em height
         /// for vector fonts, the character height for bitmap fonts. `null` draws at
         /// `font.defaultSize()`, a bitmap font's native size. `\n` starts a new line.
@@ -2333,7 +2323,9 @@ pub fn Canvas(comptime T: type) type {
             // and beat the mask. Stamping per glyph, not per line, keeps the text walk to one.
             if (paint.overwrite and scale == 1 and radius <= 2) {
                 const r: i32 = @intCast(radius);
-                var glyphs: BitmapGlyphs = .init(font, text, position.x(), 1, letter_spacing);
+                var glyphs: BitmapFont.Layout = .init(font, text, 1);
+                glyphs.x = position.x();
+                glyphs.letter_spacing = letter_spacing;
                 while (glyphs.next()) |placed| {
                     var dy: i32 = -r;
                     while (dy <= r) : (dy += 1) {
@@ -2422,41 +2414,15 @@ pub fn Canvas(comptime T: type) type {
             return extent;
         }
 
-        /// The glyphs of one line of bitmap text with their pen positions; codepoints the
-        /// font lacks only advance the pen, by the font's character width.
-        const BitmapGlyphs = struct {
-            font: BitmapFont,
-            scale: f32,
-            letter_spacing: f32,
-            iter: std.unicode.Utf8Iterator,
-            x: f32,
-
-            const Placed = struct { glyph: BitmapFont.Glyph, x: f32 };
-
-            fn init(font: BitmapFont, text: []const u8, x: f32, scale: f32, letter_spacing: f32) BitmapGlyphs {
-                return .{ .font = font, .scale = scale, .letter_spacing = letter_spacing, .iter = .{ .bytes = text, .i = 0 }, .x = x };
-            }
-
-            inline fn next(it: *BitmapGlyphs) ?Placed {
-                while (it.iter.nextCodepoint()) |codepoint| {
-                    const glyph = it.font.getGlyph(codepoint);
-                    const placed: ?Placed = if (glyph) |g| .{ .glyph = g, .x = it.x } else null;
-                    const advance = if (glyph) |g| g.info.advanceWidth() else it.font.char_width;
-                    it.x += as(f32, advance) * it.scale;
-                    it.x += it.letter_spacing;
-                    if (placed) |p| return p;
-                }
-                return null;
-            }
-        };
-
         /// Blits one line of bitmap glyphs at `position`.
         fn blitBitmapLine(self: Self, text: []const u8, position: Point(2, f32), paint: Paint, font: BitmapFont, scale: f32, letter_spacing: f32, mode: DrawMode) void {
             const text_rect = bitmapLineExtent(text, font, scale, letter_spacing).translate(position.x(), position.y());
             const clip_rect = text_rect.intersect(self.imageRect()) orelse return;
 
             const y = position.y();
-            var glyphs: BitmapGlyphs = .init(font, text, position.x(), scale, letter_spacing);
+            var glyphs: BitmapFont.Layout = .init(font, text, scale);
+            glyphs.x = position.x();
+            glyphs.letter_spacing = letter_spacing;
             while (glyphs.next()) |placed| {
                 if (scale == 1.0) {
                     self.renderGlyphUnscaled(placed.glyph, placed.x, y, paint);
@@ -2471,9 +2437,6 @@ pub fn Canvas(comptime T: type) type {
         /// integer bit positions and offsets.
         fn renderGlyphUnscaled(self: Self, glyph: BitmapFont.Glyph, x: f32, y: f32, paint: Paint) void {
             const glyph_info = glyph.info;
-            const char_data = glyph.data;
-            const bytes_per_row = glyph_info.bytesPerRow();
-
             const fx: i32 = @floor(x);
             const fy: i32 = @floor(y);
             const base_col = fx + as(i32, glyph_info.x_offset);
@@ -2486,7 +2449,7 @@ pub fn Canvas(comptime T: type) type {
                 if (py < 0 or py >= rows_i32) continue;
                 const row_offset: usize = @as(usize, @intCast(py)) * self.image.stride;
                 for (0..glyph_info.width) |col| {
-                    if (getGlyphBit(char_data, row, col, bytes_per_row) == 0) continue;
+                    if (glyph.bit(row, col) == 0) continue;
                     const px = base_col + as(i32, col);
                     if (px < 0 or px >= cols_i32) continue;
                     paint.put(&self.image.data[row_offset + @as(usize, @intCast(px))]);
@@ -2498,11 +2461,9 @@ pub fn Canvas(comptime T: type) type {
         /// identical pixels, clipped to the precomputed text rect.
         fn renderGlyphFastScaled(self: Self, glyph: BitmapFont.Glyph, x: f32, y: f32, scale: f32, clip_rect: Rectangle(f32), paint: Paint) void {
             const glyph_info = glyph.info;
-            const char_data = glyph.data;
-            const bytes_per_row = glyph_info.bytesPerRow();
             for (0..glyph_info.height) |row| {
                 for (0..glyph_info.width) |col| {
-                    if (getGlyphBit(char_data, row, col, bytes_per_row) == 0) continue;
+                    if (glyph.bit(row, col) == 0) continue;
                     const base_x = x + (as(f32, col) + as(f32, glyph_info.x_offset)) * scale;
                     const base_y = y + (as(f32, row) + as(f32, glyph_info.y_offset)) * scale;
                     const x_start: u32 = @trunc(@max(@floor(base_x), clip_rect.l));
@@ -2526,8 +2487,6 @@ pub fn Canvas(comptime T: type) type {
         /// box of the source bitmap and writes the area-weighted coverage as alpha.
         fn renderGlyphSoftScaled(self: Self, glyph: BitmapFont.Glyph, x: f32, y: f32, scale: f32, paint: Paint) void {
             const glyph_info = glyph.info;
-            const char_data = glyph.data;
-            const bytes_per_row = glyph_info.bytesPerRow();
             const glyph_width_f = as(f32, glyph_info.width);
             const glyph_height_f = as(f32, glyph_info.height);
             const dest_width = @ceil(glyph_width_f * scale);
@@ -2561,7 +2520,7 @@ pub fn Canvas(comptime T: type) type {
                         while (col_f <= col_end_f) : (col_f += 1) {
                             const row_idx: u32 = @trunc(row_f);
                             const col_idx: u32 = @trunc(col_f);
-                            if (getGlyphBit(char_data, row_idx, col_idx, bytes_per_row) == 0) continue;
+                            if (glyph.bit(row_idx, col_idx) == 0) continue;
                             const overlap_x = clamp(@min(x1, col_f + 1) - @max(x0, col_f), 0, 1);
                             const overlap_y = clamp(@min(y1, row_f + 1) - @max(y0, row_f), 0, 1);
                             total_coverage += overlap_x * overlap_y;

--- a/src/font.zig
+++ b/src/font.zig
@@ -49,8 +49,10 @@ pub const Font = union(enum) {
     /// `load` for face `face` of a `.ttc` collection. Only face 0 exists otherwise.
     pub fn loadFace(io: Io, gpa: Allocator, path: []const u8, face: u32) !Font {
         const format = try FontFormat.detectFromPath(io, path) orelse return error.UnsupportedFontFormat;
+        if (face != 0 and format != .ttc) return error.InvalidFormat;
         return switch (format) {
-            .bdf, .pcf => if (face == 0) .{ .bitmap = try BitmapFont.load(io, gpa, path, .all) } else error.InvalidFormat,
+            .bdf => .{ .bitmap = try bdf.load(io, gpa, path, .all) },
+            .pcf => .{ .bitmap = try pcf.load(io, gpa, path, .all) },
             .ttf, .otf, .ttc => .{ .vector = try VectorFont.loadFace(io, gpa, path, face) },
         };
     }
@@ -167,37 +169,20 @@ pub fn readFileMaybeGzip(io: Io, gpa: Allocator, path: []const u8) ![]u8 {
     defer gpa.free(raw);
 
     var reader: Io.Reader = .fixed(raw);
-
     const buffer = try gpa.alloc(u8, flate.max_window_len);
     defer gpa.free(buffer);
-
     var decompressor: flate.Decompress = .init(&reader, .gzip, buffer);
 
-    var aw: Io.Writer.Allocating = .init(gpa);
-    defer aw.deinit();
-
-    var remaining = Io.Limit.limited(max_file_size);
-    while (remaining.nonzero()) {
-        const n = decompressor.reader.stream(&aw.writer, remaining) catch |err| switch (err) {
-            error.EndOfStream => break,
-            error.ReadFailed => return error.InvalidCompression,
-            else => return err,
-        };
-        remaining = remaining.subtract(n).?;
-    } else {
-        // Reject streams that would exceed max_file_size by probing for one more byte
-        var one_byte_buf: [1]u8 = undefined;
-        var dummy_writer = Io.Writer.fixed(&one_byte_buf);
-        if (decompressor.reader.stream(&dummy_writer, .limited(1))) |n| {
-            if (n > 0) return error.InvalidCompression;
-        } else |err| switch (err) {
-            error.EndOfStream => {},
-            error.ReadFailed => return error.InvalidCompression,
-            else => return err,
-        }
-    }
-
-    return aw.toOwnedSlice();
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(gpa);
+    // The gzip trailer ends with the uncompressed size modulo 2^32: a sizing hint only, the
+    // limit below still applies.
+    if (raw.len >= 4) try out.ensureTotalCapacity(gpa, @min(std.mem.readInt(u32, raw[raw.len - 4 ..][0..4], .little), max_file_size));
+    decompressor.reader.appendRemaining(gpa, &out, .limited(max_file_size)) catch |err| switch (err) {
+        error.StreamTooLong, error.ReadFailed => return error.InvalidCompression,
+        else => |e| return e,
+    };
+    return out.toOwnedSlice(gpa);
 }
 
 /// Writes `bytes` to `path`, gzip-compressing when the path ends in `.gz`.

--- a/src/font/BitmapFont.zig
+++ b/src/font/BitmapFont.zig
@@ -22,18 +22,14 @@ name: []const u8,
 char_width: u8,
 /// Height of each character in pixels
 char_height: u8,
-/// First ASCII character code in the font
-first_char: u8,
-/// Last ASCII character code in the font
-last_char: u8,
-/// Raw bitmap data for all characters
-/// For fonts wider than 8 pixels, multiple bytes are used per row
-/// Data layout: [char_index][row][byte_in_row]
+/// Fixed-layout fonts (no `glyphs`) store this ASCII range contiguously in `data`, one
+/// `char_height` by `bytesPerRow` bitmap per character.
+first_char: u8 = 0,
+last_char: u8 = 0,
+/// Raw bitmap data for all characters, LSB-first within each row byte.
 data: []const u8,
-/// Optional: Map from character code to glyph data index (for variable-width fonts)
-glyph_map: ?std.AutoHashMap(u32, usize) = null,
-/// Optional: Per-character glyph data (width, offsets, etc.)
-glyph_data: ?[]const GlyphData = null,
+/// Per-codepoint glyphs of a variable-width font, each locating its bitmap in `data`.
+glyphs: ?std.AutoHashMap(u32, GlyphData) = null,
 /// Optional: Original font ascent from the source font file (for accurate save)
 font_ascent: ?i16 = null,
 
@@ -60,7 +56,7 @@ pub fn load(io: Io, allocator: Allocator, file_path: []const u8, filter: LoadFil
 
 /// Get number of bytes per row for this font
 pub fn bytesPerRow(self: BitmapFont) u32 {
-    return (@as(u32, self.char_width) + 7) / 8;
+    return GlyphData.bytesForWidth(self.char_width);
 }
 
 /// Font ascent, falling back to the character height when the source file didn't record one
@@ -73,46 +69,69 @@ pub fn scaleFor(self: BitmapFont, size: f32) f32 {
     return size / @as(f32, @floatFromInt(self.char_height));
 }
 
-/// Glyph data from the glyph map, if this codepoint has an entry
-fn mappedGlyph(self: BitmapFont, codepoint: u21) ?GlyphData {
-    const map = self.glyph_map orelse return null;
-    const idx = map.get(codepoint) orelse return null;
-    const data = self.glyph_data orelse return null;
-    if (idx >= data.len) return null;
-    return data[idx];
+/// Glyphs in the font.
+pub fn glyphCount(self: BitmapFont) u32 {
+    if (self.glyphs) |map| return map.count();
+    return if (self.first_char <= self.last_char) @as(u32, self.last_char) - self.first_char + 1 else 0;
 }
 
 /// A glyph resolved to its metadata and bitmap in a single lookup
 pub const Glyph = struct {
     info: GlyphData,
     data: []const u8,
+
+    /// The pixel at (`row`, `col`) of the bitmap: rows are `info.bytesPerRow()` bytes, LSB
+    /// first; 0 past the data.
+    pub inline fn bit(self: Glyph, row: usize, col: usize) u1 {
+        const at = row * self.info.bytesPerRow() + col / 8;
+        if (at >= self.data.len) return 0;
+        return @intCast((self.data[at] >> @intCast(col % 8)) & 1);
+    }
+
+    /// Box of the set pixels in bitmap coordinates (`r`/`b` exclusive), null for a blank glyph.
+    pub fn inkBounds(self: Glyph) ?Rectangle(u8) {
+        const bytes_per_row = self.info.bytesPerRow();
+        // Bits beyond the glyph width in the last byte may contain garbage; mask them off
+        const last_bits: u3 = @intCast(self.info.width % 8);
+        const last_mask: u8 = if (last_bits == 0) 0xFF else (@as(u8, 1) << last_bits) - 1;
+        var bounds: ?Rectangle(u8) = null;
+        for (0..self.info.height) |row| {
+            const row_data = self.data[row * bytes_per_row ..][0..bytes_per_row];
+            for (row_data, 0..) |raw, byte_idx| {
+                const byte = if (byte_idx == bytes_per_row - 1) raw & last_mask else raw;
+                if (byte == 0) continue;
+                // Pixels are LSB-first: lowest set bit is the leftmost pixel
+                const base: u8 = @intCast(byte_idx * 8);
+                const box: Rectangle(u8) = .{ .l = base + @ctz(byte), .t = @intCast(row), .r = base + 8 - @clz(byte), .b = @intCast(row + 1) };
+                bounds = if (bounds) |acc| acc.merge(box) else box;
+            }
+        }
+        return bounds;
+    }
 };
 
 /// Resolve a codepoint to its glyph info and bitmap data with a single map lookup.
 /// Returns null if the character is not in the font.
 pub fn getGlyph(self: BitmapFont, codepoint: u21) ?Glyph {
-    if (self.mappedGlyph(codepoint)) |glyph| {
-        return .{ .info = glyph, .data = self.data[glyph.bitmap_offset..][0..glyph.bitmapSize()] };
+    if (self.glyphs) |map| {
+        const info = map.get(codepoint) orelse return null;
+        return .{ .info = info, .data = self.data[info.bitmap_offset..][0..info.bitmapSize()] };
     }
-
-    // For ASCII fonts WITHOUT glyph_map, use the standard fixed-size layout
-    if (self.glyph_map == null and codepoint <= 255 and codepoint >= self.first_char and codepoint <= self.last_char) {
-        const index: u32 = @as(u8, @intCast(codepoint)) - self.first_char;
-        const bytes_per_char = @as(u32, self.char_height) * self.bytesPerRow();
-        return .{
-            .info = .{
-                .width = self.char_width,
-                .height = self.char_height,
-                .x_offset = 0,
-                .y_offset = 0,
-                .device_width = @intCast(self.char_width),
-                .bitmap_offset = index * bytes_per_char,
-            },
-            .data = self.data[index * bytes_per_char ..][0..bytes_per_char],
-        };
-    }
-
-    return null;
+    // Fixed layout: the ASCII range, one bitmap after another.
+    if (codepoint > 255 or codepoint < self.first_char or codepoint > self.last_char) return null;
+    const index: u32 = @as(u8, @intCast(codepoint)) - self.first_char;
+    const bytes_per_char = @as(u32, self.char_height) * self.bytesPerRow();
+    return .{
+        .info = .{
+            .width = self.char_width,
+            .height = self.char_height,
+            .x_offset = 0,
+            .y_offset = 0,
+            .device_width = @intCast(self.char_width),
+            .bitmap_offset = index * bytes_per_char,
+        },
+        .data = self.data[index * bytes_per_char ..][0..bytes_per_char],
+    };
 }
 
 /// Get the bitmap data for a specific character
@@ -122,175 +141,101 @@ pub fn getCharData(self: BitmapFont, codepoint: u21) ?[]const u8 {
     return glyph.data;
 }
 
-/// Get bitmap data for a specific row of a character
-/// Returns null if the character is not in the font
-pub fn getCharRow(self: BitmapFont, codepoint: u21, row: u32) ?[]const u8 {
-    const glyph = self.getGlyph(codepoint) orelse return null;
-    if (row >= glyph.info.height) return null;
-    const bytes_per_row = glyph.info.bytesPerRow();
-    return glyph.data[row * bytes_per_row ..][0..bytes_per_row];
-}
-
 /// Get the advance width for a character (how much to move the cursor)
 /// Returns per-character width if available, otherwise the default char_width
 pub fn getCharAdvanceWidth(self: BitmapFont, codepoint: u21) u16 {
-    if (self.mappedGlyph(codepoint)) |glyph| {
-        return glyph.advanceWidth();
-    }
-    return self.char_width;
+    const map = self.glyphs orelse return self.char_width;
+    const info = map.get(codepoint) orelse return self.char_width;
+    return info.advanceWidth();
 }
+
+/// Lays out one line of text at `scale`, yielding each glyph with its pen position: the
+/// bitmap counterpart of `VectorFont.Layout`. Codepoints the font lacks only advance the
+/// pen, by the character width.
+pub const Layout = struct {
+    pub const Item = struct {
+        glyph: Glyph,
+        /// Pen position of the glyph, before its advance.
+        x: f32,
+    };
+
+    font: BitmapFont,
+    scale: f32,
+    iter: std.unicode.Utf8Iterator,
+    /// The pen; set it before the first glyph to lay out from elsewhere than 0.
+    x: f32 = 0,
+    /// Extra device pixels after every glyph's advance.
+    letter_spacing: f32 = 0,
+
+    pub fn init(font: BitmapFont, text: []const u8, scale: f32) Layout {
+        return .{ .font = font, .scale = scale, .iter = .{ .bytes = text, .i = 0 } };
+    }
+
+    pub fn next(self: *Layout) ?Item {
+        while (self.iter.nextCodepoint()) |codepoint| {
+            const x = self.x;
+            if (self.place(codepoint)) |glyph| return .{ .glyph = glyph, .x = x };
+        }
+        return null;
+    }
+
+    /// Places `codepoint` at the pen and advances past it. Kept out of line: inlined into
+    /// the canvas's glyph loops it measured 40% slower.
+    pub fn place(self: *Layout, codepoint: u21) ?Glyph {
+        const glyph = self.font.getGlyph(codepoint);
+        const advance = if (glyph) |g| g.info.advanceWidth() else self.font.char_width;
+        self.x += @as(f32, advance) * self.scale;
+        self.x += self.letter_spacing;
+        return glyph;
+    }
+};
 
 /// Calculate the bounding rectangle for rendering text
 /// Returns bounds where l,t are inclusive and r,b are exclusive
 /// For example, an 8x8 character has pixels at positions 0-7, so bounds are (0,0) to (8,8)
 pub fn getTextBounds(self: BitmapFont, text: []const u8, scale: f32) Rectangle(f32) {
     var width: f32 = 0;
-    var current_line_width: f32 = 0;
+    var x: f32 = 0;
     var lines: f32 = 1;
-
-    const char_height_scaled = @as(f32, self.char_height) * scale;
-
-    var utf8_iter = std.unicode.Utf8Iterator{ .bytes = text, .i = 0 };
-    while (utf8_iter.nextCodepoint()) |codepoint| {
-        if (codepoint == '\n') {
-            width = @max(width, current_line_width);
-            current_line_width = 0;
-            lines += 1;
-        } else {
-            const char_advance = self.getCharAdvanceWidth(codepoint);
-            current_line_width += @as(f32, char_advance) * scale;
+    var iter: std.unicode.Utf8Iterator = .{ .bytes = text, .i = 0 };
+    while (iter.nextCodepoint()) |codepoint| {
+        if (codepoint != '\n') {
+            x += @as(f32, self.getCharAdvanceWidth(codepoint)) * scale;
+            continue;
         }
+        width = @max(width, x);
+        x = 0;
+        lines += 1;
     }
-    width = @max(width, current_line_width);
-    const height = lines * char_height_scaled;
-
-    // Return bounds where l,t are inclusive and r,b are exclusive
-    // For an 8x8 character, bounds should be (0,0) to (8,8)
-    // This follows the standard rectangle convention
-    return .{ .l = 0, .t = 0, .r = width, .b = height };
+    width = @max(width, x);
+    return .{ .l = 0, .t = 0, .r = width, .b = lines * (@as(f32, self.char_height) * scale) };
 }
 
 /// Calculate the tight bounding rectangle for rendering text
 /// Returns bounds that exactly encompass the visible pixels
 /// Unlike getTextBounds, this excludes character padding
 pub fn getTextBoundsTight(self: BitmapFont, text: []const u8, scale: f32) Rectangle(f32) {
-    if (text.len == 0) {
-        return Rectangle(f32){ .l = 0, .t = 0, .r = 0, .b = 0 };
-    }
-
-    var min_x: f32 = std.math.floatMax(f32);
-    var max_x: f32 = std.math.floatMin(f32);
-    var min_y: f32 = std.math.floatMax(f32);
-    var max_y: f32 = std.math.floatMin(f32);
-    var has_any_pixels = false;
-
-    var x: f32 = 0;
+    var layout: Layout = .init(self, text, scale);
     var y: f32 = 0;
-    const char_height_scaled = @as(f32, self.char_height) * scale;
-
-    var utf8_iter = std.unicode.Utf8Iterator{ .bytes = text, .i = 0 };
-    while (utf8_iter.nextCodepoint()) |codepoint| {
+    var bounds: ?Rectangle(f32) = null;
+    while (layout.iter.nextCodepoint()) |codepoint| {
         if (codepoint == '\n') {
-            x = 0;
-            y += char_height_scaled;
+            layout.x = 0;
+            y += @as(f32, self.char_height) * scale;
             continue;
         }
-
-        // Get tight bounds for this character
-        const tight = self.getCharTightBounds(codepoint);
-
-        if (tight.has_pixels) {
-            has_any_pixels = true;
-            const left = x + @as(f32, tight.bounds.l) * scale;
-            const top = y + @as(f32, tight.bounds.t) * scale;
-            const right = x + @as(f32, tight.bounds.r) * scale;
-            const bottom = y + @as(f32, tight.bounds.b) * scale;
-
-            min_x = @min(min_x, left);
-            max_x = @max(max_x, right);
-            min_y = @min(min_y, top);
-            max_y = @max(max_y, bottom);
-        }
-
-        const char_advance = self.getCharAdvanceWidth(codepoint);
-        x += @as(f32, char_advance) * scale;
-    }
-
-    if (!has_any_pixels) {
-        return Rectangle(f32){ .l = 0, .t = 0, .r = 0, .b = 0 };
-    }
-
-    return .{ .l = min_x, .t = min_y, .r = max_x, .b = max_y };
-}
-
-/// Get glyph information for a character
-pub fn getGlyphInfo(self: BitmapFont, codepoint: u21) ?GlyphData {
-    if (self.mappedGlyph(codepoint)) |glyph| {
-        return glyph;
-    }
-    // For ASCII fonts without glyph data, return default
-    if (codepoint <= 255 and codepoint >= self.first_char and codepoint <= self.last_char) {
-        return GlyphData{
-            .width = self.char_width,
-            .height = self.char_height,
-            .x_offset = 0,
-            .y_offset = 0,
-            .device_width = @intCast(self.char_width),
-            .bitmap_offset = 0,
+        const x = layout.x;
+        const glyph = layout.place(codepoint) orelse continue;
+        const ink = glyph.inkBounds() orelse continue;
+        const box: Rectangle(f32) = .{
+            .l = x + @as(f32, ink.l) * scale,
+            .t = y + @as(f32, ink.t) * scale,
+            .r = x + @as(f32, ink.r) * scale,
+            .b = y + @as(f32, ink.b) * scale,
         };
+        bounds = if (bounds) |acc| acc.merge(box) else box;
     }
-    return null;
-}
-
-const TightBounds = struct { bounds: Rectangle(u8), has_pixels: bool };
-const no_pixels: TightBounds = .{ .bounds = .{ .l = 0, .t = 0, .r = 0, .b = 0 }, .has_pixels = false };
-
-/// Get the visible bounds of a character (excluding padding)
-fn getCharTightBounds(self: BitmapFont, codepoint: u21) TightBounds {
-    const glyph = self.getGlyph(codepoint) orelse return no_pixels;
-    const glyph_info = glyph.info;
-    const char_data = glyph.data;
-
-    const bytes_per_row = glyph_info.bytesPerRow();
-    // Bits beyond the glyph width in the last byte may contain garbage; mask them off
-    const last_bits: u3 = @intCast(glyph_info.width % 8);
-    const last_mask: u8 = if (last_bits == 0) 0xFF else (@as(u8, 1) << last_bits) - 1;
-
-    var min_x: u8 = 255;
-    var max_x: u8 = 0;
-    var min_y: u8 = 255;
-    var max_y: u8 = 0;
-    var has_pixels = false;
-
-    for (0..glyph_info.height) |row| {
-        const row_data = char_data[row * bytes_per_row ..][0..bytes_per_row];
-        for (row_data, 0..) |raw, byte_idx| {
-            const byte = if (byte_idx == bytes_per_row - 1) raw & last_mask else raw;
-            if (byte == 0) continue;
-
-            // Pixels are LSB-first: lowest set bit is the leftmost pixel
-            has_pixels = true;
-            const base: u8 = @intCast(byte_idx * 8);
-            min_x = @min(min_x, base + @ctz(byte));
-            max_x = @max(max_x, base + 7 - @clz(byte));
-            min_y = @min(min_y, @as(u8, @intCast(row)));
-            max_y = @max(max_y, @as(u8, @intCast(row)));
-        }
-    }
-
-    if (!has_pixels) {
-        return no_pixels;
-    }
-
-    return .{
-        .bounds = .{
-            .l = min_x,
-            .t = min_y,
-            .r = max_x + 1, // Exclusive bound
-            .b = max_y + 1, // Exclusive bound
-        },
-        .has_pixels = true,
-    };
+    return bounds orelse .{ .l = 0, .t = 0, .r = 0, .b = 0 };
 }
 
 /// Saves the font to a file.
@@ -307,61 +252,49 @@ pub fn save(self: BitmapFont, io: Io, allocator: Allocator, file_path: []const u
 
 /// Returns the sorted list of codepoints present in this font. Caller owns the slice.
 pub fn collectCodepoints(self: BitmapFont, gpa: Allocator) ![]u21 {
-    if (self.glyph_map) |map| {
-        const keys = try gpa.alloc(u21, map.count());
-        var iter = map.iterator();
-        var idx: usize = 0;
-        while (iter.next()) |entry| : (idx += 1) {
-            keys[idx] = @intCast(entry.key_ptr.*);
-        }
+    const keys = try gpa.alloc(u21, self.glyphCount());
+    if (self.glyphs) |map| {
+        var iter = map.keyIterator();
+        for (keys) |*cp| cp.* = @intCast(iter.next().?.*);
         std.mem.sort(u21, keys, {}, std.sort.asc(u21));
-        return keys;
-    }
-
-    if (self.last_char < self.first_char) {
-        return gpa.alloc(u21, 0);
-    }
-
-    const keys = try gpa.alloc(u21, self.last_char - self.first_char + 1);
-    for (keys, 0..) |*cp, idx| {
-        cp.* = @as(u21, self.first_char) + @as(u21, @intCast(idx));
+    } else for (keys, self.first_char..) |*cp, codepoint| {
+        cp.* = @intCast(codepoint);
     }
     return keys;
 }
 
 /// Displays the font information: name, dimensions, and character range.
 pub fn format(self: BitmapFont, writer: *Io.Writer) Io.Writer.Error!void {
-    // Count total glyphs if using glyph map
-    const glyph_count: u32 = if (self.glyph_map) |map|
-        map.count()
-    else if (self.first_char <= self.last_char)
-        @as(u32, self.last_char) - self.first_char + 1
-    else
-        0;
-
-    // Determine font type
-    const font_type = if (self.glyph_map != null) "variable" else "fixed";
-
     try writer.print("BitmapFont{{ .name = \"{s}\", .char_width = {d}, .char_height = {d}, .glyphs = {d}, .type = {s} }}", .{
         self.name,
         self.char_width,
         self.char_height,
-        glyph_count,
-        font_type,
+        self.glyphCount(),
+        if (self.glyphs != null) "variable" else "fixed",
     });
 }
 
 /// Free resources (if owned)
 pub fn deinit(self: *BitmapFont, allocator: std.mem.Allocator) void {
     allocator.free(self.name);
-    if (self.glyph_map) |*map| {
-        map.deinit();
-    }
-    if (self.glyph_data) |data| {
-        allocator.free(data);
-    }
+    if (self.glyphs) |*map| map.deinit();
     allocator.free(self.data);
 }
+
+/// A three-glyph (`A`–`C`) 8x8 font for tests; static, so never `deinit` it.
+pub const test_font: BitmapFont = .{
+    .name = "TestFont",
+    .char_width = 8,
+    .char_height = 8,
+    .first_char = 'A',
+    .last_char = 'C',
+    .data = &.{
+        0x18, 0x24, 0x42, 0x42, 0x7E, 0x42, 0x42, 0x00,
+        0x7C, 0x42, 0x42, 0x7C, 0x42, 0x42, 0x7C, 0x00,
+        0x3C, 0x42, 0x40, 0x40, 0x40, 0x42, 0x3C, 0x00,
+    },
+    .font_ascent = 7,
+};
 
 test "getTextBounds with Unicode" {
     const testing = std.testing;

--- a/src/font/GlyphData.zig
+++ b/src/font/GlyphData.zig
@@ -18,9 +18,14 @@ device_width: i16,
 /// Offset into the bitmap data array where this glyph's bitmap starts
 bitmap_offset: usize = 0,
 
+/// Bytes per bitmap row for a glyph `width` pixels wide.
+pub fn bytesForWidth(width: u32) u32 {
+    return (width + 7) / 8;
+}
+
 /// Number of bytes per bitmap row for this glyph
 pub fn bytesPerRow(self: GlyphData) u32 {
-    return (@as(u32, self.width) + 7) / 8;
+    return bytesForWidth(self.width);
 }
 
 /// Total size in bytes of this glyph's bitmap

--- a/src/font/Outline.zig
+++ b/src/font/Outline.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const Point2 = @import("../geometry/Point.zig").Point(2, f32);
+const Error = @import("truetype.zig").Error;
 
 const Outline = @This();
 
@@ -29,6 +30,45 @@ points: []Point,
 contour_ends: []u32,
 
 pub const empty: Outline = .{ .points = &.{}, .contour_ends = &.{} };
+
+/// Most points or contours an outline may hold.
+pub const max_points: u32 = 0xFFFF;
+
+/// Receives the points of an outline being decoded: it counts them, and stores them when
+/// given slices, so a decoder sizes its output with one pass and fills it with another.
+pub const Builder = struct {
+    points: ?[]Point = null,
+    contour_ends: ?[]u32 = null,
+    n: u32 = 0,
+    c: u32 = 0,
+
+    pub inline fn emit(self: *Builder, x: f32, y: f32, kind: Point.Kind) void {
+        if (self.points) |points| points[self.n] = .{ .x = x, .y = y, .kind = kind };
+        self.n += 1;
+    }
+
+    pub inline fn endContour(self: *Builder) void {
+        if (self.contour_ends) |ends| ends[self.c] = self.n;
+        self.c += 1;
+    }
+
+    /// Decodes an outline through `decode(ctx, *Builder)`: one pass to count, one to fill,
+    /// so exactly two allocations.
+    pub fn build(gpa: Allocator, ctx: anytype, comptime decode: anytype) (Error || Allocator.Error)!Outline {
+        var counting: Builder = .{};
+        try decode(ctx, &counting);
+        if (counting.n > max_points or counting.c > max_points) return error.TooManyPoints;
+
+        const points = try gpa.alloc(Point, counting.n);
+        errdefer gpa.free(points);
+        const contour_ends = try gpa.alloc(u32, counting.c);
+        errdefer gpa.free(contour_ends);
+
+        var filling: Builder = .{ .points = points, .contour_ends = contour_ends };
+        try decode(ctx, &filling);
+        return .{ .points = points, .contour_ends = contour_ends };
+    }
+};
 
 /// Chord deviation allowed when flattening curves, in device pixels.
 pub const flatness_tolerance: f32 = 0.1;
@@ -116,8 +156,10 @@ fn walk(self: Outline, t: Transform, sink: *Sink) void {
         var prev_on = start;
         var ctrl: [2]Point = undefined;
         var pending: usize = 0;
-        for (1..steps + 1) |k| {
-            const p = pts[(start_index + k) % pts.len];
+        var index = start_index;
+        for (0..steps) |_| {
+            index = if (index + 1 == pts.len) 0 else index + 1;
+            const p = pts[index];
             switch (p.kind) {
                 .on_curve => {
                     segment(t, prev_on, ctrl[0..pending], p, false, sink);

--- a/src/font/VectorFont.zig
+++ b/src/font/VectorFont.zig
@@ -137,9 +137,14 @@ fn lookupGlyphIndex(self: VectorFont, codepoint: u21) u16 {
 /// Advance and left side bearing; the widest advance for an invalid index.
 pub fn glyphMetrics(self: VectorFont, gid: u16) GlyphMetrics {
     if (gid >= self.num_glyphs) return .{ .advance = self.advance_width_max, .lsb = 0 };
-    const g = self.cachedGlyph(gid) orelse return self.readMetrics(gid);
-    if (g.metrics == null) g.metrics = self.readMetrics(gid);
-    return g.metrics.?;
+    return self.metricsOf(self.cachedGlyph(gid), gid);
+}
+
+/// `glyphMetrics` through the cache entry `g` of a valid `gid`, when there is one.
+fn metricsOf(self: VectorFont, g: ?*GlyphCache.Glyph, gid: u16) GlyphMetrics {
+    const entry = g orelse return self.readMetrics(gid);
+    if (entry.metrics == null) entry.metrics = self.readMetrics(gid);
+    return entry.metrics.?;
 }
 
 /// The cache entry for `gid`; null without a cache, for an invalid id or when out of memory.
@@ -165,9 +170,14 @@ fn readMetrics(self: VectorFont, gid: u16) GlyphMetrics {
 /// The glyph's bounding box: from its `glyf` header, or the control box of its CFF
 /// charstring. Null for glyphs without contours (spaces, `.notdef`).
 pub fn glyphBounds(self: VectorFont, gid: u16) ?Bounds {
-    const g = self.cachedGlyph(gid) orelse return self.readBounds(gid);
-    if (g.bounds == null) g.bounds = self.readBounds(gid);
-    return g.bounds.?;
+    return self.boundsOf(self.cachedGlyph(gid), gid);
+}
+
+/// `glyphBounds` through the cache entry `g`, when there is one.
+fn boundsOf(self: VectorFont, g: ?*GlyphCache.Glyph, gid: u16) ?Bounds {
+    const entry = g orelse return self.readBounds(gid);
+    if (entry.bounds == null) entry.bounds = self.readBounds(gid);
+    return entry.bounds.?;
 }
 
 fn readBounds(self: VectorFont, gid: u16) ?Bounds {
@@ -211,6 +221,7 @@ pub fn outlineRef(self: VectorFont, gpa: Allocator, gid: u16) (Error || Allocato
 
 /// Horizontal kerning to add to `left`'s advance when followed by `right`, in font units.
 pub fn kern(self: VectorFont, left: u16, right: u16) i16 {
+    if (self.tables.gpos == null and self.tables.kern == null) return 0;
     const cache = self.cache orelse return self.lookupKern(left, right);
     const slot = cache.kerns.getOrPut(cache.gpa, @as(u32, left) << 16 | right) catch return self.lookupKern(left, right);
     if (!slot.found_existing) slot.value_ptr.* = self.lookupKern(left, right);
@@ -288,8 +299,10 @@ pub const Layout = struct {
         }
         const gid = self.font.glyphIndex(codepoint);
         if (self.prev) |p| self.x += as(f32, self.font.kern(p, gid)) * self.scale;
-        const metrics = self.font.glyphMetrics(gid);
-        const bounds = if (self.with_bounds or !self.font.lsb_is_at_x_zero) self.font.glyphBounds(gid) else null;
+        // One cache lookup serves both reads; `glyphIndex` keeps gid valid.
+        const cached = self.font.cachedGlyph(gid);
+        const metrics = self.font.metricsOf(cached, gid);
+        const bounds = if (self.with_bounds or !self.font.lsb_is_at_x_zero) self.font.boundsOf(cached, gid) else null;
         // Unless head says the outline already starts at its bearing, shift it there.
         const shift: f32 = if (self.font.lsb_is_at_x_zero or bounds == null) 0 else as(f32, @as(i32, metrics.lsb) - bounds.?.x_min);
         const item: Item = .{

--- a/src/font/bdf.zig
+++ b/src/font/bdf.zig
@@ -9,6 +9,7 @@ const Allocator = std.mem.Allocator;
 const Io = std.Io;
 
 const LoadFilter = @import("../font.zig").LoadFilter;
+const isGzipPath = @import("../font.zig").isGzipPath;
 const readFileMaybeGzip = @import("../font.zig").readFileMaybeGzip;
 const writeFileMaybeGzip = @import("../font.zig").writeFileMaybeGzip;
 const BitmapFont = @import("BitmapFont.zig");
@@ -33,18 +34,11 @@ const BdfFont = struct {
     glyph_count: u32,
 };
 
-/// BDF glyph information
+/// A parsed glyph: its metadata in the font's own layout (`y_offset` counted down from
+/// the top of the line) and its encoding.
 const BdfGlyph = struct {
     encoding: u32,
-    bbox: struct {
-        width: u16,
-        height: u16,
-        x_offset: i16,
-        y_offset: i16,
-    },
-    device_width: i16,
-    bitmap_offset: usize,
-    bitmap_size: u32,
+    info: GlyphData,
 };
 
 /// Single-pass BDF parser state
@@ -54,7 +48,6 @@ const BdfParseState = struct {
     bitmap_data: std.ArrayList(u8),
     all_ascii: bool = true,
     fn deinit(self: *BdfParseState, gpa: Allocator) void {
-        gpa.free(self.font.name);
         self.glyphs.deinit(gpa);
         self.bitmap_data.deinit(gpa);
     }
@@ -63,47 +56,39 @@ const BdfParseState = struct {
 /// Loads a BDF font from `path` (transparently decompressing `.bdf.gz`), keeping only characters
 /// that match `filter`.
 pub fn load(io: Io, gpa: std.mem.Allocator, path: []const u8, filter: LoadFilter) !BitmapFont {
-    const file_contents = try readFileMaybeGzip(io, gpa, path);
-    defer gpa.free(file_contents);
+    const bytes = try readFileMaybeGzip(io, gpa, path);
+    defer gpa.free(bytes);
+    return parse(gpa, bytes, filter);
+}
 
-    // Parse BDF file in a single pass
-    var lines = std.mem.tokenizeAny(u8, file_contents, "\n\r");
-    var state = BdfParseState{
-        .font = undefined,
-        .glyphs = .empty,
-        .bitmap_data = .empty,
-    };
+/// Parses the BDF text `bytes` into a font, keeping only characters that match `filter`.
+pub fn parse(gpa: Allocator, bytes: []const u8, filter: LoadFilter) !BitmapFont {
+    var lines = std.mem.tokenizeAny(u8, bytes, "\n\r");
+    var state: BdfParseState = .{ .font = try parseHeader(gpa, &lines), .glyphs = .empty, .bitmap_data = .empty };
     defer state.deinit(gpa);
+    // The name passes to the font; until then it is ours to free.
+    errdefer gpa.free(state.font.name);
 
-    // Parse header
-    state.font = try parseHeader(gpa, &lines);
-
-    // Parse glyphs
     var parsed_glyphs: u32 = 0;
     while (lines.next()) |line| {
         const trimmed = std.mem.trim(u8, line, " \t");
-
-        if (std.mem.eql(u8, trimmed, "ENDFONT")) {
-            break;
-        }
-
-        if (!std.mem.startsWith(u8, trimmed, "STARTCHAR")) {
-            continue;
-        }
-
-        // Parse glyph
-        if (try parseGlyph(gpa, &lines, &state, filter)) {
-            parsed_glyphs += 1;
-        }
-
-        if (parsed_glyphs >= state.font.glyph_count) {
-            break;
-        }
+        if (std.mem.eql(u8, trimmed, "ENDFONT")) break;
+        if (!std.mem.startsWith(u8, trimmed, "STARTCHAR")) continue;
+        if (try parseGlyph(gpa, &lines, &state, filter)) parsed_glyphs += 1;
+        if (parsed_glyphs >= state.font.glyph_count) break;
     }
 
-    // Convert to BitmapFont format
     const bitmap_data = try state.bitmap_data.toOwnedSlice(gpa);
+    errdefer gpa.free(bitmap_data);
     return convertToBitmapFont(gpa, state.font, state.glyphs.items, bitmap_data, state.all_ascii);
+}
+
+/// The family of an XLFD name (`-foundry-family-weight-...`); any other name as is.
+fn familyName(name: []const u8) []const u8 {
+    if (!std.mem.startsWith(u8, name, "-")) return name;
+    var fields = std.mem.tokenizeScalar(u8, name[1..], '-');
+    _ = fields.next(); // foundry
+    return fields.next() orelse name;
 }
 
 /// Parse BDF header
@@ -115,6 +100,7 @@ fn parseHeader(gpa: Allocator, lines: *std.mem.TokenIterator(u8, .any)) !BdfFont
         .ascent = 0,
         .glyph_count = 0,
     };
+    errdefer gpa.free(font.name);
 
     // Check STARTFONT
     const first_line = lines.next() orelse return BdfError.InvalidFormat;
@@ -131,26 +117,9 @@ fn parseHeader(gpa: Allocator, lines: *std.mem.TokenIterator(u8, .any)) !BdfFont
         const trimmed = std.mem.trim(u8, line, " \t");
 
         if (std.mem.startsWith(u8, trimmed, "FONT ")) {
-            // Extract font name
-            const font_name_str = std.mem.trim(u8, trimmed[5..], " \t");
+            const name = try gpa.dupe(u8, familyName(std.mem.trim(u8, trimmed[5..], " \t")));
             gpa.free(font.name);
-
-            // If it's an XLFD name (starts with -), extract just the family name
-            if (font_name_str.len > 0 and font_name_str[0] == '-') {
-                // XLFD format: -foundry-family-weight-slant-...
-                // We want the second field (family)
-                var iter = std.mem.tokenizeScalar(u8, font_name_str[1..], '-');
-                _ = iter.next(); // Skip foundry
-                if (iter.next()) |family| {
-                    font.name = try gpa.dupe(u8, family);
-                } else {
-                    // Fallback to full name if parsing fails
-                    font.name = try gpa.dupe(u8, font_name_str);
-                }
-            } else {
-                // Not XLFD, use as-is
-                font.name = try gpa.dupe(u8, font_name_str);
-            }
+            font.name = name;
         } else if (std.mem.startsWith(u8, trimmed, "FONTBOUNDINGBOX ")) {
             var parts = std.mem.tokenizeAny(u8, trimmed[16..], " \t");
             font.bbox_width = try std.fmt.parseInt(i16, parts.next() orelse return BdfError.MissingRequired, 10);
@@ -190,123 +159,78 @@ fn parseHexByte(hex: []const u8, byte_index: usize) BdfError!u8 {
     return (hi << 4) | lo;
 }
 
-/// Parse a single glyph and its bitmap data
-fn parseGlyph(gpa: Allocator, lines: *std.mem.TokenIterator(u8, .any), state: *BdfParseState, filter: LoadFilter) !bool {
-    var glyph = BdfGlyph{
-        .encoding = undefined,
-        .bbox = .{
-            .width = 0,
-            .height = 0,
-            .x_offset = 0,
-            .y_offset = 0,
-        },
-        .device_width = 0,
-        .bitmap_offset = state.bitmap_data.items.len,
-        .bitmap_size = 0,
-    };
+/// Consumes lines up to and including the glyph's `ENDCHAR`.
+fn skipToEndChar(lines: *std.mem.TokenIterator(u8, .any)) void {
+    while (lines.next()) |line| {
+        if (std.mem.eql(u8, std.mem.trim(u8, line, " \t"), "ENDCHAR")) return;
+    }
+}
 
-    var found_encoding = false;
-    var found_bbx = false;
+/// Parses one glyph after its `STARTCHAR`; true when it was kept.
+fn parseGlyph(gpa: Allocator, lines: *std.mem.TokenIterator(u8, .any), state: *BdfParseState, filter: LoadFilter) !bool {
+    var info: GlyphData = .{ .width = 0, .height = 0, .x_offset = 0, .y_offset = 0, .device_width = 0, .bitmap_offset = state.bitmap_data.items.len };
+    var encoding: ?u32 = null;
+    // BDF's y offset: the bitmap's bottom edge relative to the baseline.
+    var bbx_y: ?i16 = null;
 
     while (lines.next()) |line| {
         const trimmed = std.mem.trim(u8, line, " \t");
 
         if (std.mem.startsWith(u8, trimmed, "ENCODING ")) {
             const enc_str = std.mem.trim(u8, trimmed[9..], " \t");
-            // Skip negative encodings
+            // Negative encodings are unmapped glyphs.
             if (std.mem.startsWith(u8, enc_str, "-")) {
-                // Skip to ENDCHAR
-                while (lines.next()) |skip_line| {
-                    if (std.mem.eql(u8, std.mem.trim(u8, skip_line, " \t"), "ENDCHAR")) {
-                        break;
-                    }
-                }
+                skipToEndChar(lines);
                 return false;
             }
-            glyph.encoding = try std.fmt.parseInt(u32, enc_str, 10);
-            found_encoding = true;
+            encoding = try std.fmt.parseInt(u32, enc_str, 10);
         } else if (std.mem.startsWith(u8, trimmed, "DWIDTH ")) {
             var parts = std.mem.tokenizeAny(u8, trimmed[7..], " \t");
-            glyph.device_width = try std.fmt.parseInt(i16, parts.next() orelse "0", 10);
+            info.device_width = try std.fmt.parseInt(i16, parts.next() orelse "0", 10);
         } else if (std.mem.startsWith(u8, trimmed, "BBX ")) {
             var parts = std.mem.tokenizeAny(u8, trimmed[4..], " \t");
-            glyph.bbox.width = try std.fmt.parseInt(u16, parts.next() orelse return BdfError.InvalidFormat, 10);
-            glyph.bbox.height = try std.fmt.parseInt(u16, parts.next() orelse return BdfError.InvalidFormat, 10);
-            glyph.bbox.x_offset = try std.fmt.parseInt(i16, parts.next() orelse return BdfError.InvalidFormat, 10);
-            glyph.bbox.y_offset = try std.fmt.parseInt(i16, parts.next() orelse return BdfError.InvalidFormat, 10);
-            found_bbx = true;
-
+            info.width = try std.fmt.parseInt(u8, parts.next() orelse return BdfError.InvalidFormat, 10);
+            info.height = try std.fmt.parseInt(u8, parts.next() orelse return BdfError.InvalidFormat, 10);
+            info.x_offset = try std.fmt.parseInt(i16, parts.next() orelse return BdfError.InvalidFormat, 10);
+            bbx_y = try std.fmt.parseInt(i16, parts.next() orelse return BdfError.InvalidFormat, 10);
             // Default device width to glyph width if not specified
-            if (glyph.device_width == 0) {
-                glyph.device_width = @intCast(glyph.bbox.width);
-            }
+            if (info.device_width == 0) info.device_width = info.width;
         } else if (std.mem.eql(u8, trimmed, "BITMAP")) {
-            if (!found_encoding or !found_bbx) {
-                return BdfError.MissingRequired;
-            }
-
-            // Check if we should include this glyph
-            if (!filter.matches(glyph.encoding)) {
-                // Skip bitmap data
-                while (lines.next()) |skip_line| {
-                    if (std.mem.eql(u8, std.mem.trim(u8, skip_line, " \t"), "ENDCHAR")) {
-                        break;
-                    }
-                }
+            const codepoint = encoding orelse return BdfError.MissingRequired;
+            const bottom = bbx_y orelse return BdfError.MissingRequired;
+            if (!filter.matches(codepoint)) {
+                skipToEndChar(lines);
                 return false;
             }
+            // BDF offsets count up from the baseline; ours count down from the line's top.
+            info.y_offset = state.font.ascent - (bottom + @as(i16, info.height));
 
-            // Parse and store bitmap data
-            const bytes_per_row = (glyph.bbox.width + 7) / 8;
-            glyph.bitmap_size = @as(u32, glyph.bbox.height) * bytes_per_row;
-            try state.bitmap_data.ensureUnusedCapacity(gpa, glyph.bitmap_size);
-
-            for (0..glyph.bbox.height) |_| {
+            const bytes_per_row = info.bytesPerRow();
+            try state.bitmap_data.ensureUnusedCapacity(gpa, info.bitmapSize());
+            for (0..info.height) |_| {
                 const bitmap_line = lines.next() orelse return BdfError.InvalidBitmapData;
                 const bitmap_trimmed = std.mem.trim(u8, bitmap_line, " \t");
+                if (std.mem.eql(u8, bitmap_trimmed, "ENDCHAR")) return BdfError.InvalidBitmapData;
+                if (bitmap_trimmed.len > bytes_per_row * 2) return BdfError.InvalidBitmapData;
 
-                if (std.mem.eql(u8, bitmap_trimmed, "ENDCHAR")) {
-                    return BdfError.InvalidBitmapData;
-                }
-
-                const hex_chars = bitmap_trimmed.len;
-                if (hex_chars > bytes_per_row * 2) {
-                    return BdfError.InvalidBitmapData;
-                }
-
-                // Convert to our byte format
                 for (0..bytes_per_row) |byte_idx| {
                     var our_byte: u8 = 0;
                     const start_bit = byte_idx * 8;
-                    const end_bit = @min(start_bit + 8, glyph.bbox.width);
-
+                    const end_bit = @min(start_bit + 8, info.width);
                     if (end_bit > start_bit) {
                         // BDF stores pixels MSB-first per byte; convert to zignal's LSB-first layout
-                        const raw_byte = try parseHexByte(bitmap_trimmed, byte_idx);
-                        const reversed_byte = @bitReverse(raw_byte);
+                        const reversed_byte = @bitReverse(try parseHexByte(bitmap_trimmed, byte_idx));
                         const bits_to_take: u4 = @intCast(end_bit - start_bit);
                         const mask: u8 = @intCast((@as(u16, 1) << bits_to_take) - 1);
                         our_byte = reversed_byte & mask;
                     }
-
                     state.bitmap_data.appendAssumeCapacity(our_byte);
                 }
             }
 
-            // Add glyph to list
-            try state.glyphs.append(gpa, glyph);
-
-            if (glyph.encoding > 127) {
-                state.all_ascii = false;
-            }
-
-            // Skip to ENDCHAR
-            while (lines.next()) |end_line| {
-                if (std.mem.eql(u8, std.mem.trim(u8, end_line, " \t"), "ENDCHAR")) {
-                    break;
-                }
-            }
-
+            try state.glyphs.append(gpa, .{ .encoding = codepoint, .info = info });
+            if (codepoint > 127) state.all_ascii = false;
+            skipToEndChar(lines);
             return true;
         } else if (std.mem.eql(u8, trimmed, "ENDCHAR")) {
             // Glyph without bitmap?
@@ -317,131 +241,58 @@ fn parseGlyph(gpa: Allocator, lines: *std.mem.TokenIterator(u8, .any), state: *B
     return false;
 }
 
-/// Build a sparse (glyph-map) BitmapFont from parsed glyphs
-fn buildSparseFont(
-    allocator: std.mem.Allocator,
-    font: BdfFont,
-    glyphs: []const BdfGlyph,
-    bitmap_data: []u8,
-    first_char: u8,
-    last_char: u8,
-) !BitmapFont {
-    var map: std.AutoHashMap(u32, usize) = .init(allocator);
+/// A variable-width font from the parsed glyphs, taking `font.name` and `bitmap_data`.
+fn buildSparseFont(allocator: Allocator, font: BdfFont, glyphs: []const BdfGlyph, bitmap_data: []u8) !BitmapFont {
+    var map: std.AutoHashMap(u32, GlyphData) = .init(allocator);
     errdefer map.deinit();
-
-    var glyph_data_list = try allocator.alloc(GlyphData, glyphs.len);
-    errdefer allocator.free(glyph_data_list);
-
-    for (glyphs, 0..) |glyph, idx| {
-        try map.put(glyph.encoding, idx);
-
-        const adjusted_y_offset = font.ascent - (glyph.bbox.y_offset + @as(i16, @intCast(glyph.bbox.height)));
-
-        glyph_data_list[idx] = GlyphData{
-            .width = @intCast(glyph.bbox.width),
-            .height = @intCast(glyph.bbox.height),
-            .x_offset = glyph.bbox.x_offset,
-            .y_offset = adjusted_y_offset,
-            .device_width = glyph.device_width,
-            .bitmap_offset = glyph.bitmap_offset,
-        };
-    }
-
-    return BitmapFont{
-        .name = try allocator.dupe(u8, font.name),
+    try map.ensureTotalCapacity(@intCast(glyphs.len));
+    for (glyphs) |glyph| map.putAssumeCapacity(glyph.encoding, glyph.info);
+    return .{
+        .name = font.name,
         .char_width = @intCast(@abs(font.bbox_width)),
         .char_height = @intCast(@abs(font.bbox_height)),
-        .first_char = first_char,
-        .last_char = last_char,
         .data = bitmap_data,
-        .glyph_map = map,
-        .glyph_data = glyph_data_list,
+        .glyphs = map,
         .font_ascent = font.ascent,
     };
 }
 
 /// Convert parsed glyphs to BitmapFont format
-fn convertToBitmapFont(
-    allocator: std.mem.Allocator,
-    font: BdfFont,
-    glyphs: []const BdfGlyph,
-    bitmap_data: []u8,
-    all_ascii: bool,
-) !BitmapFont {
+fn convertToBitmapFont(allocator: Allocator, font: BdfFont, glyphs: []const BdfGlyph, bitmap_data: []u8, all_ascii: bool) !BitmapFont {
+    // Unicode fonts and variable-width ASCII ones use the sparse layout.
+    if (!all_ascii or glyphs.len == 0) return buildSparseFont(allocator, font, glyphs, bitmap_data);
     const char_width: u32 = @abs(font.bbox_width);
     const char_height: u32 = @abs(font.bbox_height);
-
-    if (all_ascii and glyphs.len > 0) {
-        // ASCII font - determine range
-        var min_char: u8 = 255;
-        var max_char: u8 = 0;
-
-        for (glyphs) |glyph| {
-            if (glyph.encoding <= 127) {
-                min_char = @min(min_char, @as(u8, @intCast(glyph.encoding)));
-                max_char = @max(max_char, @as(u8, @intCast(glyph.encoding)));
-            }
-        }
-
-        // Check if we need per-glyph data for variable-width fonts
-        var need_glyph_data = false;
-        for (glyphs) |glyph| {
-            if (glyph.bbox.width != char_width) {
-                need_glyph_data = true;
-                break;
-            }
-        }
-
-        if (need_glyph_data) {
-            // Variable-width ASCII font
-            return buildSparseFont(allocator, font, glyphs, bitmap_data, min_char, max_char);
-        } else {
-            // Fixed-width ASCII font - use simple layout
-            const char_count = max_char - min_char + 1;
-            const bytes_per_row = (char_width + 7) / 8;
-            const char_bitmap_size = char_height * bytes_per_row;
-
-            // Reorganize bitmap data for contiguous layout
-            const contiguous_data = try allocator.alloc(u8, char_count * char_bitmap_size);
-            @memset(contiguous_data, 0);
-
-            for (glyphs) |glyph| {
-                if (glyph.encoding >= min_char and glyph.encoding <= max_char) {
-                    const char_idx = glyph.encoding - min_char;
-                    const dest_offset = char_idx * char_bitmap_size;
-
-                    // Copy glyph bitmap to contiguous location
-                    // Handle case where glyph height might be less than font height
-                    const copy_height = @min(glyph.bbox.height, char_height);
-                    for (0..copy_height) |row| {
-                        const src_offset = glyph.bitmap_offset + row * bytes_per_row;
-                        const dst_offset = dest_offset + row * bytes_per_row;
-                        const glyph_bytes_per_row = (glyph.bbox.width + 7) / 8;
-                        const copy_bytes = @min(glyph_bytes_per_row, bytes_per_row);
-                        @memcpy(contiguous_data[dst_offset .. dst_offset + copy_bytes], bitmap_data[src_offset .. src_offset + copy_bytes]);
-                    }
-                }
-            }
-
-            // Free original bitmap data and use contiguous
-            allocator.free(bitmap_data);
-
-            return BitmapFont{
-                .name = try allocator.dupe(u8, font.name),
-                .char_width = @intCast(char_width),
-                .char_height = @intCast(char_height),
-                .first_char = min_char,
-                .last_char = max_char,
-                .data = contiguous_data,
-                .glyph_map = null,
-                .glyph_data = null,
-                .font_ascent = font.ascent,
-            };
-        }
-    } else {
-        // Unicode font - use sparse storage
-        return buildSparseFont(allocator, font, glyphs, bitmap_data, 0, 0);
+    var min_char: u8 = 255;
+    var max_char: u8 = 0;
+    for (glyphs) |glyph| {
+        if (glyph.info.width != char_width) return buildSparseFont(allocator, font, glyphs, bitmap_data);
+        min_char = @min(min_char, @as(u8, @intCast(glyph.encoding)));
+        max_char = @max(max_char, @as(u8, @intCast(glyph.encoding)));
     }
+
+    // Fixed-width ASCII font: one bitmap after another in encoding order.
+    const bytes_per_row = GlyphData.bytesForWidth(char_width);
+    const char_bitmap_size = char_height * bytes_per_row;
+    const contiguous_data = try allocator.alloc(u8, (max_char - min_char + 1) * char_bitmap_size);
+    @memset(contiguous_data, 0);
+    for (glyphs) |glyph| {
+        const dest = contiguous_data[(glyph.encoding - min_char) * char_bitmap_size ..];
+        // A glyph shorter than the font leaves its remaining rows blank.
+        const copy_bytes = @min(glyph.info.height, char_height) * bytes_per_row;
+        @memcpy(dest[0..copy_bytes], bitmap_data[glyph.info.bitmap_offset..][0..copy_bytes]);
+    }
+    allocator.free(bitmap_data);
+
+    return .{
+        .name = font.name,
+        .char_width = @intCast(char_width),
+        .char_height = @intCast(char_height),
+        .first_char = min_char,
+        .last_char = max_char,
+        .data = contiguous_data,
+        .font_ascent = font.ascent,
+    };
 }
 
 test "BDF to BitmapFont conversion" {
@@ -469,26 +320,7 @@ test "BDF to BitmapFont conversion" {
         \\ENDFONT
     ;
 
-    // Test through the full API - simulate file read
-    var lines = std.mem.tokenizeAny(u8, test_bdf, "\n\r");
-    var state = BdfParseState{
-        .font = undefined,
-        .glyphs = .empty,
-        .bitmap_data = .empty,
-    };
-    defer state.deinit(std.testing.allocator);
-
-    state.font = try parseHeader(testing.allocator, &lines);
-
-    while (lines.next()) |line| {
-        const trimmed = std.mem.trim(u8, line, " \t");
-        if (std.mem.startsWith(u8, trimmed, "STARTCHAR")) {
-            _ = try parseGlyph(std.testing.allocator, &lines, &state, .all);
-        }
-    }
-
-    const bitmap_data = try state.bitmap_data.toOwnedSlice(testing.allocator);
-    var font = try convertToBitmapFont(testing.allocator, state.font, state.glyphs.items, bitmap_data, true);
+    var font = try parse(testing.allocator, test_bdf, .all);
     defer font.deinit(testing.allocator);
 
     // Test converted font
@@ -548,187 +380,43 @@ test "BDF parses glyph rows wider than 32 bits" {
     try testing.expectEqualSlices(u8, &expected, data[0..expected.len]);
 }
 
-test "BDF save and load compressed roundtrip" {
-    // Create a simple font with a few characters
-    const char_width = 8;
-    const char_height = 8;
-    const first_char = 65; // 'A'
-    const last_char = 67; // 'C'
-    const num_chars = last_char - first_char + 1;
-    const bytes_per_char = char_height; // 8 pixels = 1 byte per row
-
-    // Create test bitmap data
-    var bitmap_data = try testing.allocator.alloc(u8, num_chars * bytes_per_char);
-    defer testing.allocator.free(bitmap_data);
-
-    // Character 'A' pattern
-    bitmap_data[0] = 0x18; // 00011000
-    bitmap_data[1] = 0x24; // 00100100
-    bitmap_data[2] = 0x42; // 01000010
-    bitmap_data[3] = 0x42; // 01000010
-    bitmap_data[4] = 0x7E; // 01111110
-    bitmap_data[5] = 0x42; // 01000010
-    bitmap_data[6] = 0x42; // 01000010
-    bitmap_data[7] = 0x00; // 00000000
-
-    // Character 'B' and 'C' patterns (same as original test)
-    @memcpy(bitmap_data[8..16], &[_]u8{ 0x7C, 0x42, 0x42, 0x7C, 0x42, 0x42, 0x7C, 0x00 });
-    @memcpy(bitmap_data[16..24], &[_]u8{ 0x3C, 0x42, 0x40, 0x40, 0x40, 0x42, 0x3C, 0x00 });
-
-    // Duplicate the data since BitmapFont takes ownership
-    const font_data = try testing.allocator.dupe(u8, bitmap_data);
-    const font_name = try testing.allocator.dupe(u8, "TestFont");
-    var font = BitmapFont{
-        .name = font_name,
-        .char_width = char_width,
-        .char_height = char_height,
-        .first_char = first_char,
-        .last_char = last_char,
-        .data = font_data,
-        .glyph_map = null,
-        .glyph_data = null,
-        .font_ascent = 7,
-    };
-    defer font.deinit(testing.allocator);
-
-    // Save to temporary compressed file
+fn expectRoundtrip(file_name: []const u8) !void {
+    const font = BitmapFont.test_font;
     var tmp_dir = testing.tmpDir(.{});
     defer tmp_dir.cleanup();
+    const dir_path = try tmp_dir.dir.realPathFileAlloc(testing.io, ".", testing.allocator);
+    defer testing.allocator.free(dir_path);
+    const path = try Io.Dir.path.join(testing.allocator, &.{ dir_path, file_name });
+    defer testing.allocator.free(path);
 
-    const test_filename = "test_font.bdf.gz";
-    const full_path = try tmp_dir.dir.realPathFileAlloc(testing.io, ".", testing.allocator);
-    defer testing.allocator.free(full_path);
+    try font.save(testing.io, testing.allocator, path);
+    if (isGzipPath(path)) {
+        // The file starts with the gzip magic.
+        const file = try Io.Dir.openFileAbsolute(testing.io, path, .{});
+        defer file.close(testing.io);
+        var header: [2]u8 = undefined;
+        var iov = [_][]u8{header[0..]};
+        _ = try file.readStreaming(testing.io, &iov);
+        try testing.expectEqualSlices(u8, &.{ 0x1f, 0x8b }, &header);
+    }
 
-    const test_path = try Io.Dir.path.join(testing.allocator, &.{ full_path, test_filename });
-    defer testing.allocator.free(test_path);
-
-    // Save compressed
-    try font.save(testing.io, testing.allocator, test_path);
-
-    // Verify the file is compressed by checking magic number
-    const file = try Io.Dir.openFileAbsolute(testing.io, test_path, .{});
-    defer file.close(testing.io);
-    var header: [2]u8 = undefined;
-    var iov = [_][]u8{header[0..]};
-    _ = try file.readStreaming(testing.io, &iov);
-    try testing.expectEqual(@as(u8, 0x1f), header[0]);
-    try testing.expectEqual(@as(u8, 0x8b), header[1]);
-
-    // Load it back
-    var loaded_font = try BitmapFont.load(testing.io, testing.allocator, test_path, .all);
-    defer loaded_font.deinit(testing.allocator);
-
-    // Verify metadata
-    try testing.expectEqual(font.char_width, loaded_font.char_width);
-    try testing.expectEqual(font.char_height, loaded_font.char_height);
-    try testing.expectEqual(font.first_char, loaded_font.first_char);
-    try testing.expectEqual(font.last_char, loaded_font.last_char);
-
-    // Verify bitmap data for each character
-    for (first_char..last_char + 1) |char_code| {
-        const original_data = font.getCharData(@intCast(char_code));
-        const loaded_data = loaded_font.getCharData(@intCast(char_code));
-
-        try testing.expect(original_data != null);
-        try testing.expect(loaded_data != null);
-        try testing.expectEqualSlices(u8, original_data.?, loaded_data.?);
+    var loaded = try BitmapFont.load(testing.io, testing.allocator, path, .all);
+    defer loaded.deinit(testing.allocator);
+    try testing.expectEqual(font.char_width, loaded.char_width);
+    try testing.expectEqual(font.char_height, loaded.char_height);
+    try testing.expectEqual(font.first_char, loaded.first_char);
+    try testing.expectEqual(font.last_char, loaded.last_char);
+    for (font.first_char..font.last_char + 1) |codepoint| {
+        try testing.expectEqualSlices(u8, font.getCharData(@intCast(codepoint)).?, loaded.getCharData(@intCast(codepoint)).?);
     }
 }
 
 test "BDF save and load roundtrip" {
-    // Create a simple font with a few characters
-    const char_width = 8;
-    const char_height = 8;
-    const first_char = 65; // 'A'
-    const last_char = 67; // 'C'
-    const num_chars = last_char - first_char + 1;
-    const bytes_per_char = char_height; // 8 pixels = 1 byte per row
+    try expectRoundtrip("test_font.bdf");
+}
 
-    // Create test bitmap data
-    var bitmap_data = try testing.allocator.alloc(u8, num_chars * bytes_per_char);
-    defer testing.allocator.free(bitmap_data);
-
-    // Character 'A' pattern
-    bitmap_data[0] = 0x18; // 00011000
-    bitmap_data[1] = 0x24; // 00100100
-    bitmap_data[2] = 0x42; // 01000010
-    bitmap_data[3] = 0x42; // 01000010
-    bitmap_data[4] = 0x7E; // 01111110
-    bitmap_data[5] = 0x42; // 01000010
-    bitmap_data[6] = 0x42; // 01000010
-    bitmap_data[7] = 0x00; // 00000000
-
-    // Character 'B' pattern
-    bitmap_data[8] = 0x7C; // 01111100
-    bitmap_data[9] = 0x42; // 01000010
-    bitmap_data[10] = 0x42; // 01000010
-    bitmap_data[11] = 0x7C; // 01111100
-    bitmap_data[12] = 0x42; // 01000010
-    bitmap_data[13] = 0x42; // 01000010
-    bitmap_data[14] = 0x7C; // 01111100
-    bitmap_data[15] = 0x00; // 00000000
-
-    // Character 'C' pattern
-    bitmap_data[16] = 0x3C; // 00111100
-    bitmap_data[17] = 0x42; // 01000010
-    bitmap_data[18] = 0x40; // 01000000
-    bitmap_data[19] = 0x40; // 01000000
-    bitmap_data[20] = 0x40; // 01000000
-    bitmap_data[21] = 0x42; // 01000010
-    bitmap_data[22] = 0x3C; // 00111100
-    bitmap_data[23] = 0x00; // 00000000
-
-    // Duplicate the data since BitmapFont takes ownership
-    const font_data = try testing.allocator.dupe(u8, bitmap_data);
-    const font_name = try testing.allocator.dupe(u8, "TestFont");
-    var font = BitmapFont{
-        .name = font_name,
-        .char_width = char_width,
-        .char_height = char_height,
-        .first_char = first_char,
-        .last_char = last_char,
-        .data = font_data,
-        .glyph_map = null,
-        .glyph_data = null,
-        .font_ascent = 7, // Test with a specific baseline
-    };
-    defer font.deinit(testing.allocator);
-
-    // Save to temporary file
-    var tmp_dir = testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
-
-    // Create path using the dir handle
-    const test_filename = "test_font.bdf";
-
-    // Save the font using the full path through tmp_dir
-    const full_path = try tmp_dir.dir.realPathFileAlloc(testing.io, ".", testing.allocator);
-    defer testing.allocator.free(full_path);
-
-    const test_path = try Io.Dir.path.join(testing.allocator, &.{ full_path, test_filename });
-    defer testing.allocator.free(test_path);
-
-    try font.save(testing.io, testing.allocator, test_path);
-
-    // Load it back
-    var loaded_font = try BitmapFont.load(testing.io, testing.allocator, test_path, .all);
-    defer loaded_font.deinit(testing.allocator);
-
-    // Verify metadata
-    try testing.expectEqual(font.char_width, loaded_font.char_width);
-    try testing.expectEqual(font.char_height, loaded_font.char_height);
-    try testing.expectEqual(font.first_char, loaded_font.first_char);
-    try testing.expectEqual(font.last_char, loaded_font.last_char);
-
-    // Verify bitmap data for each character
-    for (first_char..last_char + 1) |char_code| {
-        const original_data = font.getCharData(@intCast(char_code));
-        const loaded_data = loaded_font.getCharData(@intCast(char_code));
-
-        try testing.expect(original_data != null);
-        try testing.expect(loaded_data != null);
-        try testing.expectEqualSlices(u8, original_data.?, loaded_data.?);
-    }
+test "BDF save and load compressed roundtrip" {
+    try expectRoundtrip("test_font.bdf.gz");
 }
 
 /// Save a BitmapFont to a BDF file
@@ -780,9 +468,9 @@ fn writeBdfHeader(allocator: Allocator, list: *std.ArrayList(u8), font: BitmapFo
     // Use stored font_ascent if available, otherwise estimate from the defaulted height
     const font_ascent = font.font_ascent orelse @as(i16, height);
 
-    if (font.glyph_data) |glyphs| {
-        // Calculate actual BDF coordinates using the original font_ascent
-        for (glyphs) |glyph| {
+    if (font.glyphs) |glyphs| {
+        var iter = glyphs.valueIterator();
+        while (iter.next()) |glyph| {
             max_width = @max(max_width, glyph.width);
             max_height = @max(max_height, glyph.height);
 
@@ -803,15 +491,14 @@ fn writeBdfHeader(allocator: Allocator, list: *std.ArrayList(u8), font: BitmapFo
     try list.print(allocator, "FONT_DESCENT {d}\n", .{font_descent});
     try list.appendSlice(allocator, "ENDPROPERTIES\n");
 
-    // Count glyphs
-    const glyph_count = if (font.glyph_map) |map| map.count() else (font.last_char - font.first_char + 1);
-    try list.print(allocator, "CHARS {d}\n", .{glyph_count});
+    try list.print(allocator, "CHARS {d}\n", .{font.glyphCount()});
 }
 
 /// Write a single glyph
 fn writeBdfGlyph(allocator: Allocator, list: *std.ArrayList(u8), font: BitmapFont, encoding: u21) !void {
-    const glyph_info = font.getGlyphInfo(encoding) orelse return BdfError.MissingRequired;
-    const glyph_data = font.getCharData(encoding) orelse return BdfError.InvalidBitmapData;
+    const glyph = font.getGlyph(encoding) orelse return BdfError.MissingRequired;
+    const glyph_info = glyph.info;
+    const glyph_data = glyph.data;
 
     try list.print(allocator, "STARTCHAR U+{X:0>4}\n", .{encoding});
     try list.print(allocator, "ENCODING {d}\n", .{encoding});

--- a/src/font/font8x8.zig
+++ b/src/font/font8x8.zig
@@ -27,8 +27,6 @@ pub const basic = BitmapFont{
     .first_char = 0x20, // Space
     .last_char = 0x7E, // Tilde
     .data = font_data.basic_latin[0x20 * 8 .. 0x7F * 8], // Slice from 0x20 to 0x7E (inclusive)
-    .glyph_map = null,
-    .glyph_data = null,
 };
 
 /// Create an extended Latin font (ASCII + Latin-1 Supplement)
@@ -45,97 +43,30 @@ pub fn extended(allocator: std.mem.Allocator) !BitmapFont {
 /// This requires allocation and can fail
 /// The returned font must be freed with deinit()
 pub fn create(gpa: std.mem.Allocator, filter: LoadFilter) !BitmapFont {
-    // Build list of characters to include
-    var char_list: std.ArrayList(u21) = .empty;
-    defer char_list.deinit(gpa);
+    var glyphs: std.AutoHashMap(u32, GlyphData) = .init(gpa);
+    errdefer glyphs.deinit();
+    var data: std.ArrayList(u8) = .empty;
+    errdefer data.deinit(gpa);
 
-    switch (filter) {
-        .all => {
-            // Add all available characters from all ranges
-            for (font_data.ranges) |range| {
-                var code = range.start;
-                while (code <= range.end) : (code += 1) {
-                    try char_list.append(gpa, code);
-                }
-            }
-        },
-        .ranges => |ranges| {
-            // Add characters from specified ranges
-            for (ranges) |req_range| {
-                // Find overlapping ranges in our data
-                for (font_data.ranges) |data_range| {
-                    const start = @max(req_range.start, data_range.start);
-                    const end = @min(req_range.end, data_range.end);
-                    if (start <= end) {
-                        var code = start;
-                        while (code <= end) : (code += 1) {
-                            try char_list.append(gpa, code);
-                        }
-                    }
-                }
-            }
-        },
-    }
-
-    if (char_list.items.len == 0) {
-        return error.NoCharactersFound;
-    }
-
-    // Sort characters for consistent output
-    std.mem.sort(u21, char_list.items, {}, std.sort.asc(u21));
-
-    // Remove duplicates
-    var unique_chars: std.ArrayList(u21) = .empty;
-    defer unique_chars.deinit(gpa);
-
-    for (char_list.items, 0..) |code, i| {
-        if (i == 0 or code != char_list.items[i - 1]) {
-            try unique_chars.append(gpa, code);
+    // The data ranges are ascending and disjoint, so one pass yields the glyphs in order.
+    for (font_data.ranges) |range| {
+        var code = range.start;
+        while (code <= range.end) : (code += 1) {
+            if (!filter.matches(code)) continue;
+            try glyphs.putNoClobber(code, .{ .width = 8, .height = 8, .x_offset = 0, .y_offset = 0, .device_width = 8, .bitmap_offset = data.items.len });
+            try data.appendSlice(gpa, range.data[(code - range.start) * 8 ..][0..8]);
         }
     }
+    if (glyphs.count() == 0) return error.NoCharactersFound;
 
-    // Build glyph map and data
-    var glyph_map: std.AutoHashMap(u32, usize) = .init(gpa);
-    errdefer glyph_map.deinit();
-
-    var glyph_data_list = try gpa.alloc(GlyphData, unique_chars.items.len);
-    errdefer gpa.free(glyph_data_list);
-
-    // Calculate total bitmap size needed
-    const total_size = unique_chars.items.len * 8; // 8 bytes per character
-    var bitmap_data = try gpa.alloc(u8, total_size);
-    errdefer gpa.free(bitmap_data);
-
-    // Copy character data; every candidate came from font_data.ranges, so lookup can't fail
-    for (unique_chars.items, 0..) |code, idx| {
-        const char_data = font_data.findCharData(code).?;
-
-        try glyph_map.put(code, idx);
-
-        glyph_data_list[idx] = GlyphData{
-            .width = 8,
-            .height = 8,
-            .x_offset = 0,
-            .y_offset = 0,
-            .device_width = 8,
-            .bitmap_offset = idx * 8,
-        };
-
-        @memcpy(bitmap_data[idx * 8 .. (idx + 1) * 8], char_data);
-    }
-
-    const font_name = try gpa.dupe(u8, "8x8 Unicode");
-    errdefer gpa.free(font_name);
-
-    return BitmapFont{
-        .name = font_name,
+    const name = try gpa.dupe(u8, "8x8 Unicode");
+    errdefer gpa.free(name);
+    return .{
+        .name = name,
         .char_width = 8,
         .char_height = 8,
-        .first_char = 0, // Not used with glyph_map
-        .last_char = 0, // Not used with glyph_map
-        .data = bitmap_data,
-        .glyph_map = glyph_map,
-        .glyph_data = glyph_data_list,
+        .data = try data.toOwnedSlice(gpa),
+        .glyphs = glyphs,
     };
 }
 
@@ -164,8 +95,7 @@ test "create ASCII font dynamically" {
     try testing.expectEqual(@as(u8, 8), dynamic_font.char_height);
 
     // Should have glyph map since it's dynamically created
-    try testing.expect(dynamic_font.glyph_map != null);
-    try testing.expect(dynamic_font.glyph_data != null);
+    try testing.expect(dynamic_font.glyphs != null);
 
     // Test getting character data through glyph map
     const char_data = dynamic_font.getCharData('A');
@@ -220,7 +150,7 @@ test "create font with all available ranges" {
     defer all_font.deinit(testing.allocator);
 
     // Should have many characters available
-    try testing.expect(all_font.glyph_map.?.count() > 200);
+    try testing.expect(all_font.glyphs.?.count() > 200);
 
     // Test various ranges are included
     try testing.expect(all_font.getCharData('A') != null); // ASCII

--- a/src/font/format.zig
+++ b/src/font/format.zig
@@ -3,6 +3,8 @@
 const std = @import("std");
 const Io = std.Io;
 
+const isGzipPath = @import("../font.zig").isGzipPath;
+
 /// Supported font formats for automatic detection and loading
 pub const FontFormat = enum {
     bdf, // Bitmap Distribution Format
@@ -36,7 +38,7 @@ pub const FontFormat = enum {
 
     /// Detect font format from the file extension, ignoring a trailing `.gz`
     pub fn detectFromExtension(path: []const u8) ?FontFormat {
-        const stem = if (std.ascii.endsWithIgnoreCase(path, ".gz")) path[0 .. path.len - 3] else path;
+        const stem = if (isGzipPath(path)) path[0 .. path.len - 3] else path;
         if (std.ascii.endsWithIgnoreCase(stem, ".bdf")) return .bdf;
         if (std.ascii.endsWithIgnoreCase(stem, ".pcf")) return .pcf;
         if (std.ascii.endsWithIgnoreCase(stem, ".ttf")) return .ttf;
@@ -48,9 +50,7 @@ pub const FontFormat = enum {
     /// Detect font format from file path by reading the first few bytes
     pub fn detectFromPath(io: Io, file_path: []const u8) !?FontFormat {
         // Compressed files can't be sniffed, so trust the extension
-        if (std.ascii.endsWithIgnoreCase(file_path, ".gz")) {
-            return detectFromExtension(file_path);
-        }
+        if (isGzipPath(file_path)) return detectFromExtension(file_path);
 
         const file = try Io.Dir.cwd().openFile(io, file_path, .{});
         defer file.close(io);

--- a/src/font/layout.zig
+++ b/src/font/layout.zig
@@ -8,7 +8,6 @@ const Font = @import("../font.zig").Font;
 const BitmapFont = @import("BitmapFont.zig");
 const VectorFont = @import("VectorFont.zig");
 const Rectangle = @import("../geometry.zig").Rectangle;
-const as = @import("../meta.zig").as;
 
 pub const TextAlign = enum { left, center, right };
 pub const VerticalAlign = enum { top, middle, bottom };
@@ -32,9 +31,7 @@ pub const TextLayout = struct {
 /// `letter_spacing` after every glyph for either kind. Wrapping and measuring walk the
 /// text once through it.
 pub const Pen = struct {
-    const Bitmap = struct { font: BitmapFont, scale: f32, x: f32 = 0 };
-
-    inner: union(enum) { bitmap: Bitmap, vector: VectorFont.Layout },
+    inner: union(enum) { bitmap: BitmapFont.Layout, vector: VectorFont.Layout },
     iter: std.unicode.Utf8Iterator,
     letter_spacing: f32,
     glyphs: usize = 0,
@@ -42,7 +39,11 @@ pub const Pen = struct {
     pub fn init(font: Font, text: []const u8, size: f32, letter_spacing: f32) Pen {
         return .{
             .inner = switch (font) {
-                .bitmap => |b| .{ .bitmap = .{ .font = b, .scale = b.scaleFor(size) } },
+                .bitmap => |b| blk: {
+                    var layout: BitmapFont.Layout = .init(b, text, b.scaleFor(size));
+                    layout.letter_spacing = letter_spacing;
+                    break :blk .{ .bitmap = layout };
+                },
                 .vector => |v| blk: {
                     var layout: VectorFont.Layout = .init(v, text, size);
                     layout.letter_spacing = letter_spacing;
@@ -65,8 +66,7 @@ pub const Pen = struct {
     pub fn next(self: *Pen) ?Glyph {
         const codepoint = self.iter.nextCodepoint() orelse return null;
         switch (self.inner) {
-            .bitmap => |*b| b.x += as(f32, b.font.getCharAdvanceWidth(codepoint)) * b.scale + self.letter_spacing,
-            .vector => |*v| _ = v.place(codepoint),
+            inline else => |*layout| _ = layout.place(codepoint),
         }
         self.glyphs += 1;
         return .{ .codepoint = codepoint, .end = self.iter.i };
@@ -77,8 +77,7 @@ pub const Pen = struct {
     pub fn width(self: Pen) f32 {
         if (self.glyphs == 0) return 0;
         const x = switch (self.inner) {
-            .bitmap => |b| b.x,
-            .vector => |v| v.x,
+            inline else => |layout| layout.x,
         };
         return @max(0, x - self.letter_spacing);
     }

--- a/src/font/pcf.zig
+++ b/src/font/pcf.zig
@@ -17,6 +17,7 @@ const testing = std.testing;
 const native_endian = builtin.cpu.arch.endian();
 
 const LoadFilter = @import("../font.zig").LoadFilter;
+const isGzipPath = @import("../font.zig").isGzipPath;
 const readFileMaybeGzip = @import("../font.zig").readFileMaybeGzip;
 const writeFileMaybeGzip = @import("../font.zig").writeFileMaybeGzip;
 const BitmapFont = @import("BitmapFont.zig");
@@ -25,18 +26,12 @@ const GlyphData = @import("GlyphData.zig");
 /// Errors that can occur during PCF parsing
 pub const PcfError = error{
     InvalidFormat,
-    InvalidVersion,
     MissingRequired,
     InvalidTableEntry,
     InvalidBitmapData,
-    AllocationFailed,
-    UnsupportedFormat,
-    InvalidCompression,
     TableOffsetOutOfBounds,
     InvalidGlyphCount,
-    InvalidMetricsFormat,
     InvalidEncodingRange,
-    BitmapSizeMismatch,
 };
 
 /// PCF format constants
@@ -59,64 +54,32 @@ const TableType = enum(u32) {
     bdf_accelerators = (1 << 8),
 };
 
-/// PCF format flags structure for better type safety
+/// The bits of a table's format field this parser reads.
 const FormatFlags = struct {
-    const glyph_pad_mask: u32 = 0x3;
-    const byte_order_mask: u32 = 1 << 2;
-    const bit_order_mask: u32 = 1 << 3;
-    const scan_unit_mask: u32 = 0x30;
-    const scan_unit_shift: u5 = 4;
-    const compressed_metrics_mask: u32 = 0x100;
-    const accel_w_inkbounds_mask: u32 = 0x200;
-    const ink_bounds_mask: u32 = 0x400;
-
-    // Helper to decode format flags from u32
-    pub fn decode(format: u32) FormatFlags {
-        return FormatFlags{
-            .glyph_pad = @truncate(format & glyph_pad_mask),
-            .byte_order_msb = (format & byte_order_mask) != 0,
-            .bit_order_msb = (format & bit_order_mask) != 0,
-            .scan_unit = @truncate((format & scan_unit_mask) >> scan_unit_shift),
-            .compressed_metrics = (format & compressed_metrics_mask) != 0,
-            .accel_w_inkbounds = (format & accel_w_inkbounds_mask) != 0,
-            .ink_bounds = (format & ink_bounds_mask) != 0,
-        };
-    }
-
+    /// Log2 of the bytes each bitmap row is padded to.
     glyph_pad: u2,
     byte_order_msb: bool,
     bit_order_msb: bool,
-    scan_unit: u2,
-    accel_w_inkbounds: bool,
     compressed_metrics: bool,
-    ink_bounds: bool,
-};
 
-/// PCF glyph padding values
-const GlyphPadding = enum(u2) {
-    pad_1 = 0,
-    pad_2 = 1,
-    pad_4 = 2,
-    pad_8 = 3,
+    fn decode(format: u32) FormatFlags {
+        return .{
+            .glyph_pad = @truncate(format & 0x3),
+            .byte_order_msb = format & (1 << 2) != 0,
+            .bit_order_msb = format & (1 << 3) != 0,
+            .compressed_metrics = format & 0x100 != 0,
+        };
+    }
 
-    pub fn getPadBytes(self: GlyphPadding) u32 {
-        return @as(u32, 1) << @backingInt(self);
+    fn byteOrder(self: FormatFlags) std.builtin.Endian {
+        return if (self.byte_order_msb) .big else .little;
+    }
+
+    /// Bytes each bitmap row is padded to.
+    fn padBytes(self: FormatFlags) u32 {
+        return @as(u32, 1) << self.glyph_pad;
     }
 };
-
-/// Get byte order from format field
-fn getByteOrder(format: u32) std.builtin.Endian {
-    const flags = FormatFlags.decode(format);
-    return if (flags.byte_order_msb) .big else .little;
-}
-
-/// Calculate glyph dimensions from metric
-fn getGlyphDimensions(metric: Metric) struct { width: u16, height: u16 } {
-    return .{
-        .width = @intCast(@abs(metric.right_sided_bearing - metric.left_sided_bearing)),
-        .height = @intCast(@abs(metric.ascent + metric.descent)),
-    };
-}
 
 /// Table of contents entry for PCF files
 /// Each PCF file contains multiple tables identified by type
@@ -136,24 +99,24 @@ const Metric = struct {
     ascent: i16, // Distance from baseline to top of glyph
     descent: i16, // Distance from baseline to bottom of glyph (positive)
     attributes: u16, // Additional glyph attributes (usually 0)
+
+    /// The fields that bound a glyph.
+    const extents = .{ "left_sided_bearing", "right_sided_bearing", "character_width", "ascent", "descent" };
+
+    fn width(self: Metric) u16 {
+        return @intCast(@abs(self.right_sided_bearing - self.left_sided_bearing));
+    }
+
+    fn height(self: Metric) u16 {
+        return @intCast(@abs(self.ascent + self.descent));
+    }
 };
 
-/// PCF accelerator table
+/// What the accelerator table contributes: the font's vertical extent and widest glyph.
 const Accelerator = struct {
-    no_overlap: bool,
-    constant_metrics: bool,
-    terminal_font: bool,
-    constant_width: bool,
-    ink_inside: bool,
-    ink_metrics: bool,
-    draw_direction: bool,
     font_ascent: i32,
     font_descent: i32,
-    max_overlap: i32,
-    min_bounds: Metric,
     max_bounds: Metric,
-    ink_min_bounds: ?Metric,
-    ink_max_bounds: ?Metric,
 };
 
 /// PCF encoding entry
@@ -163,7 +126,6 @@ const EncodingEntry = struct {
     max_char_or_byte2: u16, // Maximum value for low byte of character code
     min_byte1: u16, // Minimum value for high byte of character code
     max_byte1: u16, // Maximum value for high byte of character code
-    default_char: u16, // Character to use for undefined codes
     glyph_indices: []u16, // 2D array of glyph indices (0xFFFF = undefined)
 };
 
@@ -174,12 +136,6 @@ const Property = struct {
         string: []const u8,
         integer: i32,
     },
-};
-
-/// PCF properties table result
-const PropertiesInfo = struct {
-    properties: []Property,
-    string_pool: []u8, // Owns the string data
 };
 
 /// Loads a PCF font from `path` (transparently decompressing `.pcf.gz`), keeping only characters
@@ -222,63 +178,36 @@ pub fn load(io: Io, allocator: std.mem.Allocator, path: []const u8, filter: Load
     const bitmaps_table = findTable(tables, .bitmaps) orelse return PcfError.MissingRequired;
     const encodings_table = findTable(tables, .bdf_encodings) orelse return PcfError.MissingRequired;
     const accel_table = findTable(tables, .accelerators) orelse findTable(tables, .bdf_accelerators);
-    const properties_table = findTable(tables, .properties);
 
-    // Parse properties table if present (optional)
-    var properties_info: ?PropertiesInfo = null;
-
-    if (properties_table) |props_table| {
-        properties_info = parseProperties(arena_allocator, file_contents, props_table) catch |err| blk: {
-            // Properties are optional, so we continue even if parsing fails
-            std.log.debug("Failed to parse properties table: {}", .{err});
-            break :blk null;
-        };
-    }
+    // Properties are optional, so a bad table only costs the name.
+    const properties: []const Property = if (findTable(tables, .properties)) |table|
+        parseProperties(arena_allocator, file_contents, table) catch &.{}
+    else
+        &.{};
 
     // Parse accelerator table for font metrics
     var font_ascent: i16 = 0;
-    var font_descent: i16 = 0;
     var max_width: u16 = 0;
     var max_height: u16 = 0;
 
     if (accel_table) |accel| {
         const accel_data = try parseAccelerator(file_contents, accel);
         font_ascent = std.math.cast(i16, accel_data.font_ascent) orelse std.math.maxInt(i16);
-        font_descent = std.math.cast(i16, accel_data.font_descent) orelse std.math.maxInt(i16);
         max_width = std.math.cast(u16, @max(accel_data.max_bounds.character_width, 0)) orelse std.math.maxInt(u16);
         const total_height = @max(0, accel_data.font_ascent) + @max(0, accel_data.font_descent);
         max_height = std.math.cast(u16, total_height) orelse std.math.maxInt(u16);
     } else {
         // Default values if no accelerator table
         font_ascent = 14;
-        font_descent = 2;
         max_width = 16;
         max_height = 16;
     }
 
-    // Parse encodings to get character mappings
     const encoding = try parseEncodings(arena_allocator, file_contents, encodings_table);
-
-    // Parse metrics
-    const metrics = try parseMetrics(arena_allocator, file_contents, metrics_table, encoding.glyph_indices.len);
-
-    // Parse bitmap data
+    const metrics = try parseMetrics(arena_allocator, file_contents, metrics_table);
     const bitmap_info = try parseBitmaps(arena_allocator, file_contents, bitmaps_table);
 
-    // Extract font name while in arena scope and duplicate with main allocator
-    var font_name: []u8 = undefined;
-    if (properties_info) |props| {
-        // Try to get FAMILY_NAME first, fall back to other properties
-        if (getStringProperty(props.properties, "FAMILY_NAME")) |family| {
-            font_name = try allocator.dupe(u8, family);
-        } else if (getStringProperty(props.properties, "FONT")) |font| {
-            font_name = try allocator.dupe(u8, font);
-        } else {
-            font_name = try allocator.dupe(u8, "PCF Font");
-        }
-    } else {
-        font_name = try allocator.dupe(u8, "PCF Font");
-    }
+    const font_name = try allocator.dupe(u8, getStringProperty(properties, "FAMILY_NAME") orelse getStringProperty(properties, "FONT") orelse "PCF Font");
     errdefer allocator.free(font_name);
 
     // Convert to BitmapFont format
@@ -309,70 +238,44 @@ fn validateTableBounds(data: []const u8, table: TableEntry) !void {
     }
 }
 
-/// Parse accelerator table
-fn parseAccelerator(data: []const u8, table: TableEntry) !Accelerator {
+/// A reader positioned past a table's format field, with the flags that field decoded to.
+const OpenTable = struct {
+    reader: Io.Reader,
+    flags: FormatFlags,
+    byte_order: std.builtin.Endian,
+};
+
+fn openTable(data: []const u8, table: TableEntry) !OpenTable {
     try validateTableBounds(data, table);
-
-    var reader: Io.Reader = .fixed(data[table.offset .. table.offset + table.size]);
-
-    // Read format field and determine byte order
-    const format = try reader.takeVarInt(u32, .little, @sizeOf(u32));
-    const byte_order = getByteOrder(format);
-
-    var accel: Accelerator = undefined;
-
-    // Fields follow the PCF accelerator layout: the bool flags are single bytes
-    accel.no_overlap = (try reader.takeByte()) != 0;
-    accel.constant_metrics = (try reader.takeByte()) != 0;
-    accel.terminal_font = (try reader.takeByte()) != 0;
-    accel.constant_width = (try reader.takeByte()) != 0;
-    accel.ink_inside = (try reader.takeByte()) != 0;
-    accel.ink_metrics = (try reader.takeByte()) != 0;
-    accel.draw_direction = (try reader.takeByte()) != 0;
-    _ = try reader.takeByte(); // padding
-
-    // Read font metrics
-    accel.font_ascent = try reader.takeVarInt(i32, byte_order, @sizeOf(i32));
-    accel.font_descent = try reader.takeVarInt(i32, byte_order, @sizeOf(i32));
-    accel.max_overlap = try reader.takeVarInt(i32, byte_order, @sizeOf(i32));
-
-    // Read min bounds
-    accel.min_bounds = try readMetric(&reader, byte_order, false);
-    accel.max_bounds = try readMetric(&reader, byte_order, false);
-
-    // Read ink bounds if present
-    const accel_flags = FormatFlags.decode(table.format);
-    if (accel_flags.accel_w_inkbounds) {
-        accel.ink_min_bounds = try readMetric(&reader, byte_order, false);
-        accel.ink_max_bounds = try readMetric(&reader, byte_order, false);
-    } else {
-        accel.ink_min_bounds = null;
-        accel.ink_max_bounds = null;
-    }
-
-    return accel;
+    var reader: Io.Reader = .fixed(data[table.offset..][0..table.size]);
+    const flags = FormatFlags.decode(try reader.takeVarInt(u32, .little, @sizeOf(u32)));
+    return .{ .reader = reader, .flags = flags, .byte_order = flags.byteOrder() };
 }
 
-/// Parse properties table
-fn parseProperties(allocator: std.mem.Allocator, data: []const u8, table: TableEntry) !PropertiesInfo {
-    try validateTableBounds(data, table);
+/// Parse accelerator table
+fn parseAccelerator(data: []const u8, table: TableEntry) !Accelerator {
+    var t = try openTable(data, table);
+    // Seven flag bytes and a pad, then the vertical metrics.
+    try t.reader.discardAll(8);
+    const font_ascent = try t.reader.takeVarInt(i32, t.byte_order, @sizeOf(i32));
+    const font_descent = try t.reader.takeVarInt(i32, t.byte_order, @sizeOf(i32));
+    try t.reader.discardAll(@sizeOf(i32)); // max_overlap
+    _ = try readMetric(&t.reader, t.byte_order, false); // min_bounds
+    return .{
+        .font_ascent = font_ascent,
+        .font_descent = font_descent,
+        .max_bounds = try readMetric(&t.reader, t.byte_order, false),
+    };
+}
 
-    var reader: Io.Reader = .fixed(data[table.offset .. table.offset + table.size]);
+/// Parse properties table; names and string values are slices into `data`.
+fn parseProperties(allocator: std.mem.Allocator, data: []const u8, table: TableEntry) ![]Property {
+    var t = try openTable(data, table);
 
-    // Read format field and determine byte order
-    const format = try reader.takeVarInt(u32, .little, @sizeOf(u32));
-    const byte_order = getByteOrder(format);
-
-    // Read number of properties
-    const prop_count = try reader.takeVarInt(u32, byte_order, @sizeOf(u32));
+    const prop_count = try t.reader.takeVarInt(u32, t.byte_order, @sizeOf(u32));
     if (prop_count > 1000) { // Sanity check
         return PcfError.InvalidTableEntry;
     }
-
-    // Allocate properties array
-    var result: PropertiesInfo = undefined;
-    result.properties = try allocator.alloc(Property, prop_count);
-    errdefer allocator.free(result.properties);
 
     // Temporary storage for property info before string resolution
     const PropertyInfo = struct {
@@ -383,84 +286,48 @@ fn parseProperties(allocator: std.mem.Allocator, data: []const u8, table: TableE
     const prop_infos = try allocator.alloc(PropertyInfo, prop_count);
     defer allocator.free(prop_infos);
 
-    // Read property info
     for (prop_infos) |*prop| {
-        prop.name_offset = try reader.takeVarInt(u32, byte_order, @sizeOf(u32));
-        const is_string_byte = try reader.takeByte();
-        prop.is_string = is_string_byte != 0;
-        prop.value = try reader.takeVarInt(i32, byte_order, @sizeOf(i32));
+        prop.name_offset = try t.reader.takeVarInt(u32, t.byte_order, @sizeOf(u32));
+        prop.is_string = try t.reader.takeByte() != 0;
+        prop.value = try t.reader.takeVarInt(i32, t.byte_order, @sizeOf(i32));
     }
 
-    // Skip padding to align to 4 bytes if needed
-    // Each property info entry is 9 bytes
+    // Each property info entry is 9 bytes; the string pool starts 4-byte aligned.
     const prop_data_size = prop_count * 9;
-    const padding = (4 - (prop_data_size & 3)) & 3;
-    try reader.discardAll(padding);
+    try t.reader.discardAll(std.mem.alignForward(usize, prop_data_size, 4) - prop_data_size);
 
-    // Read string pool size
-    const string_size = try reader.takeVarInt(u32, byte_order, @sizeOf(u32));
+    const string_size = try t.reader.takeVarInt(u32, t.byte_order, @sizeOf(u32));
+    const string_pool = t.reader.take(string_size) catch return PcfError.InvalidTableEntry;
 
-    // Calculate remaining bytes in the reader's buffer
-    const remaining_bytes = reader.buffer.len - reader.seek;
-    if (string_size > remaining_bytes) {
-        return PcfError.InvalidTableEntry;
+    const properties = try allocator.alloc(Property, prop_count);
+    errdefer allocator.free(properties);
+    for (prop_infos, properties) |prop_info, *property| {
+        property.name = try poolString(string_pool, prop_info.name_offset);
+        property.value = if (prop_info.is_string)
+            .{ .string = try poolString(string_pool, @bitCast(prop_info.value)) }
+        else
+            .{ .integer = prop_info.value };
     }
-
-    // Read string pool
-    result.string_pool = try allocator.alloc(u8, string_size);
-    try reader.readSliceAll(result.string_pool);
-
-    // Resolve property names and string values
-    for (prop_infos, 0..) |prop_info, i| {
-        // Get property name from string pool
-        if (prop_info.name_offset >= string_size) {
-            return PcfError.InvalidTableEntry;
-        }
-
-        const name_start = prop_info.name_offset;
-        var name_end = name_start;
-        while (name_end < string_size and result.string_pool[name_end] != 0) : (name_end += 1) {}
-
-        result.properties[i].name = result.string_pool[name_start..name_end];
-
-        if (prop_info.is_string) {
-            // Value is an offset into string pool
-            const value_offset: u32 = @bitCast(prop_info.value);
-            if (value_offset >= string_size) {
-                return PcfError.InvalidTableEntry;
-            }
-
-            const value_start = value_offset;
-            var value_end = value_start;
-            while (value_end < string_size and result.string_pool[value_end] != 0) : (value_end += 1) {}
-
-            result.properties[i].value = .{ .string = result.string_pool[value_start..value_end] };
-        } else {
-            // Value is an integer
-            result.properties[i].value = .{ .integer = prop_info.value };
-        }
-    }
-
-    return result;
+    return properties;
 }
 
-/// Find a property by name
-fn findProperty(properties: []const Property, name: []const u8) ?Property {
-    for (properties) |prop| {
-        if (std.mem.eql(u8, prop.name, name)) {
-            return prop;
-        }
-    }
-    return null;
+/// The NUL-terminated string at `offset` of the pool.
+fn poolString(pool: []const u8, offset: u32) ![]const u8 {
+    if (offset >= pool.len) return PcfError.InvalidTableEntry;
+    const rest = pool[offset..];
+    return rest[0 .. std.mem.indexOfScalar(u8, rest, 0) orelse rest.len];
 }
 
 /// Get string value from properties by name
 fn getStringProperty(properties: []const Property, name: []const u8) ?[]const u8 {
-    const prop = findProperty(properties, name) orelse return null;
-    return switch (prop.value) {
-        .string => |s| s,
-        else => null,
-    };
+    for (properties) |prop| {
+        if (!std.mem.eql(u8, prop.name, name)) continue;
+        return switch (prop.value) {
+            .string => |s| s,
+            .integer => null,
+        };
+    }
+    return null;
 }
 
 /// Read metric from stream (handles both compressed and uncompressed formats)
@@ -494,24 +361,26 @@ fn readMetric(reader: *Io.Reader, byte_order: std.builtin.Endian, compressed: bo
     }
 }
 
+/// Writes an uncompressed metric, little-endian, as `readMetric` reads it.
+fn writeMetric(writer: *Io.Writer, m: Metric) !void {
+    try writer.writeInt(i16, m.left_sided_bearing, .little);
+    try writer.writeInt(i16, m.right_sided_bearing, .little);
+    try writer.writeInt(i16, m.character_width, .little);
+    try writer.writeInt(i16, m.ascent, .little);
+    try writer.writeInt(i16, m.descent, .little);
+    try writer.writeInt(u16, m.attributes, .little);
+}
+
 /// Parse encodings table
 fn parseEncodings(allocator: std.mem.Allocator, data: []const u8, table: TableEntry) !EncodingEntry {
-    try validateTableBounds(data, table);
-
-    var reader = Io.Reader.fixed(data[table.offset .. table.offset + table.size]);
-
-    // Read format field and determine byte order
-    const format = try reader.takeVarInt(u32, .little, @sizeOf(u32));
-    const byte_order = getByteOrder(format);
+    var t = try openTable(data, table);
 
     var encoding: EncodingEntry = undefined;
-
-    // Read encoding info
-    encoding.min_char_or_byte2 = try reader.takeVarInt(u16, byte_order, @sizeOf(u16));
-    encoding.max_char_or_byte2 = try reader.takeVarInt(u16, byte_order, @sizeOf(u16));
-    encoding.min_byte1 = try reader.takeVarInt(u16, byte_order, @sizeOf(u16));
-    encoding.max_byte1 = try reader.takeVarInt(u16, byte_order, @sizeOf(u16));
-    encoding.default_char = try reader.takeVarInt(u16, byte_order, @sizeOf(u16));
+    encoding.min_char_or_byte2 = try t.reader.takeVarInt(u16, t.byte_order, @sizeOf(u16));
+    encoding.max_char_or_byte2 = try t.reader.takeVarInt(u16, t.byte_order, @sizeOf(u16));
+    encoding.min_byte1 = try t.reader.takeVarInt(u16, t.byte_order, @sizeOf(u16));
+    encoding.max_byte1 = try t.reader.takeVarInt(u16, t.byte_order, @sizeOf(u16));
+    try t.reader.discardAll(@sizeOf(u16)); // default_char
 
     // Calculate total encodings with overflow protection
     const cols: u32 = encoding.max_char_or_byte2 - encoding.min_char_or_byte2 + 1;
@@ -524,150 +393,67 @@ fn parseEncodings(allocator: std.mem.Allocator, data: []const u8, table: TableEn
 
     // Read glyph indices in bulk, swapping bytes only if the file endianness differs
     encoding.glyph_indices = try allocator.alloc(u16, encodings_count);
-    try reader.readSliceAll(std.mem.sliceAsBytes(encoding.glyph_indices));
-    if (byte_order != native_endian) {
+    try t.reader.readSliceAll(std.mem.sliceAsBytes(encoding.glyph_indices));
+    if (t.byte_order != native_endian) {
         for (encoding.glyph_indices) |*index| index.* = @byteSwap(index.*);
     }
 
     return encoding;
 }
 
-/// Metrics parsing result
-const MetricsInfo = struct {
-    metrics: []Metric,
-    glyph_count: u32,
-};
-
 /// Parse metrics table
-fn parseMetrics(allocator: std.mem.Allocator, data: []const u8, table: TableEntry, max_glyphs: usize) !MetricsInfo {
-    try validateTableBounds(data, table);
-
-    var reader = Io.Reader.fixed(data[table.offset .. table.offset + table.size]);
-
-    // Read format field and determine byte order
-    const format = try reader.takeVarInt(u32, .little, @sizeOf(u32));
-    const byte_order = getByteOrder(format);
-
-    const flags = FormatFlags.decode(format);
-    const compressed = flags.compressed_metrics;
-
-    var result: MetricsInfo = undefined;
-
-    if (compressed) {
-        // Read compressed metrics count
-        const metrics_count = try reader.takeVarInt(u16, byte_order, @sizeOf(u16));
-        if (metrics_count > max_glyph_count) {
-            return PcfError.InvalidGlyphCount;
-        }
-        result.glyph_count = metrics_count;
-
-        // Allocate and read compressed metrics
-        result.metrics = try allocator.alloc(Metric, metrics_count);
-
-        for (result.metrics) |*metric| {
-            metric.* = try readMetric(&reader, byte_order, true);
-        }
-    } else {
-        // Read uncompressed metrics count
-        const metrics_count = try reader.takeVarInt(u32, byte_order, @sizeOf(u32));
-        if (metrics_count > max_glyph_count) {
-            return PcfError.InvalidGlyphCount;
-        }
-        result.glyph_count = @min(metrics_count, max_glyphs);
-
-        // Allocate and read uncompressed metrics
-        result.metrics = try allocator.alloc(Metric, result.glyph_count);
-
-        for (result.metrics) |*metric| {
-            metric.* = try readMetric(&reader, byte_order, false);
-        }
-    }
-
-    return result;
+fn parseMetrics(allocator: std.mem.Allocator, data: []const u8, table: TableEntry) ![]Metric {
+    var t = try openTable(data, table);
+    const compressed = t.flags.compressed_metrics;
+    // Compressed metrics come with a short count.
+    const count: u32 = if (compressed) try t.reader.takeVarInt(u16, t.byte_order, 2) else try t.reader.takeVarInt(u32, t.byte_order, 4);
+    if (count > max_glyph_count) return PcfError.InvalidGlyphCount;
+    const metrics = try allocator.alloc(Metric, count);
+    for (metrics) |*metric| metric.* = try readMetric(&t.reader, t.byte_order, compressed);
+    return metrics;
 }
 
 /// Bitmap parsing result
 const BitmapInfo = struct {
-    bitmap_data: []u8,
+    /// The bitmap table's pixel data, borrowed from the file.
+    bitmap_data: []const u8,
     offsets: []u32,
-    bitmap_sizes: BitmapSizes,
-    format: u32,
-};
-
-/// PCF bitmap sizes structure
-const BitmapSizes = struct {
-    image_width: u32, // Width of the bitmap image in pixels
-    image_height: u32, // Height of the bitmap image in pixels
-    image_size: u32, // Total size of bitmap data in bytes
-    bitmap_count: u32, // Number of bitmaps (same as glyph count)
+    flags: FormatFlags,
 };
 
 /// Parse bitmaps table
 fn parseBitmaps(allocator: std.mem.Allocator, data: []const u8, table: TableEntry) !BitmapInfo {
-    try validateTableBounds(data, table);
+    var t = try openTable(data, table);
 
-    var reader: Io.Reader = .fixed(data[table.offset .. table.offset + table.size]);
-
-    // Read format field and determine byte order
-    const format = try reader.takeVarInt(u32, .little, @sizeOf(u32));
-    const byte_order = getByteOrder(format);
-
-    // Read glyph count
-    const glyph_count = try reader.takeVarInt(u32, byte_order, @sizeOf(u32));
+    const glyph_count = try t.reader.takeVarInt(u32, t.byte_order, @sizeOf(u32));
     if (glyph_count > max_glyph_count) {
         return PcfError.InvalidGlyphCount;
     }
 
     // Read bitmap offsets in bulk, swapping bytes only if the file endianness differs
-    var result: BitmapInfo = undefined;
-    result.format = format;
-    result.offsets = try allocator.alloc(u32, glyph_count);
-    try reader.readSliceAll(std.mem.sliceAsBytes(result.offsets));
-    if (byte_order != native_endian) {
-        for (result.offsets) |*offset| offset.* = @byteSwap(offset.*);
+    const offsets = try allocator.alloc(u32, glyph_count);
+    try t.reader.readSliceAll(std.mem.sliceAsBytes(offsets));
+    if (t.byte_order != native_endian) {
+        for (offsets) |*offset| offset.* = @byteSwap(offset.*);
     }
 
-    // Read bitmap sizes array
-    result.bitmap_sizes = BitmapSizes{
-        .image_width = try reader.takeVarInt(u32, byte_order, @sizeOf(u32)),
-        .image_height = try reader.takeVarInt(u32, byte_order, @sizeOf(u32)),
-        .image_size = try reader.takeVarInt(u32, byte_order, @sizeOf(u32)),
-        .bitmap_count = try reader.takeVarInt(u32, byte_order, @sizeOf(u32)),
+    // The data size for each row padding (1, 2, 4, 8 bytes); the format says which applies.
+    var sizes: [4]u32 = undefined;
+    for (&sizes) |*size| size.* = try t.reader.takeVarInt(u32, t.byte_order, @sizeOf(u32));
+    const data_size = sizes[t.flags.glyph_pad];
+
+    return .{
+        .bitmap_data = try t.reader.take(data_size),
+        .offsets = offsets,
+        .flags = t.flags,
     };
-
-    // Note: bitmap_count might not always match glyph_count exactly in some PCF files
-    // Some fonts may have padding or extra bitmap slots
-
-    // Determine correct size based on format padding
-    // The 4 values in bitmap_sizes correspond to padding 1, 2, 4, 8 bytes
-    const flags = FormatFlags.decode(format);
-    const data_size = switch (flags.glyph_pad) {
-        0 => result.bitmap_sizes.image_width,
-        1 => result.bitmap_sizes.image_height,
-        2 => result.bitmap_sizes.image_size,
-        3 => result.bitmap_sizes.bitmap_count,
-    };
-
-    // Read bitmap data
-    result.bitmap_data = try allocator.alloc(u8, data_size);
-    try reader.readSliceAll(result.bitmap_data);
-
-    return result;
 }
 
 /// Convert a single glyph bitmap from PCF format to our format.
 /// The caller must have reserved capacity in `output` for the converted bytes.
-fn convertGlyphBitmap(
-    bitmap_data: []const u8,
-    offset: u32,
-    width: u16,
-    height: u16,
-    format_flags: FormatFlags,
-    glyph_pad: GlyphPadding,
-    output: *std.ArrayList(u8),
-) void {
-    const bytes_per_row = (width + 7) / 8;
-    const pcf_row_bytes = std.mem.alignForward(u32, bytes_per_row, glyph_pad.getPadBytes());
+fn convertGlyphBitmap(bitmap_data: []const u8, offset: u32, width: u16, height: u16, flags: FormatFlags, output: *std.ArrayList(u8)) void {
+    const bytes_per_row = GlyphData.bytesForWidth(width);
+    const pcf_row_bytes = std.mem.alignForward(u32, bytes_per_row, flags.padBytes());
 
     // Convert each row
     for (0..height) |row| {
@@ -678,7 +464,7 @@ fn convertGlyphBitmap(
             if (src_offset + byte_idx < bitmap_data.len) {
                 const byte = bitmap_data[src_offset + byte_idx];
                 // PCF uses MSB first by default, convert if needed
-                output.appendAssumeCapacity(if (format_flags.bit_order_msb) @bitReverse(byte) else byte);
+                output.appendAssumeCapacity(if (flags.bit_order_msb) @bitReverse(byte) else byte);
             } else {
                 output.appendAssumeCapacity(0);
             }
@@ -689,7 +475,7 @@ fn convertGlyphBitmap(
 /// Convert parsed PCF data to BitmapFont format
 fn convertToBitmapFont(
     gpa: std.mem.Allocator,
-    metrics_info: MetricsInfo,
+    metrics: []const Metric,
     bitmap_info: BitmapInfo,
     encoding: EncodingEntry,
     filter: LoadFilter,
@@ -706,10 +492,6 @@ fn convertToBitmapFont(
     }) = .empty;
     defer glyph_list.deinit(gpa);
 
-    var all_ascii = true;
-    var min_char: u8 = 255;
-    var max_char: u8 = 0;
-
     // PCF uses a 2D encoding table: rows are byte1 (high byte), columns are byte2 (low byte)
     const chars_per_row = encoding.max_char_or_byte2 - encoding.min_char_or_byte2 + 1;
 
@@ -722,29 +504,14 @@ fn convertToBitmapFont(
         const codepoint: u32 = @intCast(((encoding.min_byte1 + row) << 8) | (encoding.min_char_or_byte2 + col));
 
         if (!filter.matches(codepoint)) continue;
-
-        if (glyph_index < metrics_info.glyph_count) {
-            try glyph_list.append(gpa, .{
-                .codepoint = codepoint,
-                .glyph_index = glyph_index,
-                .metric = metrics_info.metrics[glyph_index],
-            });
-
-            if (codepoint > 127) {
-                all_ascii = false;
-            } else {
-                min_char = @min(min_char, @as(u8, @intCast(codepoint)));
-                max_char = @max(max_char, @as(u8, @intCast(codepoint)));
-            }
-        }
+        if (glyph_index >= metrics.len) continue;
+        try glyph_list.append(gpa, .{ .codepoint = codepoint, .glyph_index = glyph_index, .metric = metrics[glyph_index] });
     }
 
     // Pre-calculate total bitmap size needed
     var total_bitmap_size: u32 = 0;
     for (glyph_list.items) |glyph_info| {
-        const dims = getGlyphDimensions(glyph_info.metric);
-        const bytes_per_row = (dims.width + 7) / 8;
-        total_bitmap_size += bytes_per_row * dims.height;
+        total_bitmap_size += GlyphData.bytesForWidth(glyph_info.metric.width()) * glyph_info.metric.height();
     }
 
     // Pre-allocate converted bitmap buffer
@@ -752,95 +519,55 @@ fn convertToBitmapFont(
     defer converted_bitmaps.deinit(gpa);
     try converted_bitmaps.ensureTotalCapacity(gpa, total_bitmap_size);
 
-    var glyph_map: std.AutoHashMap(u32, usize) = .init(gpa);
-    errdefer glyph_map.deinit();
-    try glyph_map.ensureTotalCapacity(@intCast(glyph_list.items.len));
+    var glyphs: std.AutoHashMap(u32, GlyphData) = .init(gpa);
+    errdefer glyphs.deinit();
+    try glyphs.ensureTotalCapacity(@intCast(glyph_list.items.len));
 
-    var glyph_data_list = try gpa.alloc(GlyphData, glyph_list.items.len);
-    errdefer gpa.free(glyph_data_list);
-
-    const format_flags = FormatFlags.decode(bitmap_info.format);
-    const glyph_pad: GlyphPadding = @fromBackingInt(format_flags.glyph_pad);
-
-    for (glyph_list.items, 0..) |glyph_info, list_index| {
+    for (glyph_list.items) |glyph_info| {
         const metric = glyph_info.metric;
-        const dims = getGlyphDimensions(metric);
-
-        // Store converted bitmap offset
         const converted_offset = converted_bitmaps.items.len;
 
         if (glyph_info.glyph_index >= bitmap_info.offsets.len) {
             return PcfError.InvalidBitmapData;
         }
-        // Convert bitmap data for this glyph
         const bitmap_offset = bitmap_info.offsets[glyph_info.glyph_index];
         if (bitmap_offset >= bitmap_info.bitmap_data.len) {
             return PcfError.InvalidBitmapData;
         }
+        convertGlyphBitmap(bitmap_info.bitmap_data, bitmap_offset, metric.width(), metric.height(), bitmap_info.flags, &converted_bitmaps);
 
-        convertGlyphBitmap(
-            bitmap_info.bitmap_data,
-            bitmap_offset,
-            dims.width,
-            dims.height,
-            format_flags,
-            glyph_pad,
-            &converted_bitmaps,
-        );
-
-        // Create glyph data entry
-        try glyph_map.put(glyph_info.codepoint, list_index);
-
-        // Adjust y_offset to account for font baseline
-        const adjusted_y_offset = ascent - metric.ascent;
-
-        glyph_data_list[list_index] = GlyphData{
-            .width = @intCast(dims.width),
-            .height = @intCast(dims.height),
+        glyphs.putAssumeCapacity(glyph_info.codepoint, .{
+            .width = @intCast(metric.width()),
+            .height = @intCast(metric.height()),
             .x_offset = metric.left_sided_bearing,
-            .y_offset = adjusted_y_offset,
+            // Adjust y_offset to account for font baseline
+            .y_offset = ascent - metric.ascent,
             .device_width = metric.character_width,
             .bitmap_offset = converted_offset,
-        };
+        });
     }
 
-    // Create final bitmap data
-    const bitmap_data = try converted_bitmaps.toOwnedSlice(gpa);
-
-    return BitmapFont{
+    return .{
         .name = name,
         .char_width = @intCast(@min(max_width, 255)),
         .char_height = @intCast(@min(max_height, 255)),
-        .first_char = if (all_ascii) min_char else 0,
-        .last_char = if (all_ascii) max_char else 0,
-        .data = bitmap_data,
-        .glyph_map = glyph_map,
-        .glyph_data = glyph_data_list,
+        .data = try converted_bitmaps.toOwnedSlice(gpa),
+        .glyphs = glyphs,
     };
 }
 
 // --- PCF Writing Support ---
 
 const TableBuffer = struct {
-    table_type: u32,
-    format: u32,
+    table_type: TableType,
     data: []u8,
-};
-
-const GlyphMetrics = struct {
-    left: i16,
-    right: i16,
-    width: i16,
-    ascent: i16,
-    descent: i16,
-    attributes: u16,
 };
 
 const GlyphEntry = struct {
     codepoint: u21,
-    metrics: GlyphMetrics,
-    width: u16,
-    height: u16,
+    metrics: Metric,
+    width: u8,
+    height: u8,
     bitmap_offset: u32,
 };
 
@@ -864,16 +591,16 @@ fn buildGlyphEntries(
     const font_ascent = font.ascent();
 
     for (codepoints, 0..) |cp, idx| {
-        const glyph_info = font.getGlyphInfo(cp) orelse return PcfError.MissingRequired;
+        const glyph = font.getGlyph(cp) orelse return PcfError.MissingRequired;
+        const glyph_info = glyph.info;
         const width = glyph_info.width;
         const height = glyph_info.height;
-        const char_data = font.getCharData(cp) orelse return PcfError.InvalidBitmapData;
 
         const left = glyph_info.x_offset;
         const glyph_ascent = font_ascent - glyph_info.y_offset;
 
         const bitmap_offset: u32 = @intCast(bitmap_buffer.items.len);
-        try bitmap_buffer.appendSlice(allocator, char_data);
+        try bitmap_buffer.appendSlice(allocator, glyph.data);
 
         // Accumulate table sizes for each PCF padding option (1, 2, 4, 8 bytes)
         for (&pad_sizes, 0..) |*size, pad_idx| {
@@ -884,9 +611,9 @@ fn buildGlyphEntries(
         entries[idx] = GlyphEntry{
             .codepoint = cp,
             .metrics = .{
-                .left = left,
-                .right = @as(i16, width) + left,
-                .width = glyph_info.device_width,
+                .left_sided_bearing = left,
+                .right_sided_bearing = @as(i16, width) + left,
+                .character_width = glyph_info.device_width,
                 .ascent = glyph_ascent,
                 .descent = @max(@as(i16, height) - glyph_ascent, 0),
                 .attributes = 0,
@@ -913,16 +640,7 @@ fn writeMetricsTable(allocator: Allocator, glyphs: []const GlyphEntry) ![]u8 {
 
     try writer.writeInt(u32, 0, .little); // Format: uncompressed metrics
     try writer.writeInt(u32, @intCast(glyphs.len), .little);
-
-    for (glyphs) |glyph| {
-        const m = glyph.metrics;
-        try writer.writeInt(i16, m.left, .little);
-        try writer.writeInt(i16, m.right, .little);
-        try writer.writeInt(i16, m.width, .little);
-        try writer.writeInt(i16, m.ascent, .little);
-        try writer.writeInt(i16, m.descent, .little);
-        try writer.writeInt(u16, m.attributes, .little);
-    }
+    for (glyphs) |glyph| try writeMetric(&writer, glyph.metrics);
 
     return buffer;
 }
@@ -1021,55 +739,43 @@ fn writePropertiesTable(allocator: Allocator, font: BitmapFont) ![]u8 {
     var string_pool: std.ArrayList(u8) = .empty;
     defer string_pool.deinit(allocator);
 
-    const PropVal = struct {
-        name: []const u8,
-        is_string: bool,
-        s_val: []const u8,
-        i_val: i32,
-    };
+    var props: std.ArrayList(Property) = .empty;
+    defer props.deinit(allocator);
 
-    var props_list: std.ArrayList(PropVal) = .empty;
-    defer props_list.deinit(allocator);
-
-    try props_list.append(allocator, .{ .name = "FONT", .is_string = true, .s_val = font.name, .i_val = 0 });
-    try props_list.append(allocator, .{ .name = "PIXEL_SIZE", .is_string = false, .s_val = "", .i_val = @intCast(font.char_height) });
-    try props_list.append(allocator, .{ .name = "POINT_SIZE", .is_string = false, .s_val = "", .i_val = @as(i32, font.char_height) * 10 });
-    try props_list.append(allocator, .{ .name = "RESOLUTION_X", .is_string = false, .s_val = "", .i_val = 75 });
-    try props_list.append(allocator, .{ .name = "RESOLUTION_Y", .is_string = false, .s_val = "", .i_val = 75 });
-    try props_list.append(allocator, .{ .name = "SPACING", .is_string = true, .s_val = if (font.glyph_map != null) "P" else "C", .i_val = 0 });
+    try props.append(allocator, .{ .name = "FONT", .value = .{ .string = font.name } });
+    try props.append(allocator, .{ .name = "PIXEL_SIZE", .value = .{ .integer = font.char_height } });
+    try props.append(allocator, .{ .name = "POINT_SIZE", .value = .{ .integer = @as(i32, font.char_height) * 10 } });
+    try props.append(allocator, .{ .name = "RESOLUTION_X", .value = .{ .integer = 75 } });
+    try props.append(allocator, .{ .name = "RESOLUTION_Y", .value = .{ .integer = 75 } });
+    try props.append(allocator, .{ .name = "SPACING", .value = .{ .string = if (font.glyphs != null) "P" else "C" } });
 
     if (font.font_ascent) |asc| {
-        try props_list.append(allocator, .{ .name = "FONT_ASCENT", .is_string = false, .s_val = "", .i_val = asc });
-        const desc = @as(i32, font.char_height) - asc;
-        try props_list.append(allocator, .{ .name = "FONT_DESCENT", .is_string = false, .s_val = "", .i_val = desc });
+        try props.append(allocator, .{ .name = "FONT_ASCENT", .value = .{ .integer = asc } });
+        try props.append(allocator, .{ .name = "FONT_DESCENT", .value = .{ .integer = @as(i32, font.char_height) - asc } });
     }
 
     // Add strings to pool and record offsets
-    var prop_entries = try allocator.alloc(struct { name_off: u32, is_string: u8, val: i32 }, props_list.items.len);
+    const prop_entries = try allocator.alloc(struct { name_off: u32, is_string: u8, val: i32 }, props.items.len);
     defer allocator.free(prop_entries);
 
-    for (props_list.items, 0..) |p, i| {
+    for (props.items, prop_entries) |p, *entry| {
         const name_off: u32 = @intCast(string_pool.items.len);
         try string_pool.appendSlice(allocator, p.name);
         try string_pool.append(allocator, 0);
 
-        var val: i32 = p.i_val;
-        if (p.is_string) {
-            const val_off: u32 = @intCast(string_pool.items.len);
-            try string_pool.appendSlice(allocator, p.s_val);
-            try string_pool.append(allocator, 0);
-            val = @bitCast(val_off);
-        }
-
-        prop_entries[i] = .{
-            .name_off = name_off,
-            .is_string = if (p.is_string) 1 else 0,
-            .val = val,
+        entry.* = switch (p.value) {
+            .integer => |value| .{ .name_off = name_off, .is_string = 0, .val = value },
+            .string => |value| blk: {
+                const val_off: u32 = @intCast(string_pool.items.len);
+                try string_pool.appendSlice(allocator, value);
+                try string_pool.append(allocator, 0);
+                break :blk .{ .name_off = name_off, .is_string = 1, .val = @bitCast(val_off) };
+            },
         };
     }
 
     const prop_data_size = prop_entries.len * 9;
-    const padding = (4 - (prop_data_size & 3)) & 3;
+    const padding = std.mem.alignForward(usize, prop_data_size, 4) - prop_data_size;
 
     const total_size = 4 + 4 + prop_data_size + padding + 4 + string_pool.items.len;
     const buffer = try allocator.alloc(u8, total_size);
@@ -1094,41 +800,19 @@ fn writePropertiesTable(allocator: Allocator, font: BitmapFont) ![]u8 {
 
 fn writeAcceleratorsTable(allocator: Allocator, glyphs: []const GlyphEntry, font_ascent: i16, font_descent: i16) ![]u8 {
     // Fold global bounds over all glyphs, starting from saturated sentinels
-    var min_bounds: Metric = .{
-        .left_sided_bearing = std.math.maxInt(i16),
-        .right_sided_bearing = std.math.maxInt(i16),
-        .character_width = std.math.maxInt(i16),
-        .ascent = std.math.maxInt(i16),
-        .descent = std.math.maxInt(i16),
-        .attributes = 0,
-    };
-    var max_bounds: Metric = .{
-        .left_sided_bearing = std.math.minInt(i16),
-        .right_sided_bearing = std.math.minInt(i16),
-        .character_width = std.math.minInt(i16),
-        .ascent = std.math.minInt(i16),
-        .descent = std.math.minInt(i16),
-        .attributes = 0,
-    };
-
-    for (glyphs) |g| {
-        const m = g.metrics;
-        min_bounds.left_sided_bearing = @min(min_bounds.left_sided_bearing, m.left);
-        min_bounds.right_sided_bearing = @min(min_bounds.right_sided_bearing, m.right);
-        min_bounds.character_width = @min(min_bounds.character_width, m.width);
-        min_bounds.ascent = @min(min_bounds.ascent, m.ascent);
-        min_bounds.descent = @min(min_bounds.descent, m.descent);
-
-        max_bounds.left_sided_bearing = @max(max_bounds.left_sided_bearing, m.left);
-        max_bounds.right_sided_bearing = @max(max_bounds.right_sided_bearing, m.right);
-        max_bounds.character_width = @max(max_bounds.character_width, m.width);
-        max_bounds.ascent = @max(max_bounds.ascent, m.ascent);
-        max_bounds.descent = @max(max_bounds.descent, m.descent);
-    }
-
-    if (glyphs.len == 0) {
-        min_bounds = std.mem.zeroes(Metric);
-        max_bounds = std.mem.zeroes(Metric);
+    var min_bounds: Metric = std.mem.zeroes(Metric);
+    var max_bounds: Metric = std.mem.zeroes(Metric);
+    if (glyphs.len > 0) {
+        inline for (Metric.extents) |field| {
+            @field(min_bounds, field) = std.math.maxInt(i16);
+            @field(max_bounds, field) = std.math.minInt(i16);
+        }
+        for (glyphs) |g| {
+            inline for (Metric.extents) |field| {
+                @field(min_bounds, field) = @min(@field(min_bounds, field), @field(g.metrics, field));
+                @field(max_bounds, field) = @max(@field(max_bounds, field), @field(g.metrics, field));
+            }
+        }
     }
 
     // Size calculation
@@ -1139,34 +823,15 @@ fn writeAcceleratorsTable(allocator: Allocator, glyphs: []const GlyphEntry, font
     var writer = Io.Writer.fixed(buffer);
 
     try writer.writeInt(u32, 0, .little); // Format (no accel w/ inkbounds)
-    try writer.writeByte(0); // noOverlap
-    try writer.writeByte(0); // constantMetrics
-    try writer.writeByte(0); // terminalFont
-    try writer.writeByte(0); // constantWidth
-    try writer.writeByte(0); // inkInside
-    try writer.writeByte(0); // inkMetrics
-    try writer.writeByte(0); // drawDirection
-    try writer.writeByte(0); // padding
+    // noOverlap, constantMetrics, terminalFont, constantWidth, inkInside, inkMetrics,
+    // drawDirection and padding
+    try writer.splatByteAll(0, 8);
 
     try writer.writeInt(i32, font_ascent, .little);
     try writer.writeInt(i32, font_descent, .little);
     try writer.writeInt(i32, max_bounds.right_sided_bearing, .little); // max_overlap approximation
-
-    // Write min bounds
-    try writer.writeInt(i16, min_bounds.left_sided_bearing, .little);
-    try writer.writeInt(i16, min_bounds.right_sided_bearing, .little);
-    try writer.writeInt(i16, min_bounds.character_width, .little);
-    try writer.writeInt(i16, min_bounds.ascent, .little);
-    try writer.writeInt(i16, min_bounds.descent, .little);
-    try writer.writeInt(u16, min_bounds.attributes, .little);
-
-    // Write max bounds
-    try writer.writeInt(i16, max_bounds.left_sided_bearing, .little);
-    try writer.writeInt(i16, max_bounds.right_sided_bearing, .little);
-    try writer.writeInt(i16, max_bounds.character_width, .little);
-    try writer.writeInt(i16, max_bounds.ascent, .little);
-    try writer.writeInt(i16, max_bounds.descent, .little);
-    try writer.writeInt(u16, max_bounds.attributes, .little);
+    try writeMetric(&writer, min_bounds);
+    try writeMetric(&writer, max_bounds);
 
     return buffer;
 }
@@ -1203,11 +868,11 @@ pub fn save(io: Io, gpa: Allocator, font: BitmapFont, path: []const u8) !void {
     defer gpa.free(accel_table);
 
     const tables = [_]TableBuffer{
-        .{ .table_type = @backingInt(TableType.properties), .format = 0, .data = properties_table },
-        .{ .table_type = @backingInt(TableType.accelerators), .format = 0, .data = accel_table },
-        .{ .table_type = @backingInt(TableType.metrics), .format = 0, .data = metrics_table },
-        .{ .table_type = @backingInt(TableType.bitmaps), .format = 0, .data = bitmaps_table },
-        .{ .table_type = @backingInt(TableType.bdf_encodings), .format = 0, .data = encoding_table },
+        .{ .table_type = .properties, .data = properties_table },
+        .{ .table_type = .accelerators, .data = accel_table },
+        .{ .table_type = .metrics, .data = metrics_table },
+        .{ .table_type = .bitmaps, .data = bitmaps_table },
+        .{ .table_type = .bdf_encodings, .data = encoding_table },
     };
 
     const header_size = 8 + tables.len * 16;
@@ -1229,8 +894,8 @@ pub fn save(io: Io, gpa: Allocator, font: BitmapFont, path: []const u8) !void {
     try aw.writer.writeInt(u32, tables.len, .little);
 
     for (tables, 0..) |table, idx| {
-        try aw.writer.writeInt(u32, table.table_type, .little);
-        try aw.writer.writeInt(u32, table.format, .little);
+        try aw.writer.writeInt(u32, @backingInt(table.table_type), .little);
+        try aw.writer.writeInt(u32, 0, .little); // format
         try aw.writer.writeInt(u32, @intCast(table.data.len), .little);
         try aw.writer.writeInt(u32, offsets[idx], .little);
     }
@@ -1248,89 +913,13 @@ pub fn save(io: Io, gpa: Allocator, font: BitmapFont, path: []const u8) !void {
 }
 
 test "FormatFlags decoding" {
-    // Test format flag decoding
-    const test_cases = [_]struct {
-        format: u32,
-        expected: FormatFlags,
-    }{
-        .{
-            .format = 0x00000000,
-            .expected = .{
-                .glyph_pad = 0,
-                .byte_order_msb = false,
-                .bit_order_msb = false,
-                .scan_unit = 0,
-                .accel_w_inkbounds = false,
-                .compressed_metrics = false,
-                .ink_bounds = false,
-            },
-        },
-        .{
-            .format = 0x00000004,
-            .expected = .{
-                .glyph_pad = 0,
-                .byte_order_msb = true,
-                .bit_order_msb = false,
-                .scan_unit = 0,
-                .accel_w_inkbounds = false,
-                .compressed_metrics = false,
-                .ink_bounds = false,
-            },
-        },
-        .{
-            .format = 0x00000008,
-            .expected = .{
-                .glyph_pad = 0,
-                .byte_order_msb = false,
-                .bit_order_msb = true,
-                .scan_unit = 0,
-                .accel_w_inkbounds = false,
-                .compressed_metrics = false,
-                .ink_bounds = false,
-            },
-        },
-        .{
-            .format = 0x0000010C, // Typical compressed metrics format
-            .expected = .{
-                .glyph_pad = 0,
-                .byte_order_msb = true,
-                .bit_order_msb = true,
-                .scan_unit = 0,
-                .accel_w_inkbounds = false,
-                .compressed_metrics = true,
-                .ink_bounds = false,
-            },
-        },
-        .{
-            .format = 0x00000031, // glyph pad 1, scan unit 3
-            .expected = .{
-                .glyph_pad = 1,
-                .byte_order_msb = false,
-                .bit_order_msb = false,
-                .scan_unit = 3,
-                .accel_w_inkbounds = false,
-                .compressed_metrics = false,
-                .ink_bounds = false,
-            },
-        },
-        .{
-            .format = 0x0000070C, // compressed + accel inkbounds + ink bounds
-            .expected = .{
-                .glyph_pad = 0,
-                .byte_order_msb = true,
-                .bit_order_msb = true,
-                .scan_unit = 0,
-                .accel_w_inkbounds = true,
-                .compressed_metrics = true,
-                .ink_bounds = true,
-            },
-        },
-    };
-
-    for (test_cases) |tc| {
-        const flags = FormatFlags.decode(tc.format);
-        try testing.expectEqualDeep(tc.expected, flags);
-    }
+    try testing.expectEqual(FormatFlags{ .glyph_pad = 0, .byte_order_msb = false, .bit_order_msb = false, .compressed_metrics = false }, FormatFlags.decode(0));
+    // Typical compressed metrics format.
+    try testing.expectEqual(FormatFlags{ .glyph_pad = 0, .byte_order_msb = true, .bit_order_msb = true, .compressed_metrics = true }, FormatFlags.decode(0x10C));
+    // Glyph pad 1 (2-byte rows), scan unit 3 (ignored).
+    const padded = FormatFlags.decode(0x31);
+    try testing.expectEqual(FormatFlags{ .glyph_pad = 1, .byte_order_msb = false, .bit_order_msb = false, .compressed_metrics = false }, padded);
+    try testing.expectEqual(2, padded.padBytes());
 }
 
 test "Table bounds validation" {
@@ -1422,156 +1011,48 @@ test "Properties parsing" {
     };
 
     const props = try parseProperties(allocator, buffer[0..writer.end], table);
-    defer allocator.free(props.properties);
-    defer allocator.free(props.string_pool);
+    defer allocator.free(props);
 
-    try testing.expectEqual(@as(usize, 1), props.properties.len);
-
-    // Check property
-    try testing.expectEqualStrings("PIXEL_SIZE", props.properties[0].name);
-    try testing.expect(props.properties[0].value == .integer);
-    try testing.expectEqual(@as(i32, 16), props.properties[0].value.integer);
+    try testing.expectEqual(@as(usize, 1), props.len);
+    try testing.expectEqualStrings("PIXEL_SIZE", props[0].name);
+    try testing.expectEqual(@as(i32, 16), props[0].value.integer);
 }
 
-test "PCF save and load roundtrip" {
-    // Create a simple font manually
-    const char_width = 8;
-    const char_height = 8;
-
-    // 3 chars: A, B, C
-    const data_size = 3 * char_height; // 1 byte per row * 8 rows * 3 chars
-    const bitmap_data = try testing.allocator.alloc(u8, data_size);
-    defer testing.allocator.free(bitmap_data);
-
-    // Pattern for A
-    bitmap_data[0] = 0x18;
-    bitmap_data[1] = 0x24;
-    bitmap_data[2] = 0x42;
-    bitmap_data[3] = 0x42;
-    bitmap_data[4] = 0x7E;
-    bitmap_data[5] = 0x42;
-    bitmap_data[6] = 0x42;
-    bitmap_data[7] = 0x00;
-
-    // Pattern for B
-    bitmap_data[8] = 0x7C;
-    bitmap_data[9] = 0x42;
-    bitmap_data[10] = 0x42;
-    bitmap_data[11] = 0x7C;
-    bitmap_data[12] = 0x42;
-    bitmap_data[13] = 0x42;
-    bitmap_data[14] = 0x7C;
-    bitmap_data[15] = 0x00;
-
-    // Pattern for C
-    bitmap_data[16] = 0x3C;
-    bitmap_data[17] = 0x42;
-    bitmap_data[18] = 0x40;
-    bitmap_data[19] = 0x40;
-    bitmap_data[20] = 0x40;
-    bitmap_data[21] = 0x42;
-    bitmap_data[22] = 0x3C;
-    bitmap_data[23] = 0x00;
-
-    const font_data = try testing.allocator.dupe(u8, bitmap_data);
-    const font_name = try testing.allocator.dupe(u8, "TestFont");
-
-    var font: BitmapFont = .{
-        .name = font_name,
-        .char_width = char_width,
-        .char_height = char_height,
-        .first_char = 65, // 'A'
-        .last_char = 67, // 'C'
-        .data = font_data,
-        .glyph_map = null,
-        .glyph_data = null,
-        .font_ascent = 7,
-    };
-    defer font.deinit(testing.allocator);
-
-    // Save
+fn expectRoundtrip(file_name: []const u8) !void {
+    const font = BitmapFont.test_font;
     var tmp_dir = testing.tmpDir(.{});
     defer tmp_dir.cleanup();
     const tmp_path = try tmp_dir.dir.realPathFileAlloc(testing.io, ".", testing.allocator);
     defer testing.allocator.free(tmp_path);
-    const full_path = try Io.Dir.path.join(testing.allocator, &.{ tmp_path, "test.pcf" });
-    defer testing.allocator.free(full_path);
+    const path = try Io.Dir.path.join(testing.allocator, &.{ tmp_path, file_name });
+    defer testing.allocator.free(path);
 
-    try font.save(testing.io, testing.allocator, full_path);
-
-    // Load back
-    var loaded = try BitmapFont.load(testing.io, testing.allocator, full_path, .all);
-    defer loaded.deinit(testing.allocator);
-
-    // Verify
-    try testing.expectEqualStrings(font.name, loaded.name);
-    try testing.expectEqual(font.char_width, loaded.char_width);
-    try testing.expectEqual(font.char_height, loaded.char_height);
-    try testing.expectEqual(font.first_char, loaded.first_char);
-    try testing.expectEqual(font.last_char, loaded.last_char);
-
-    // Verify data
-    for (font.first_char..font.last_char + 1) |cp| {
-        const original = font.getCharData(@intCast(cp));
-        const new_data = loaded.getCharData(@intCast(cp));
-        try testing.expect(original != null);
-        try testing.expect(new_data != null);
-        try testing.expectEqualSlices(u8, original.?, new_data.?);
-    }
-}
-
-test "PCF save and load compressed roundtrip" {
-    // Similar to uncompressed test but with .gz extension
-    const char_width = 8;
-    const char_height = 8;
-
-    const data_size = 3 * char_height;
-    const bitmap_data = try testing.allocator.alloc(u8, data_size);
-    defer testing.allocator.free(bitmap_data);
-    @memset(bitmap_data, 0xAA); // Dummy pattern
-
-    const font_data = try testing.allocator.dupe(u8, bitmap_data);
-    const font_name = try testing.allocator.dupe(u8, "CompressedTestFont");
-
-    var font: BitmapFont = .{
-        .name = font_name,
-        .char_width = char_width,
-        .char_height = char_height,
-        .first_char = 65,
-        .last_char = 67,
-        .data = font_data,
-        .glyph_map = null,
-        .glyph_data = null,
-        .font_ascent = 7,
-    };
-    defer font.deinit(testing.allocator);
-
-    var tmp_dir = testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
-
-    const tmp_path = try tmp_dir.dir.realPathFileAlloc(testing.io, ".", testing.allocator);
-    defer testing.allocator.free(tmp_path);
-    const full_path = try Io.Dir.path.join(testing.allocator, &.{ tmp_path, "test.pcf.gz" });
-    defer testing.allocator.free(full_path);
-
-    try font.save(testing.io, testing.allocator, full_path);
-
-    // Verify it is a gzip file
-    {
-        const file = try Io.Dir.openFileAbsolute(testing.io, full_path, .{});
+    try font.save(testing.io, testing.allocator, path);
+    if (isGzipPath(path)) {
+        // The file starts with the gzip magic.
+        const file = try Io.Dir.openFileAbsolute(testing.io, path, .{});
         defer file.close(testing.io);
         var header: [2]u8 = undefined;
         var iov = [_][]u8{header[0..]};
         _ = try file.readStreaming(testing.io, &iov);
-        try testing.expectEqual(@as(u8, 0x1f), header[0]);
-        try testing.expectEqual(@as(u8, 0x8b), header[1]);
+        try testing.expectEqualSlices(u8, &.{ 0x1f, 0x8b }, &header);
     }
 
-    // Load back
-    var loaded: BitmapFont = try .load(testing.io, testing.allocator, full_path, .all);
+    var loaded = try BitmapFont.load(testing.io, testing.allocator, path, .all);
     defer loaded.deinit(testing.allocator);
-
     try testing.expectEqualStrings(font.name, loaded.name);
     try testing.expectEqual(font.char_width, loaded.char_width);
     try testing.expectEqual(font.char_height, loaded.char_height);
+    try testing.expectEqual(font.glyphCount(), loaded.glyphCount());
+    for (font.first_char..font.last_char + 1) |codepoint| {
+        try testing.expectEqualSlices(u8, font.getCharData(@intCast(codepoint)).?, loaded.getCharData(@intCast(codepoint)).?);
+    }
+}
+
+test "PCF save and load roundtrip" {
+    try expectRoundtrip("test.pcf");
+}
+
+test "PCF save and load compressed roundtrip" {
+    try expectRoundtrip("test.pcf.gz");
 }

--- a/src/font/truetype/cff.zig
+++ b/src/font/truetype/cff.zig
@@ -22,7 +22,6 @@ pub const max_subr_depth = 10;
 pub const max_stack = 513;
 /// Operators executed per glyph, subrs included; bounds hostile subr fan-out.
 pub const max_ops = 1 << 16;
-pub const max_outline_points = 0xFFFF;
 /// CFF2 Private DICTs blend their hint values, so their operand stacks are as deep as
 /// charstring stacks.
 const max_dict_operands = max_stack;
@@ -42,7 +41,7 @@ pub const Index = struct {
 
     /// Parses the INDEX at `pos`; `end` is the position just past it. CFF2 counts are
     /// four bytes wide.
-    fn parse(r: Reader, pos: u32, comptime version: Version) Error!Parsed {
+    fn parse(r: Reader, pos: u32, version: Version) Error!Parsed {
         const count_size: u32 = if (version == .cff2) 4 else 2;
         const count: u32 = if (version == .cff2) try r.u32At(pos) else try r.u16At(pos);
         if (count == 0) return .{ .index = .empty, .end = pos + count_size };
@@ -174,10 +173,7 @@ const Private = struct {
         if (try dictGet(dict, Op.vsindex, 1)) |v| private.vsindex = try toOffset(v[0]);
         const subrs = try dictGet(dict, Op.subrs, 1) orelse return private;
         const subrs_at = std.math.add(u32, offset, try toOffset(subrs[0])) catch return error.UnexpectedEof;
-        private.subrs = switch (version) {
-            .cff => (try Index.parse(r, subrs_at, .cff)).index,
-            .cff2 => (try Index.parse(r, subrs_at, .cff2)).index,
-        };
+        private.subrs = (try Index.parse(r, subrs_at, version)).index;
         return private;
     }
 };
@@ -402,13 +398,9 @@ fn validateFdSelect(r: Reader, pos: u32, num_glyphs: u16) Error!u32 {
     return pos;
 }
 
-/// Receives the decoded path; counts only when the output slices are absent, and
-/// tracks the control box either way.
+/// Turns the decoded path into outline points, tracking the control box on the way.
 const Sink = struct {
-    points: ?[]Outline.Point = null,
-    contour_ends: ?[]u32 = null,
-    n: u32 = 0,
-    c: u32 = 0,
+    out: *Outline.Builder,
     contour_start: u32 = 0,
     start: [2]f32 = .{ 0, 0 },
     /// The latest on-curve point, held back until the next segment or `close` shows
@@ -418,8 +410,7 @@ const Sink = struct {
     max: [2]f32 = .{ -std.math.inf(f32), -std.math.inf(f32) },
 
     fn write(self: *Sink, x: f32, y: f32, kind: Outline.Point.Kind) void {
-        if (self.points) |points| points[self.n] = .{ .x = x, .y = y, .kind = kind };
-        self.n += 1;
+        self.out.emit(x, y, kind);
         self.min = .{ @min(self.min[0], x), @min(self.min[1], y) };
         self.max = .{ @max(self.max[0], x), @max(self.max[1], y) };
     }
@@ -431,7 +422,7 @@ const Sink = struct {
 
     fn moveTo(self: *Sink, x: f32, y: f32) void {
         self.close();
-        self.contour_start = self.n;
+        self.contour_start = self.out.n;
         self.start = .{ x, y };
         self.write(x, y, .on_curve);
     }
@@ -457,10 +448,9 @@ const Sink = struct {
             if (p[0] != self.start[0] or p[1] != self.start[1]) self.write(p[0], p[1], .on_curve);
             self.pending = null;
         }
-        if (self.n == self.contour_start) return;
-        if (self.contour_ends) |ends| ends[self.c] = self.n;
-        self.c += 1;
-        self.contour_start = self.n;
+        if (self.out.n == self.contour_start) return;
+        self.out.endContour();
+        self.contour_start = self.out.n;
     }
 };
 
@@ -792,36 +782,30 @@ fn interpret(font: VectorFont, gid: u16, sink: *Sink) Error!void {
 
 /// Control box of the charstring's points; null for glyphs without contours.
 pub fn bounds(font: VectorFont, gid: u16) ?VectorFont.Bounds {
-    var sink: Sink = .{};
+    var counting: Outline.Builder = .{};
+    var sink: Sink = .{ .out = &counting };
     interpret(font, gid, &sink) catch return null;
-    if (sink.n == 0) return null;
+    if (counting.n == 0) return null;
     return .{
-        .x_min = saturate(@floor(sink.min[0])),
-        .y_min = saturate(@floor(sink.min[1])),
-        .x_max = saturate(@ceil(sink.max[0])),
-        .y_max = saturate(@ceil(sink.max[1])),
+        .x_min = std.math.lossyCast(i16, @floor(sink.min[0])),
+        .y_min = std.math.lossyCast(i16, @floor(sink.min[1])),
+        .x_max = std.math.lossyCast(i16, @ceil(sink.max[0])),
+        .y_max = std.math.lossyCast(i16, @ceil(sink.max[1])),
     };
 }
 
-fn saturate(v: f32) i16 {
-    return @trunc(@min(@max(v, -32768.0), 32767.0));
-}
-
-/// Decodes `gid` into an owned `Outline`: one run to count, one to fill, so exactly
-/// two allocations.
+/// Decodes `gid` into an owned `Outline`.
 pub fn outline(font: VectorFont, gpa: Allocator, gid: u16) (Error || Allocator.Error)!Outline {
-    var sink: Sink = .{};
-    try interpret(font, gid, &sink);
-    if (sink.n > max_outline_points or sink.c > max_outline_points) return error.TooManyPoints;
+    const Glyph = struct {
+        font: VectorFont,
+        gid: u16,
 
-    const points = try gpa.alloc(Outline.Point, sink.n);
-    errdefer gpa.free(points);
-    const contour_ends = try gpa.alloc(u32, sink.c);
-    errdefer gpa.free(contour_ends);
-
-    sink = .{ .points = points, .contour_ends = contour_ends };
-    try interpret(font, gid, &sink);
-    return .{ .points = points, .contour_ends = contour_ends };
+        fn walk(self: @This(), out: *Outline.Builder) Error!void {
+            var sink: Sink = .{ .out = out };
+            try interpret(self.font, self.gid, &sink);
+        }
+    };
+    return Outline.Builder.build(gpa, Glyph{ .font = font, .gid = gid }, Glyph.walk);
 }
 
 const synthetic = @import("synthetic.zig");

--- a/src/font/truetype/cmap.zig
+++ b/src/font/truetype/cmap.zig
@@ -81,12 +81,7 @@ fn lookup4(r: Reader, st: Subtable, codepoint: u21) Error!u16 {
     const id_range_offsets = id_deltas + 2 * st.count;
 
     // First segment whose endCode >= cp.
-    var lo: u32 = 0;
-    var hi: u32 = st.count;
-    while (lo < hi) {
-        const mid = lo + (hi - lo) / 2;
-        if (try r.u16At(end_codes + 2 * mid) < cp) lo = mid + 1 else hi = mid;
-    }
+    const lo = try r.lowerBound(u16, end_codes, 2, st.count, 0, cp);
     if (lo == st.count) return 0;
     const start = try r.u16At(start_codes + 2 * lo);
     if (start > cp) return 0;
@@ -100,12 +95,8 @@ fn lookup4(r: Reader, st: Subtable, codepoint: u21) Error!u16 {
 
 fn lookup12(r: Reader, st: Subtable, codepoint: u21) Error!u16 {
     const groups = st.offset + 16;
-    var lo: u32 = 0;
-    var hi: u32 = st.count;
-    while (lo < hi) {
-        const mid = lo + (hi - lo) / 2;
-        if (try r.u32At(groups + 12 * mid + 4) < codepoint) lo = mid + 1 else hi = mid;
-    }
+    // First group whose end >= codepoint.
+    const lo = try r.lowerBound(u32, groups, 12, st.count, 4, codepoint);
     if (lo == st.count) return 0;
     const start = try r.u32At(groups + 12 * lo);
     if (start > codepoint) return 0;

--- a/src/font/truetype/glyf.zig
+++ b/src/font/truetype/glyf.zig
@@ -14,7 +14,6 @@ const Outline = @import("../Outline.zig");
 pub const max_composite_depth = 8;
 /// Component visits allowed per top-level glyph; bounds the fan-out of nested composites.
 pub const max_composite_components = 1024;
-pub const max_outline_points = 0xFFFF;
 
 pub const flag_on_curve: u8 = 0x01;
 const flag_x_short: u8 = 0x02;
@@ -64,43 +63,22 @@ fn glyphReader(font: VectorFont, range: Range) Error!Reader {
     return .init(try glyf.slice(range.offset, range.len));
 }
 
-/// Resolves `gid` (composites included) into an owned `Outline`: one walk to count,
-/// one to fill, so exactly two allocations.
+/// Resolves `gid` (composites included) into an owned `Outline`.
 pub fn outline(font: VectorFont, gpa: Allocator, gid: u16) (Error || Allocator.Error)!Outline {
-    var sink: Sink = .{};
-    var budget: u32 = max_composite_components;
-    try walk(font, gid, .identity, 0, &budget, &sink);
-    if (sink.n > max_outline_points or sink.c > max_outline_points) return error.TooManyPoints;
+    const Glyph = struct {
+        font: VectorFont,
+        gid: u16,
 
-    const points = try gpa.alloc(Outline.Point, sink.n);
-    errdefer gpa.free(points);
-    const contour_ends = try gpa.alloc(u32, sink.c);
-    errdefer gpa.free(contour_ends);
-
-    sink = .{ .points = points, .contour_ends = contour_ends };
-    budget = max_composite_components;
-    try walk(font, gid, .identity, 0, &budget, &sink);
-    return .{ .points = points, .contour_ends = contour_ends };
+        fn walkGlyph(self: @This(), sink: *Sink) Error!void {
+            var budget: u32 = max_composite_components;
+            try walk(self.font, self.gid, .identity, 0, &budget, sink);
+        }
+    };
+    return Outline.Builder.build(gpa, Glyph{ .font = font, .gid = gid }, Glyph.walkGlyph);
 }
 
-/// Receives decoded points; counts only when the output slices are absent, which lets
-/// simple glyphs be sized from their header without decoding.
-const Sink = struct {
-    points: ?[]Outline.Point = null,
-    contour_ends: ?[]u32 = null,
-    n: u32 = 0,
-    c: u32 = 0,
-
-    fn point(self: *Sink, x: f32, y: f32, on_curve: bool) void {
-        if (self.points) |points| points[self.n] = .{ .x = x, .y = y, .kind = if (on_curve) .on_curve else .quad_control };
-        self.n += 1;
-    }
-
-    fn endContour(self: *Sink) void {
-        if (self.contour_ends) |ends| ends[self.c] = self.n;
-        self.c += 1;
-    }
-};
+/// Simple glyphs are sized from their header, so a counting pass never decodes them.
+const Sink = Outline.Builder;
 
 /// Component transform: x' = a·x + c·y + dx, y' = b·x + d·y + dy.
 const Affine = struct {
@@ -219,7 +197,7 @@ fn simple(r: Reader, num_contours: u16, transform: Affine, sink: *Sink) Error!vo
         x += try coordDelta(r, &x_off, flag, flag_x_short, flag_x_same_or_positive);
         y += try coordDelta(r, &y_off, flag, flag_y_short, flag_y_same_or_positive);
         const p = transform.apply(@floatFromInt(x), @floatFromInt(y));
-        sink.point(p[0], p[1], flag & flag_on_curve != 0);
+        sink.emit(p[0], p[1], if (flag & flag_on_curve != 0) .on_curve else .quad_control);
         if (i == contour_end) {
             sink.endContour();
             contour += 1;

--- a/src/font/truetype/gpos.zig
+++ b/src/font/truetype/gpos.zig
@@ -79,16 +79,10 @@ fn pairSubtable(r: Reader, sub: usize, left: u16, right: u16) Error!?i16 {
             const pair_set = sub + try r.u16At(sub + 10 + 2 * @as(usize, coverage_index));
             const pair_count = try r.u16At(pair_set);
             const pair_size = 2 + record_size;
-            var lo: usize = 0;
-            var hi: usize = pair_count;
-            while (lo < hi) {
-                const mid = lo + (hi - lo) / 2;
-                const rec = pair_set + 2 + mid * pair_size;
-                const second = try r.u16At(rec);
-                if (second == right) return try valueAt(r, rec + 2, x_advance);
-                if (second < right) lo = mid + 1 else hi = mid;
-            }
-            return null;
+            const i = try r.lowerBound(u16, pair_set + 2, pair_size, pair_count, 0, right);
+            const rec = pair_set + 2 + i * pair_size;
+            if (i == pair_count or try r.u16At(rec) != right) return null;
+            return try valueAt(r, rec + 2, x_advance);
         },
         2 => {
             const class1 = try classOf(r, sub + try r.u16At(sub + 8), left);
@@ -112,15 +106,9 @@ fn coverageIndex(r: Reader, cov: usize, gid: u16) Error!?u16 {
     switch (try r.u16At(cov)) {
         1 => {
             const count = try r.u16At(cov + 2);
-            var lo: usize = 0;
-            var hi: usize = count;
-            while (lo < hi) {
-                const mid = lo + (hi - lo) / 2;
-                const g = try r.u16At(cov + 4 + 2 * mid);
-                if (g == gid) return @intCast(mid);
-                if (g < gid) lo = mid + 1 else hi = mid;
-            }
-            return null;
+            const i = try r.lowerBound(u16, cov + 4, 2, count, 0, gid);
+            if (i == count or try r.u16At(cov + 4 + 2 * i) != gid) return null;
+            return @intCast(i);
         },
         2 => {
             const rec = try rangeRecord(r, cov + 4, try r.u16At(cov + 2), gid) orelse return null;
@@ -132,22 +120,13 @@ fn coverageIndex(r: Reader, cov: usize, gid: u16) Error!?u16 {
 
 /// The `{start, end, value}` range record containing `gid`, or null.
 fn rangeRecord(r: Reader, base: usize, count: u16, gid: u16) Error!?struct { start: u16, value: u16 } {
-    var lo: usize = 0;
-    var hi: usize = count;
-    while (lo < hi) {
-        const mid = lo + (hi - lo) / 2;
-        const rec = base + 6 * mid;
-        const start = try r.u16At(rec);
-        const end = try r.u16At(rec + 2);
-        if (gid < start) {
-            hi = mid;
-        } else if (gid > end) {
-            lo = mid + 1;
-        } else {
-            return .{ .start = start, .value = try r.u16At(rec + 4) };
-        }
-    }
-    return null;
+    // The ranges are sorted and disjoint: the first whose end reaches gid is the candidate.
+    const i = try r.lowerBound(u16, base, 6, count, 2, gid);
+    if (i == count) return null;
+    const rec = base + 6 * i;
+    const start = try r.u16At(rec);
+    if (gid < start) return null;
+    return .{ .start = start, .value = try r.u16At(rec + 4) };
 }
 
 /// Class of `gid` in a class definition table; 0 when unlisted.

--- a/src/font/truetype/kern.zig
+++ b/src/font/truetype/kern.zig
@@ -37,17 +37,11 @@ fn lookupInner(r: Reader, left: u16, right: u16) Error!i16 {
 fn lookupFormat0(r: Reader, off: usize, left: u16, right: u16) Error!i16 {
     const num_pairs = try r.u16At(off);
     const pairs = off + 8;
+    // Each record starts with the pair as one big-endian u32, sorted.
     const key = (@as(u32, left) << 16) | right;
-    var lo: usize = 0;
-    var hi: usize = num_pairs;
-    while (lo < hi) {
-        const mid = lo + (hi - lo) / 2;
-        const rec = pairs + mid * 6;
-        const pair = (@as(u32, try r.u16At(rec)) << 16) | try r.u16At(rec + 2);
-        if (pair == key) return try r.i16At(rec + 4);
-        if (pair < key) lo = mid + 1 else hi = mid;
-    }
-    return 0;
+    const i = try r.lowerBound(u32, pairs, 6, num_pairs, 0, key);
+    if (i == num_pairs or try r.u32At(pairs + i * 6) != key) return 0;
+    return r.i16At(pairs + i * 6 + 4);
 }
 
 const synthetic = @import("synthetic.zig");

--- a/src/font/truetype/reader.zig
+++ b/src/font/truetype/reader.zig
@@ -32,20 +32,36 @@ pub const Reader = struct {
         return r.data[off..end];
     }
 
+    pub fn intAt(r: Reader, comptime T: type, off: usize) Error!T {
+        return std.mem.readInt(T, (try r.slice(off, @sizeOf(T)))[0..@sizeOf(T)], .big);
+    }
+
     pub fn u8At(r: Reader, off: usize) Error!u8 {
-        return (try r.slice(off, 1))[0];
+        return r.intAt(u8, off);
     }
 
     pub fn u16At(r: Reader, off: usize) Error!u16 {
-        return std.mem.readInt(u16, (try r.slice(off, 2))[0..2], .big);
+        return r.intAt(u16, off);
     }
 
     pub fn i16At(r: Reader, off: usize) Error!i16 {
-        return std.mem.readInt(i16, (try r.slice(off, 2))[0..2], .big);
+        return r.intAt(i16, off);
     }
 
     pub fn u32At(r: Reader, off: usize) Error!u32 {
-        return std.mem.readInt(u32, (try r.slice(off, 4))[0..4], .big);
+        return r.intAt(u32, off);
+    }
+
+    /// Index of the first of `count` records, `stride` bytes apart from `base`, whose `T`
+    /// key at `key_off` is not below `target`; `count` when none is. Keys must be sorted.
+    pub fn lowerBound(r: Reader, comptime T: type, base: usize, stride: usize, count: usize, key_off: usize, target: T) Error!usize {
+        var lo: usize = 0;
+        var hi: usize = count;
+        while (lo < hi) {
+            const mid = lo + (hi - lo) / 2;
+            if (try r.intAt(T, base + mid * stride + key_off) < target) lo = mid + 1 else hi = mid;
+        }
+        return lo;
     }
 
     /// 2.14 fixed point, used by composite glyph transforms.
@@ -64,4 +80,15 @@ test "reads are bounds checked" {
     try std.testing.expectError(error.UnexpectedEof, r.u16At(7));
     try std.testing.expectError(error.UnexpectedEof, r.u32At(std.math.maxInt(usize) - 1));
     try std.testing.expectError(error.UnexpectedEof, r.slice(4, std.math.maxInt(usize)));
+}
+
+test "lower bound over sorted records" {
+    // Three 4-byte records keyed by their second u16: 5, 9, 9.
+    const bytes = [_]u8{ 0, 1, 0, 5, 0, 2, 0, 9, 0, 3, 0, 9 };
+    const r: Reader = .init(&bytes);
+    try std.testing.expectEqual(0, try r.lowerBound(u16, 0, 4, 3, 2, 5));
+    try std.testing.expectEqual(1, try r.lowerBound(u16, 0, 4, 3, 2, 6));
+    try std.testing.expectEqual(1, try r.lowerBound(u16, 0, 4, 3, 2, 9));
+    try std.testing.expectEqual(3, try r.lowerBound(u16, 0, 4, 3, 2, 10));
+    try std.testing.expectError(error.UnexpectedEof, r.lowerBound(u16, 0, 4, 4, 2, 10));
 }


### PR DESCRIPTION
Quality pass over `src/font` (reuse / simplification / efficiency / altitude), output unchanged: the canvas MD5 fixtures are untouched and pass, all 197 font tests pass, the Python bindings build, and bitmap-text timings are within noise of `master`. Net −1017 lines across 17 files.

## BitmapFont
- `glyph_map` (codepoint → index) + `glyph_data` slice → one `glyphs: ?AutoHashMap(u32, GlyphData)`; loaders, `getGlyph`, `collectCodepoints`, `format`, `deinit` lose the indirection and its null/bounds checks.
- `getGlyphInfo` (a drifting copy of `getGlyph`'s fixed-layout fallback: no `glyph_map` guard, `bitmap_offset = 0`) and the caller-less `getCharRow` removed; the savers do one `getGlyph` instead of two lookups.
- `Glyph.bit` (bit unpacking moved out of the canvas) and `Glyph.inkBounds() ?Rectangle(u8)`; tight text bounds use `Rectangle.merge` as the vector side does.
- `BitmapFont.Layout` mirrors `VectorFont.Layout`; `layout.Pen`, `getTextBounds`, `getTextBoundsTight` and both canvas walkers now share one pen (`Canvas.BitmapGlyphs` deleted).
- `glyphCount()` replaces three copies of the count logic; `font8x8.create` is one filtered pass instead of expand → sort → dedup.

## Loaders
- **bdf** (−400): `parse(gpa, bytes, filter)` split from `load`; glyphs carry a `GlyphData` from the parser; `skipToEndChar` ×3, `familyName`; the name is handed over rather than duplicated; dead `bitmap_size` field and sparse-path `first/last_char` tracking gone; both roundtrip tests are one helper over a static `BitmapFont.test_font`.
- **pcf** (−500): five copies of the validate/open/format/byte-order prologue → `openTable`; the writer's `GlyphMetrics` was `Metric` with renamed fields — now shared with `writeMetric` and an `inline for` bounds fold; `BitmapSizes` → `[4]u32` indexed by the pad flag; `PropVal` → the existing `Property` union; ~12 parsed-but-unread values discarded instead of stored; properties and the bitmap table borrowed from the file instead of copied; metrics branches merged (the uncompressed path's `@min(count, encodings)` truncation is dropped — it could only lose referenced glyphs); roundtrip tests folded.

## truetype / VectorFont / font.zig
- `Reader.lowerBound` replaces six hand-written binary searches (cmap ×2, kern, gpos pair set, coverage, range records).
- `Outline.Builder` with a shared two-pass `build` replaces the duplicated count-then-fill sinks and `outline()` bodies in `glyf` and `cff` (and the twice-defined `max_outline_points`); `cff.saturate` → `std.math.lossyCast`; `Index.parse`'s `version` is runtime; `Outline.walk` drops a per-point modulo.
- `VectorFont.kern` returns early when the font has no kerning tables (no zero entries filling the cache); `Layout.place` looks the glyph up once for metrics and bounds.
- gzip: the hand-rolled bounded inflate loop → `appendRemaining`, presized from the gzip ISIZE trailer; `Font.loadFace` dispatches to the loaders directly (the format was detected twice); `format.zig` uses `isGzipPath`.

## Left for separate PRs
Retiring the fixed-width representation, single-line layouts with `\n` owned by `layout.zig`, a `layout.place` iterator for alignment, mask-box geometry in `GlyphCache.place`, an `fs` helper for the gzip/file utilities, CFF's triple interpretation, and `Font.getTextBounds` via `layout.measure` (trims trailing spaces, so an output change).
