### PR TITLE
refactor: create files through the cwd whatever the path

### DIFF
--- a/src/codecs/bmp.zig
+++ b/src/codecs/bmp.zig
@@ -1044,10 +1044,7 @@ pub fn save(comptime T: type, io: Io, allocator: Allocator, image: Image(T), fil
     const data = try encode(T, allocator, image, .default);
     defer allocator.free(data);
 
-    const file = if (Io.Dir.path.isAbsolute(file_path))
-        try Io.Dir.createFileAbsolute(io, file_path, .{})
-    else
-        try Io.Dir.cwd().createFile(io, file_path, .{});
+    const file = try Io.Dir.cwd().createFile(io, file_path, .{});
     defer file.close(io);
 
     try file.writeStreamingAll(io, data);

--- a/src/codecs/gif.zig
+++ b/src/codecs/gif.zig
@@ -927,10 +927,7 @@ pub fn save(comptime T: type, io: Io, allocator: Allocator, image: Image(T), fil
 }
 
 fn writeFile(io: Io, file_path: []const u8, data: []const u8) !void {
-    const file = if (Io.Dir.path.isAbsolute(file_path))
-        try Io.Dir.createFileAbsolute(io, file_path, .{})
-    else
-        try Io.Dir.cwd().createFile(io, file_path, .{});
+    const file = try Io.Dir.cwd().createFile(io, file_path, .{});
     defer file.close(io);
     try file.writeStreamingAll(io, data);
 }

--- a/src/codecs/jpeg.zig
+++ b/src/codecs/jpeg.zig
@@ -294,10 +294,7 @@ pub fn save(comptime T: type, io: Io, allocator: Allocator, image: Image(T), fil
     const bytes = try encode(T, allocator, image, .{ .subsampling = .yuv420 });
     defer allocator.free(bytes);
 
-    const file = if (Io.Dir.path.isAbsolute(file_path))
-        try Io.Dir.createFileAbsolute(io, file_path, .{})
-    else
-        try Io.Dir.cwd().createFile(io, file_path, .{});
+    const file = try Io.Dir.cwd().createFile(io, file_path, .{});
     defer file.close(io);
     try file.writeStreamingAll(io, bytes);
 }

--- a/src/codecs/png.zig
+++ b/src/codecs/png.zig
@@ -1428,10 +1428,7 @@ pub fn save(comptime T: type, io: Io, allocator: Allocator, image: Image(T), fil
     const png_data = try encode(T, allocator, image, .default);
     defer allocator.free(png_data);
 
-    const file = if (Io.Dir.path.isAbsolute(file_path))
-        try Io.Dir.createFileAbsolute(io, file_path, .{})
-    else
-        try Io.Dir.cwd().createFile(io, file_path, .{});
+    const file = try Io.Dir.cwd().createFile(io, file_path, .{});
     defer file.close(io);
 
     try file.writeStreamingAll(io, png_data);

--- a/src/font.zig
+++ b/src/font.zig
@@ -187,10 +187,7 @@ pub fn readFileMaybeGzip(io: Io, gpa: Allocator, path: []const u8) ![]u8 {
 
 /// Writes `bytes` to `path`, gzip-compressing when the path ends in `.gz`.
 pub fn writeFileMaybeGzip(io: Io, gpa: Allocator, path: []const u8, bytes: []const u8) !void {
-    const file = if (Io.Dir.path.isAbsolute(path))
-        try Io.Dir.createFileAbsolute(io, path, .{})
-    else
-        try Io.Dir.cwd().createFile(io, path, .{});
+    const file = try Io.Dir.cwd().createFile(io, path, .{});
     defer file.close(io);
 
     if (!isGzipPath(path)) {


### PR DESCRIPTION
The last reuse item from the font review (#419). Five writers (gif, jpeg, bmp, png encoders and `font.writeFileMaybeGzip`) carried the same four-line `if (isAbsolute) createFileAbsolute else cwd().createFile` branch; the readers never did, and `Io.Dir.createFile` accepts absolute paths like `openFile` does, so each site is one line. −15 lines. The save/load roundtrip tests (fonts and codecs) write to absolute temporary paths and pass.