### PR TITLE
refactor(text): place lines in layout and masks in GlyphCache

### DIFF
--- a/src/canvas/Canvas.zig
+++ b/src/canvas/Canvas.zig
@@ -2197,41 +2197,20 @@ pub fn Canvas(comptime T: type) type {
             return self.image.getRectangle().as(f32);
         }
 
-        /// Shared by every text entry point: breaks `text` into lines, places the block and
-        /// each line inside `box` per `layout`, and draws the lines. The lines are kept from
-        /// the one wrapping pass, since placing the block needs their count first.
+        /// Shared by every text entry point: draws the lines of `text` where `layout` places
+        /// them in `box`.
         fn renderText(self: Self, text: []const u8, box: Rectangle(f32), paint: Paint, font: Font, font_size: ?f32, layout: TextLayout, style: GlyphStyle, mode: DrawMode) !void {
             const px = font_size orelse font.defaultSize();
             if (px <= 0) return;
-            const max_width: ?f32 = if (layout.wrap) box.width() else null;
-            var lines: text_layout.Lines = .init(font, text, px, max_width, layout.letter_spacing);
             var stack: [lines_scratch_size]u8 align(16) = undefined;
             var buffer_first: std.heap.BufferFirstAllocator = .init(&stack, self.allocator);
             const scratch = buffer_first.allocator();
-            var kept: std.ArrayList(text_layout.Lines.Line) = .empty;
-            defer kept.deinit(scratch);
-            while (lines.next()) |line| try kept.append(scratch, line);
-
-            const advance = text_layout.lineAdvance(font, px, layout);
-            const block = as(f32, kept.items.len) * advance;
-            const top: f32 = switch (layout.valign) {
-                .top => box.t,
-                .middle => box.t + (box.height() - block) / 2,
-                .bottom => box.b - block,
+            var placed: text_layout.PlacedLines = try .init(scratch, font, text, px, box, layout);
+            defer placed.deinit(scratch);
+            while (placed.next()) |line| switch (font) {
+                .bitmap => |bitmap| try self.drawTextBitmap(line.text, line.origin, paint, bitmap, bitmap.scaleFor(px), layout.letter_spacing, style, mode),
+                .vector => |vector| try self.drawTextVector(line.text, line.origin, paint, vector, px, layout.letter_spacing, style, mode),
             };
-            for (kept.items, 0..) |line, i| {
-                const y = top + as(f32, i) * advance;
-                const x: f32 = switch (layout.halign) {
-                    .left => box.l,
-                    .center => box.l + (box.width() - lines.width(line)) / 2,
-                    .right => box.r - lines.width(line),
-                };
-                const position: Point(2, f32) = .init(.{ x, y });
-                switch (font) {
-                    .bitmap => |bitmap| try self.drawTextBitmap(line.text, position, paint, bitmap, bitmap.scaleFor(px), layout.letter_spacing, style, mode),
-                    .vector => |vector| try self.drawTextVector(line.text, position, paint, vector, px, layout.letter_spacing, style, mode),
-                }
-            }
         }
 
         /// Lays out one line with `VectorFont.Layout`, then fills or strokes each glyph's
@@ -2265,29 +2244,20 @@ pub fn Canvas(comptime T: type) type {
             };
         }
 
