### PR TITLE
perf(font): interpret CFF glyphs once, index GPOS pair lookups at load

### DIFF
--- a/src/font/GlyphCache.zig
+++ b/src/font/GlyphCache.zig
@@ -215,7 +215,10 @@ test "level 1 matches the uncached font" {
             try testing.expectEqualSlices(u32, expected.contour_ends, second.outline.contour_ends);
         }
         try testing.expectEqual(@as(usize, plain.num_glyphs), cache.glyphs.count());
-        try testing.expectEqual(Stats{ .hits = plain.num_glyphs, .misses = plain.num_glyphs }, cache.outline_stats);
+        // Every outline was parsed once; for CFF the bounds read above parsed it, so both
+        // `outlineRef` calls were hits.
+        const hits: usize = if (opts.cff) 2 * @as(usize, plain.num_glyphs) else plain.num_glyphs;
+        try testing.expectEqual(Stats{ .hits = hits, .misses = plain.num_glyphs }, cache.outline_stats);
 
         // An invalid id gets the fallback values and no entry.
         const invalid = plain.num_glyphs;

--- a/src/font/Outline.zig
+++ b/src/font/Outline.zig
@@ -34,38 +34,55 @@ pub const empty: Outline = .{ .points = &.{}, .contour_ends = &.{} };
 /// Most points or contours an outline may hold.
 pub const max_points: u32 = 0xFFFF;
 
-/// Receives the points of an outline being decoded: it counts them, and stores them when
-/// given slices, so a decoder sizes its output with one pass and fills it with another.
+/// Receives the points of an outline being decoded: it always counts them, and stores
+/// as many as its slices hold.
 pub const Builder = struct {
     points: ?[]Point = null,
     contour_ends: ?[]u32 = null,
     n: u32 = 0,
     c: u32 = 0,
 
+    /// Points `build` decodes into stack scratch before allocating; a glyph with more is
+    /// decoded a second time into its exact allocation.
+    const scratch_points = 1024;
+    const scratch_contours = 64;
+
     pub inline fn emit(self: *Builder, x: f32, y: f32, kind: Point.Kind) void {
-        if (self.points) |points| points[self.n] = .{ .x = x, .y = y, .kind = kind };
+        if (self.points) |points| if (self.n < points.len) {
+            points[self.n] = .{ .x = x, .y = y, .kind = kind };
+        };
         self.n += 1;
     }
 
     pub inline fn endContour(self: *Builder) void {
-        if (self.contour_ends) |ends| ends[self.c] = self.n;
+        if (self.contour_ends) |ends| if (self.c < ends.len) {
+            ends[self.c] = self.n;
+        };
         self.c += 1;
     }
 
-    /// Decodes an outline through `decode(ctx, *Builder)`: one pass to count, one to fill,
-    /// so exactly two allocations.
+    /// Decodes an outline through `decode(ctx, *Builder)` into exactly two allocations:
+    /// one pass into stack scratch that also counts, then a copy, or a second pass when the
+    /// glyph outgrows the scratch.
     pub fn build(gpa: Allocator, ctx: anytype, comptime decode: anytype) (Error || Allocator.Error)!Outline {
-        var counting: Builder = .{};
-        try decode(ctx, &counting);
-        if (counting.n > max_points or counting.c > max_points) return error.TooManyPoints;
+        var scratch: [scratch_points]Point = undefined;
+        var scratch_ends: [scratch_contours]u32 = undefined;
+        var b: Builder = .{ .points = &scratch, .contour_ends = &scratch_ends };
+        try decode(ctx, &b);
+        if (b.n > max_points or b.c > max_points) return error.TooManyPoints;
 
-        const points = try gpa.alloc(Point, counting.n);
+        const points = try gpa.alloc(Point, b.n);
         errdefer gpa.free(points);
-        const contour_ends = try gpa.alloc(u32, counting.c);
+        const contour_ends = try gpa.alloc(u32, b.c);
         errdefer gpa.free(contour_ends);
 
-        var filling: Builder = .{ .points = points, .contour_ends = contour_ends };
-        try decode(ctx, &filling);
+        if (b.n <= scratch.len and b.c <= scratch_ends.len) {
+            @memcpy(points, scratch[0..b.n]);
+            @memcpy(contour_ends, scratch_ends[0..b.c]);
+        } else {
+            b = .{ .points = points, .contour_ends = contour_ends };
+            try decode(ctx, &b);
+        }
         return .{ .points = points, .contour_ends = contour_ends };
     }
 };