-        /// Paints `item` from its cached coverage mask, rasterizing one on a miss with the pen
-        /// origin snapped to a quarter pixel. False when the mask is over the cache's size
-        /// limit or cannot be allocated, so the caller draws the glyph directly.
+        /// Paints `item` from its cached coverage mask, rasterizing one on a miss where
+        /// `GlyphCache.place` puts it. False when the mask is over the cache's size limit or
+        /// cannot be allocated, so the caller draws the glyph directly.
         fn drawCachedGlyph(self: Self, font: VectorFont, item: VectorFont.Layout.Item, ink: Rectangle(f32), transform: Outline.Transform, paint: Paint) !bool {
-            assert(transform.shear == 0);
             const cache = font.cache.?;
-            const placed = GlyphCache.place(item.gid, transform);
+            const placed = GlyphCache.place(item.gid, transform, ink, item.origin);
             const mask = cache.getMask(placed.key) orelse blk: {
-                // The snapped glyph's box relative to the integer pen position, with a pixel
-                // of antialiasing margin.
-                const box = ink.translate(placed.phase.x() - item.origin.x(), placed.phase.y() - item.origin.y()).grow(1);
-                const left = @floor(box.l);
-                const top = @floor(box.t);
-                const width = @ceil(box.r) - left;
-                const height = @ceil(box.b) - top;
-                if (!cache.fits(width, height)) return false;
+                if (!cache.fits(placed.width, placed.height)) return false;
                 var ref = (try self.glyphOutline(font, item.gid)) orelse return true;
                 defer ref.deinit(self.allocator);
-                const mask = cache.reserve(placed.key, @trunc(left), @trunc(top), @trunc(width), @trunc(height)) catch return false;
+                const mask = cache.reserve(placed) catch return false;
                 errdefer cache.drop(placed.key);
                 const mask_canvas: Canvas(u8) = .init(self.allocator, .initFromSlice(mask.height, mask.width, mask.data));
-                const origin: Point(2, f32) = .init(.{ placed.phase.x() - left, placed.phase.y() - top });
-                try mask_canvas.rasterizeGlyph(ref.outline, .{ .scale = transform.scale, .origin = origin });
+                try mask_canvas.rasterizeGlyph(ref.outline, placed.transform);
                 break :blk mask;
             };
             self.blitMask(.initFromSlice(mask.height, mask.width, mask.data), placed.x + mask.left, placed.y + mask.top, paint);

--- a/src/font/GlyphCache.zig
+++ b/src/font/GlyphCache.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const Point2 = @import("../geometry/Point.zig").Point(2, f32);
+const Rectangle = @import("../geometry.zig").Rectangle;
 const as = @import("../meta.zig").as;
 const VectorFont = @import("VectorFont.zig");
 const Outline = @import("Outline.zig");
@@ -48,25 +49,45 @@ pub const MaskKey = packed struct(u64) {
 };
 
 /// Where a glyph's mask goes: its key, the integer pen position the mask is offset from,
-/// and the snapped fraction the mask is rendered at.
+/// the snapped fraction the mask is rendered at, and the mask's box.
 pub const Placement = struct {
     key: MaskKey,
     x: i32,
     y: i32,
     /// In [0, 1) per axis.
     phase: Point2,
+    /// The mask's box relative to (`x`, `y`): the snapped glyph's ink with a pixel of
+    /// antialiasing margin, on whole pixels.
+    left: i32,
+    top: i32,
+    width: u32,
+    height: u32,
+    /// Places the outline inside the mask.
+    transform: Outline.Transform,
 };
 
-pub fn place(gid: u16, transform: Outline.Transform) Placement {
+/// The placement of glyph `gid` drawn with `transform`, whose ink covers `ink` when its
+/// pen is at `pen` (both relative to the same origin). Shear is not part of a mask's key.
+pub fn place(gid: u16, transform: Outline.Transform, ink: Rectangle(f32), pen: Point2) Placement {
+    std.debug.assert(transform.shear == 0);
     const ox = @floor(transform.origin.x());
     const oy = @floor(transform.origin.y());
     const bx = phase(transform.origin.x() - ox);
     const by = phase(transform.origin.y() - oy);
+    const snapped: Point2 = .init(.{ as(f32, bx) / phases, as(f32, by) / phases });
+    const box = ink.translate(snapped.x() - pen.x(), snapped.y() - pen.y()).grow(1);
+    const left = @floor(box.l);
+    const top = @floor(box.t);
     return .{
         .key = .{ .scale_bits = @bitCast(transform.scale), .gid = gid, .bx = bx, .by = by },
         .x = @trunc(ox),
         .y = @trunc(oy),
-        .phase = .init(.{ as(f32, bx) / phases, as(f32, by) / phases }),
+        .phase = snapped,
+        .left = @trunc(left),
+        .top = @trunc(top),
+        .width = @trunc(@ceil(box.r) - left),
+        .height = @trunc(@ceil(box.b) - top),
+        .transform = .{ .scale = transform.scale, .origin = .init(.{ snapped.x() - left, snapped.y() - top }) },
     };
 }
 
@@ -125,20 +146,20 @@ pub fn getMask(self: *GlyphCache, key: MaskKey) ?Mask {
 
 /// Whether a `width` x `height` mask may be stored: no more than a sixteenth of the budget,
 /// so one headline glyph cannot keep flushing the rest.
-pub fn fits(self: GlyphCache, width: f32, height: f32) bool {
-    return width * height <= as(f32, self.max_mask_bytes / 16);
+pub fn fits(self: GlyphCache, width: u32, height: u32) bool {
+    return @as(usize, width) * height <= self.max_mask_bytes / 16;
 }
 
-/// Stores a zeroed mask for `key` (which must be new and `fits`) and returns it to be
-/// rasterized into; every other mask is dropped first when the budget would overflow.
-pub fn reserve(self: *GlyphCache, key: MaskKey, left: i32, top: i32, width: u32, height: u32) Allocator.Error!Mask {
-    const bytes = @as(usize, width) * height;
+/// Stores a zeroed mask for `placed` (whose key must be new and box `fits`) and returns it
+/// to be rasterized into; every other mask is dropped first when the budget would overflow.
+pub fn reserve(self: *GlyphCache, placed: Placement) Allocator.Error!Mask {
+    const bytes = @as(usize, placed.width) * placed.height;
     if (self.mask_bytes + bytes > self.max_mask_bytes) self.clearMasks();
     const data = try self.gpa.alloc(u8, bytes);
     errdefer self.gpa.free(data);
     @memset(data, 0);
-    const mask: Mask = .{ .left = left, .top = top, .width = width, .height = height, .data = data };
-    try self.masks.putNoClobber(self.gpa, key, mask);
+    const mask: Mask = .{ .left = placed.left, .top = placed.top, .width = placed.width, .height = placed.height, .data = data };
+    try self.masks.putNoClobber(self.gpa, placed.key, mask);
     self.mask_bytes += bytes;
     return mask;
 }
@@ -231,12 +252,20 @@ test "level 1 matches the uncached font" {
 }
 
 test "placement snaps the origin to a quarter pixel" {
-    const placed = place(7, .{ .scale = 0.5, .origin = .init(.{ 10.3, -0.9 }) });
+    // A glyph inked over [1, 3) x [-2, 0) around its pen at the text origin.
+    const placed = place(7, .{ .scale = 0.5, .origin = .init(.{ 10.3, -0.9 }) }, .{ .l = 1, .t = -2, .r = 3, .b = 0 }, .origin);
     try testing.expectEqual(MaskKey{ .scale_bits = @bitCast(@as(f32, 0.5)), .gid = 7, .bx = 1, .by = 0 }, placed.key);
     try testing.expectEqual(@as(i32, 10), placed.x);
     try testing.expectEqual(@as(i32, -1), placed.y);
     try testing.expectEqual(@as(f32, 0.25), placed.phase.x());
     try testing.expectEqual(@as(f32, 0), placed.phase.y());
+    // The ink at the snapped phase, a pixel of margin around it, on whole pixels.
+    try testing.expectEqual(@as(i32, 0), placed.left);
+    try testing.expectEqual(@as(i32, -3), placed.top);
+    try testing.expectEqual(@as(u32, 5), placed.width);
+    try testing.expectEqual(@as(u32, 4), placed.height);
+    try testing.expectEqual(Point2.init(.{ 0.25, 3 }), placed.transform.origin);
+    try testing.expectEqual(@as(f32, 0.5), placed.transform.scale);
     // The fraction never rounds up into the next pixel.
     try testing.expectEqual(@as(u2, 3), phase(0.9999999));
 }
@@ -251,7 +280,11 @@ test "mask store honors the budget" {
     const key: MaskKey = .{ .scale_bits = 0, .gid = 1, .bx = 0, .by = 0 };
     try testing.expect(cache.getMask(key) == null);
     for (0..3) |i| {
-        const mask = try cache.reserve(.{ .scale_bits = 0, .gid = @intCast(i), .bx = 0, .by = 0 }, 0, 0, 6, 10);
+        var placed = place(@intCast(i), .{ .scale = 0, .origin = .origin }, .{ .l = 0, .t = 0, .r = 4, .b = 8 }, .origin);
+        placed.key.scale_bits = 0;
+        try testing.expectEqual(@as(u32, 6), placed.width);
+        try testing.expectEqual(@as(u32, 10), placed.height);
+        const mask = try cache.reserve(placed);
         try testing.expect(std.mem.allEqual(u8, mask.data, 0));
     }
     // The third insert would have exceeded 160 bytes: the first two were dropped.

--- a/src/font/layout.zig
+++ b/src/font/layout.zig
@@ -3,11 +3,13 @@
 //! `Font.getTextBounds`, so vector kerning is honored when deciding breaks.
 
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 
 const Font = @import("../font.zig").Font;
 const BitmapFont = @import("BitmapFont.zig");
 const VectorFont = @import("VectorFont.zig");
 const Rectangle = @import("../geometry.zig").Rectangle;
+const Point2 = @import("../geometry/Point.zig").Point(2, f32);
 
 pub const TextAlign = enum { left, center, right };
 pub const VerticalAlign = enum { top, middle, bottom };
@@ -205,6 +207,66 @@ pub fn measure(font: Font, text: []const u8, size: f32, max_width: ?f32, layout:
     return .{ .l = 0, .t = 0, .r = width, .b = @as(f32, @floatFromInt(count)) * lineAdvance(font, size, layout) };
 }
 
+/// The lines of `text` placed inside `box` as `layout` says: the block aligned vertically,
+/// each line horizontally, wrapped to the box when asked. Placing the block needs the
+/// line count first, so the lines from the one wrapping pass are kept in `scratch`.
+pub const PlacedLines = struct {
+    pub const Line = struct {
+        text: []const u8,
+        /// Top-left corner of the line.
+        origin: Point2,
+    };
+
+    lines: Lines,
+    kept: []Lines.Line,
+    box: Rectangle(f32),
+    halign: TextAlign,
+    top: f32,
+    advance: f32,
+    index: usize = 0,
+
+    pub fn init(scratch: Allocator, font: Font, text: []const u8, size: f32, box: Rectangle(f32), layout: TextLayout) Allocator.Error!PlacedLines {
+        const max_width: ?f32 = if (layout.wrap) box.width() else null;
+        var lines: Lines = .init(font, text, size, max_width, layout.letter_spacing);
+        var kept: std.ArrayList(Lines.Line) = .empty;
+        errdefer kept.deinit(scratch);
+        while (lines.next()) |line| try kept.append(scratch, line);
+
+        const advance = lineAdvance(font, size, layout);
+        const block = @as(f32, @floatFromInt(kept.items.len)) * advance;
+        return .{
+            .lines = lines,
+            .kept = try kept.toOwnedSlice(scratch),
+            .box = box,
+            .halign = layout.halign,
+            .top = switch (layout.valign) {
+                .top => box.t,
+                .middle => box.t + (box.height() - block) / 2,
+                .bottom => box.b - block,
+            },
+            .advance = advance,
+        };
+    }
+
+    pub fn deinit(self: *PlacedLines, scratch: Allocator) void {
+        scratch.free(self.kept);
+        self.* = undefined;
+    }
+
+    pub fn next(self: *PlacedLines) ?Line {
+        if (self.index == self.kept.len) return null;
+        const line = self.kept[self.index];
+        const y = self.top + @as(f32, @floatFromInt(self.index)) * self.advance;
+        const x: f32 = switch (self.halign) {
+            .left => self.box.l,
+            .center => self.box.l + (self.box.width() - self.lines.width(line)) / 2,
+            .right => self.box.r - self.lines.width(line),
+        };
+        self.index += 1;
+        return .{ .text = line.text, .origin = .init(.{ x, y }) };
+    }
+};
+
 const testing = std.testing;
 const font8x8 = @import("font8x8.zig");
 const synthetic = @import("truetype/synthetic.zig");
@@ -267,6 +329,25 @@ test "spacing and measure" {
     try testing.expectEqual(Rectangle(f32){ .l = 0, .t = 0, .r = 28, .b = 36 }, box);
     try testing.expectEqual(Rectangle(f32){ .l = 0, .t = 0, .r = 0, .b = 8 }, measure(font, "", 8, null, .default));
     try testing.expectEqual(font.getTextBounds("ab\ncd", 8), measure(font, "ab\ncd", 8, null, .default));
+}
+
+test "placed lines align the block and each line" {
+    const font: Font = .{ .bitmap = font8x8.basic };
+    const box: Rectangle(f32) = .{ .l = 10, .t = 20, .r = 74, .b = 60 };
+    var placed: PlacedLines = try .init(testing.allocator, font, "aaa bbb ccc", 8, box, .{ .wrap = true, .halign = .center, .valign = .middle });
+    defer placed.deinit(testing.allocator);
+    // Two lines of 8 px in a 40 px box start 12 px down; "aaa bbb" is 56 px wide, "ccc" 24.
+    const first = placed.next().?;
+    try testing.expectEqualStrings("aaa bbb", first.text);
+    try testing.expectEqual(Point2.init(.{ 14, 32 }), first.origin);
+    const second = placed.next().?;
+    try testing.expectEqualStrings("ccc", second.text);
+    try testing.expectEqual(Point2.init(.{ 30, 40 }), second.origin);
+    try testing.expectEqual(null, placed.next());
+
+    var bottom_right: PlacedLines = try .init(testing.allocator, font, "ab", 8, box, .{ .halign = .right, .valign = .bottom });
+    defer bottom_right.deinit(testing.allocator);
+    try testing.expectEqual(Point2.init(.{ 58, 52 }), bottom_right.next().?.origin);
 }
 
 test "pen walks bitmap and vector lines alike" {


### PR DESCRIPTION
Two altitude items from the font review (#419), output unchanged.

- **Line placement belongs to `layout.zig`.** `Canvas.renderText` computed the block's `valign` offset and each line's `halign` offset — the quantities `layout.measure` already walks — and kept a list of lines only because placement needs the count first. `layout.PlacedLines` now owns that: `init(scratch, font, text, size, box, layout)` runs the one wrapping pass and places the block, `next()` yields each line with its top-left origin. The canvas loop is a `switch` that draws. Unit-tested against hand-computed origins.
- **Mask geometry belongs to `GlyphCache.place`.** `drawCachedGlyph` derived the mask box (ink translated by phase − pen, grown by a pixel, floored/ceiled) and rebuilt the mask-local `Transform` — all knowledge of how `Mask.left/top` relate to the quarter-pixel phase that `GlyphCache` documents. `place(gid, transform, ink, pen)` now returns the box and the transform alongside the key; `reserve` takes the placement; the `shear == 0` assertion moved with it. The canvas rasterizes into `placed.transform` and blits.

The arithmetic moved verbatim (same operations in the same order). Verification: MD5 fixtures pass (the wrapped/aligned text box case covers placement; `drawing.zig` covers the cache); additionally cached text over DejaVuSans and FreeSans at 14 fractional positions/sizes hashes identically before and after (`b9c520…`).