--- a/src/font/VectorFont.zig
+++ b/src/font/VectorFont.zig
@@ -176,8 +176,34 @@ pub fn glyphBounds(self: VectorFont, gid: u16) ?Bounds {
 /// `glyphBounds` through the cache entry `g`, when there is one.
 fn boundsOf(self: VectorFont, g: ?*GlyphCache.Glyph, gid: u16) ?Bounds {
     const entry = g orelse return self.readBounds(gid);
-    if (entry.bounds == null) entry.bounds = self.readBounds(gid);
+    if (entry.bounds == null) {
+        // A CFF box is the charstring interpreted, as its outline is: parse the outline
+        // once into the cache and read the box off it.
+        if (self.tables.outlines == .cff and entry.outline == null) {
+            const cache = self.cache.?;
+            cache.outline_stats.misses += 1;
+            entry.outline = self.outline(cache.gpa, gid) catch null;
+        }
+        entry.bounds = if (entry.outline) |o| controlBox(o) else self.readBounds(gid);
+    }
     return entry.bounds.?;
+}
+
+/// Box of an outline's points, controls included, as `cff.bounds` computes it.
+fn controlBox(o: Outline) ?Bounds {
+    if (o.points.len == 0) return null;
+    var min: [2]f32 = .{ std.math.inf(f32), std.math.inf(f32) };
+    var max: [2]f32 = .{ -std.math.inf(f32), -std.math.inf(f32) };
+    for (o.points) |p| {
+        min = .{ @min(min[0], p.x), @min(min[1], p.y) };
+        max = .{ @max(max[0], p.x), @max(max[1], p.y) };
+    }
+    return .{
+        .x_min = std.math.lossyCast(i16, @floor(min[0])),
+        .y_min = std.math.lossyCast(i16, @floor(min[1])),
+        .x_max = std.math.lossyCast(i16, @ceil(max[0])),
+        .y_max = std.math.lossyCast(i16, @ceil(max[1])),
+    };
 }
 
 fn readBounds(self: VectorFont, gid: u16) ?Bounds {
@@ -230,7 +256,7 @@ pub fn kern(self: VectorFont, left: u16, right: u16) i16 {
 
 fn lookupKern(self: VectorFont, left: u16, right: u16) i16 {
     const r: truetype.Reader = .init(self.data);
-    if (self.tables.gpos) |t| return truetype.gpos.pairAdjust(r.table(t), left, right);
+    if (self.tables.gpos) |pairs| return truetype.gpos.pairAdjust(r.table(pairs.table), pairs, left, right);
     if (self.tables.kern) |t| return truetype.kern.lookup(r.table(t), left, right);
     return 0;
 }

--- a/src/font/layout.zig
+++ b/src/font/layout.zig
@@ -114,6 +114,8 @@ pub const Lines = struct {
     letter_spacing: f32,
     /// Runs one past the end once the last line is out.
     pos: usize = 0,
+    /// Where the paragraph being wrapped ends, found once rather than once per line.
+    paragraph_end: ?usize = null,
 
     pub fn init(font: Font, text: []const u8, size: f32, max_width: ?f32, letter_spacing: f32) Lines {
         return .{ .font = font, .text = text, .size = size, .max_width = max_width, .letter_spacing = letter_spacing };
@@ -121,9 +123,10 @@ pub const Lines = struct {
 
     pub fn next(self: *Lines) ?Line {
         if (self.pos > self.text.len) return null;
-        const rest = self.text[self.pos..];
-        const newline = std.mem.indexOfScalar(u8, rest, '\n');
-        const paragraph = if (newline) |n| rest[0..n] else rest;
+        if (self.paragraph_end == null or self.pos > self.paragraph_end.?) {
+            self.paragraph_end = std.mem.indexOfScalarPos(u8, self.text, self.pos, '\n') orelse self.text.len;
+        }
+        const paragraph = self.text[self.pos..self.paragraph_end.?];
         // Past the paragraph lies its newline or the end of the text.
         var consumed = paragraph.len + 1;
         var line: Line = undefined;

--- a/src/font/truetype.zig
+++ b/src/font/truetype.zig
@@ -66,7 +66,7 @@ pub const Tables = struct {
     cmap: Table,
     kern: ?Table = null,
     /// Present only when it holds pair adjustment; it then takes precedence over `kern`.
-    gpos: ?Table = null,
+    gpos: ?gpos.PairPos = null,
 };
 
 pub const sfnt_true_type: u32 = 0x00010000;
@@ -247,7 +247,7 @@ pub fn parseFace(data: []const u8, face: u32) Error!VectorFont {
             .cmap = cmap_t,
             .kern = kern_table,
             // A GPOS without pair adjustment has nothing this parser reads.
-            .gpos = if (gpos_table) |t| (if (gpos.hasPairPos(r.table(t))) t else null) else null,
+            .gpos = if (gpos_table) |t| try gpos.findPairPos(r.table(t), t) else null,
         },
         .cmap = cmap_subtable,
     };

--- a/src/font/truetype/gpos.zig
+++ b/src/font/truetype/gpos.zig
@@ -7,19 +7,31 @@ const std = @import("std");
 const truetype = @import("../truetype.zig");
 const Error = truetype.Error;
 const Reader = truetype.Reader;
+const Table = truetype.Table;
 
 const lookup_type_pair = 2;
 const lookup_type_extension = 9;
 const value_x_advance: u16 = 0x0004;
 
-/// Whether the font has any pair-positioning lookup; without one the table is useless here.
-pub fn hasPairPos(r: Reader) bool {
-    return hasPairPosInner(r) catch false;
-}
+/// The pair-positioning lookups of a GPOS table, located once at load so a kerning query
+/// visits only them.
+pub const PairPos = struct {
+    table: Table,
+    /// Positions of the pair adjustment lookups (extension ones included) in the table.
+    lookups: [max_lookups]u32,
+    count: u8,
 
-fn hasPairPosInner(r: Reader) Error!bool {
+    /// Lookups remembered per font; a table with more falls back to scanning them all.
+    pub const max_lookups = 8;
+};
+
+/// The pair-positioning lookups of the GPOS table `t` read through `r`; null without any,
+/// so a table with nothing this parser reads costs nothing later.
+pub fn findPairPos(r: Reader, t: Table) Error!?PairPos {
+    var pairs: PairPos = .{ .table = t, .lookups = undefined, .count = 0 };
     const lookup_list: usize = try r.u16At(8);
     const count = try r.u16At(lookup_list);
+    var found: usize = 0;
     for (0..count) |i| {
         const lookup = lookup_list + try r.u16At(lookup_list + 2 + 2 * i);
         var kind = try r.u16At(lookup);
@@ -27,23 +39,28 @@ fn hasPairPosInner(r: Reader) Error!bool {
             if (try r.u16At(lookup + 4) == 0) continue;
             kind = try r.u16At(lookup + try r.u16At(lookup + 6) + 2);
         }
-        if (kind == lookup_type_pair) return true;
+        if (kind != lookup_type_pair) continue;
+        if (found < PairPos.max_lookups) pairs.lookups[found] = @intCast(lookup);
+        found += 1;
     }
-    return false;
+    if (found == 0) return null;
+    // Past the limit every lookup is scanned, as `count == 0` says.
+    pairs.count = if (found <= PairPos.max_lookups) @intCast(found) else 0;
+    return pairs;
 }
 
 /// Horizontal advance adjustment for the pair, summed over lookups; within a lookup the
 /// first subtable that covers the pair wins. 0 when nothing applies or the table is malformed.
-pub fn pairAdjust(r: Reader, left: u16, right: u16) i16 {
-    return pairAdjustInner(r, left, right) catch 0;
+pub fn pairAdjust(r: Reader, pairs: PairPos, left: u16, right: u16) i16 {
+    return pairAdjustInner(r, pairs, left, right) catch 0;
 }
 
-fn pairAdjustInner(r: Reader, left: u16, right: u16) Error!i16 {
+fn pairAdjustInner(r: Reader, pairs: PairPos, left: u16, right: u16) Error!i16 {
     const lookup_list: usize = try r.u16At(8);
-    const count = try r.u16At(lookup_list);
+    const count: usize = if (pairs.count > 0) pairs.count else try r.u16At(lookup_list);
     var total: i32 = 0;
     for (0..count) |i| {
-        const lookup = lookup_list + try r.u16At(lookup_list + 2 + 2 * i);
+        const lookup = if (pairs.count > 0) pairs.lookups[i] else lookup_list + try r.u16At(lookup_list + 2 + 2 * i);
         const kind = try r.u16At(lookup);
         if (kind != lookup_type_pair and kind != lookup_type_extension) continue;
         const subtable_count = try r.u16At(lookup + 4);
@@ -166,6 +183,11 @@ test "pair adjustment: format 1, format 2 via extension, GPOS over kern" {
 test "truncated GPOS reads as no kerning" {
     var buf: [synthetic.buffer_size]u8 = undefined;
     var font = synthetic.font(&buf, .{});
-    font.tables.gpos.?.len = 12;
+    font.tables.gpos.?.table.len = 12;
     try std.testing.expectEqual(@as(i16, 0), font.kern(1, 3));
+    // Scanning every lookup finds the same pairs as the remembered ones.
+    var scanning = synthetic.font(&buf, .{});
+    scanning.tables.gpos.?.count = 0;
+    try std.testing.expectEqual(@as(i16, -80), scanning.kern(1, 3));
+    try std.testing.expectEqual(@as(i16, -30), scanning.kern(1, 2));
 }


### PR DESCRIPTION
Follow-up to #419, the efficiency items left over from the font review. Output unchanged: MD5 fixtures and all 197 font tests pass.

- **One decode per glyph.** `Outline.Builder.build` decoded every glyph twice (count, then fill). It now decodes into stack scratch (1024 points / 64 contours) that also counts, then copies into the exact allocations; only a glyph past the scratch is decoded a second time. Still exactly two allocations.
- **CFF bounds off the cached outline.** A cached CFF glyph cost three charstring interpretations: `glyphBounds` (in `Layout.place`), then count and fill for `outlineRef`. `boundsOf` now parses the outline into the cache on the first bounds read and derives the control box from its points — the same `floor`/`ceil` of the same minima/maxima `cff.bounds` computes, so bit-identical. Uncached CFF goes from 3 interpretations to 2.
- **GPOS pair lookups indexed at load.** Every uncached kerning query walked the whole lookup list to find the pair-adjustment lookups; `gpos.findPairPos` records their positions once (`Tables.gpos` is now a `PairPos`; up to 8 remembered, more falls back to scanning) and `pairAdjust` visits only those. The `hasPairPos` walk that threw its result away is gone.
- **`Lines.next`** found the paragraph's newline once per wrapped line; it is found once per paragraph.

ReleaseFast, 512² RGB, DejaVuSans.ttf / FreeSans.otf at 24 px, min of 9 interleaved runs vs `master` (performance governor):

| benchmark | old ms | new ms | Δ |
|---|---|---|---|
| CFF soft text, no cache | 1.133 | 1.022 | −9.8% |
| `getTextBounds` (kerned) | 0.648 | 0.606 | −6.5% |
| TrueType soft / fast / cached, wrapped box, bitmap text | | | ±1.6% (noise) |
