### PR TITLE
refactor(font): one way to measure text

### DIFF
--- a/bindings/python/src/font.zig
+++ b/bindings/python/src/font.zig
@@ -230,7 +230,8 @@ fn font_has_glyph(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObject
 const font_get_text_bounds_doc =
     \\Box occupied by `text` drawn at `size`, relative to its top-left corner.
     \\
-    \\Width is the widest line's advance, height is the number of lines times the line height.
+    \\The same box as `measure_text` with its defaults: the widest line, without its trailing
+    \\spaces, by the number of lines times the line height.
     \\
     \\## Parameters
     \\- `text` (str): Text to measure; `\n` starts a new line

--- a/examples/src/make_logo.zig
+++ b/examples/src/make_logo.zig
@@ -110,11 +110,11 @@ fn drawSignalWaves(canvas: *Canvas(Rgb), allocator: std.mem.Allocator) !void {
 
 fn drawZignalText(canvas: *Canvas(Rgb)) !void {
     // Use the default 8x8 font
-    const font = zignal.font.font8x8.basic;
+    const font: zignal.Font = .{ .bitmap = zignal.font.font8x8.basic };
 
     // Scale factor for the text
     const scale: f32 = 10;
-    const size = scale * (zignal.Font{ .bitmap = font }).defaultSize();
+    const size = scale * font.defaultSize();
 
     // Calculate text dimensions
     const text = "ZIGNAL";
@@ -131,7 +131,7 @@ fn drawZignalText(canvas: *Canvas(Rgb)) !void {
     // First pass: calculate total width using tight bounds
     var total_width: f32 = 0;
     for (text, 0..) |char, i| {
-        const tight_bounds = font.getTextBoundsTight(&[_]u8{char}, scale);
+        const tight_bounds = font.getTextBoundsTight(&[_]u8{char}, size);
         const visual_width = tight_bounds.r - tight_bounds.l;
         const padding: f32 = if (char == 'I') 25 else 15;
         total_width += visual_width + if (i < text.len - 1) padding else 0;
@@ -144,13 +144,13 @@ fn drawZignalText(canvas: *Canvas(Rgb)) !void {
         const char_str = [_]u8{char};
 
         // Shadow layer for depth
-        try canvas.drawText(&char_str, .init(.{ current_x + 2, y_pos + 2 }), shadow_color, .{ .bitmap = font }, size, .fast);
+        try canvas.drawText(&char_str, .init(.{ current_x + 2, y_pos + 2 }), shadow_color, font, size, .fast);
 
         // Main character
-        try canvas.drawText(&char_str, .init(.{ current_x, y_pos }), text_color, .{ .bitmap = font }, size, .fast);
+        try canvas.drawText(&char_str, .init(.{ current_x, y_pos }), text_color, font, size, .fast);
 
         // Calculate next position using tight bounds
-        const tight_bounds = font.getTextBoundsTight(&char_str, scale);
+        const tight_bounds = font.getTextBoundsTight(&char_str, size);
         const visual_width = tight_bounds.r - tight_bounds.l;
         const padding: f32 = if (char == 'I') 25 else 15;
         current_x += visual_width + padding;

--- a/src/canvas/Canvas.zig
+++ b/src/canvas/Canvas.zig
@@ -2405,13 +2405,13 @@ pub fn Canvas(comptime T: type) type {
             for (0..n) |i| out[i] = @max(suffix[i], prefix[i + window - 1]);
         }
 
-        /// The box of one line of bitmap text relative to its pen origin: the font's bounds
-        /// plus the letter spacing after each glyph.
+        /// The box of one line of bitmap text relative to its pen origin: the pen after the
+        /// last glyph, with negative letter spacing ignored so every glyph stays inside.
         fn bitmapLineExtent(text: []const u8, font: BitmapFont, scale: f32, letter_spacing: f32) Rectangle(f32) {
-            const glyphs = std.unicode.utf8CountCodepoints(text) catch text.len;
-            var extent = font.getTextBounds(text, scale);
-            extent.r += @max(letter_spacing, 0) * as(f32, glyphs);
-            return extent;
+            var glyphs: BitmapFont.Layout = .init(font, text, scale);
+            glyphs.letter_spacing = @max(letter_spacing, 0);
+            while (glyphs.next()) |_| {}
+            return .{ .l = 0, .t = 0, .r = glyphs.x, .b = as(f32, font.char_height) * scale };
         }
 
         /// Blits one line of bitmap glyphs at `position`.

--- a/src/font.zig
+++ b/src/font.zig
@@ -112,20 +112,15 @@ pub const Font = union(enum) {
         };
     }
 
-    /// Box occupied by `text` relative to its top-left corner.
+    /// Box occupied by `text` relative to its top-left corner: `measureText` under the
+    /// default layout, so trailing spaces are left out of the width.
     pub fn getTextBounds(self: Font, text: []const u8, size: f32) Rectangle(f32) {
-        return switch (self) {
-            .bitmap => |b| b.getTextBounds(text, b.scaleFor(size)),
-            .vector => |v| v.getTextBounds(text, size),
-        };
+        return layout.measure(self, text, size, null, .default);
     }
 
     /// Box of the inked pixels of `text` relative to its top-left corner.
     pub fn getTextBoundsTight(self: Font, text: []const u8, size: f32) Rectangle(f32) {
-        return switch (self) {
-            .bitmap => |b| b.getTextBoundsTight(text, b.scaleFor(size)),
-            .vector => |v| v.getTextBoundsTight(text, size),
-        };
+        return layout.measureTight(self, text, size);
     }
 
     /// Box `Canvas.drawTextBox` fills with `text` under `layout`, relative to its top-left
@@ -261,7 +256,7 @@ test "Font.load dispatches on the format" {
     try std.testing.expectEqual(@as(f32, 16), font.defaultSize());
     const bitmap: Font = .{ .bitmap = font8x8.basic };
     try std.testing.expectEqual(@as(f32, 8), bitmap.defaultSize());
-    try std.testing.expectEqual(@as(f32, 24), font8x8.basic.getTextBounds("abc", 1).r);
+    try std.testing.expectEqual(@as(f32, 24), bitmap.getTextBounds("abc", 8).r);
     try std.testing.expectEqual(@as(f32, 48), bitmap.getTextBounds("abc", 16).r);
     try std.testing.expectEqual(@as(f32, 16), bitmap.lineHeight(16));
     try std.testing.expect(bitmap.hasGlyph('a'));

--- a/src/font/BitmapFont.zig
+++ b/src/font/BitmapFont.zig
@@ -188,55 +188,18 @@ pub const Layout = struct {
         self.x += self.letter_spacing;
         return glyph;
     }
-};
 
-/// Calculate the bounding rectangle for rendering text
-/// Returns bounds where l,t are inclusive and r,b are exclusive
-/// For example, an 8x8 character has pixels at positions 0-7, so bounds are (0,0) to (8,8)
-pub fn getTextBounds(self: BitmapFont, text: []const u8, scale: f32) Rectangle(f32) {
-    var width: f32 = 0;
-    var x: f32 = 0;
-    var lines: f32 = 1;
-    var iter: std.unicode.Utf8Iterator = .{ .bytes = text, .i = 0 };
-    while (iter.nextCodepoint()) |codepoint| {
-        if (codepoint != '\n') {
-            x += @as(f32, self.getCharAdvanceWidth(codepoint)) * scale;
-            continue;
-        }
-        width = @max(width, x);
-        x = 0;
-        lines += 1;
-    }
-    width = @max(width, x);
-    return .{ .l = 0, .t = 0, .r = width, .b = lines * (@as(f32, self.char_height) * scale) };
-}
-
-/// Calculate the tight bounding rectangle for rendering text
-/// Returns bounds that exactly encompass the visible pixels
-/// Unlike getTextBounds, this excludes character padding
-pub fn getTextBoundsTight(self: BitmapFont, text: []const u8, scale: f32) Rectangle(f32) {
-    var layout: Layout = .init(self, text, scale);
-    var y: f32 = 0;
-    var bounds: ?Rectangle(f32) = null;
-    while (layout.iter.nextCodepoint()) |codepoint| {
-        if (codepoint == '\n') {
-            layout.x = 0;
-            y += @as(f32, self.char_height) * scale;
-            continue;
-        }
-        const x = layout.x;
-        const glyph = layout.place(codepoint) orelse continue;
-        const ink = glyph.inkBounds() orelse continue;
-        const box: Rectangle(f32) = .{
-            .l = x + @as(f32, ink.l) * scale,
-            .t = y + @as(f32, ink.t) * scale,
-            .r = x + @as(f32, ink.r) * scale,
-            .b = y + @as(f32, ink.b) * scale,
+    /// Device-pixel box of the glyph's ink, relative to the line's top-left corner.
+    pub fn inkBounds(self: Layout, item: Item) ?Rectangle(f32) {
+        const ink = item.glyph.inkBounds() orelse return null;
+        return .{
+            .l = item.x + @as(f32, ink.l) * self.scale,
+            .t = @as(f32, ink.t) * self.scale,
+            .r = item.x + @as(f32, ink.r) * self.scale,
+            .b = @as(f32, ink.b) * self.scale,
         };
-        bounds = if (bounds) |acc| acc.merge(box) else box;
     }
-    return bounds orelse .{ .l = 0, .t = 0, .r = 0, .b = 0 };
-}
+};
 
 /// Saves the font to a file.
 /// Supports BDF (`.bdf`, `.bdf.gz`) and PCF (`.pcf`, `.pcf.gz`) formats.
@@ -295,80 +258,3 @@ pub const test_font: BitmapFont = .{
     },
     .font_ascent = 7,
 };
-
-test "getTextBounds with Unicode" {
-    const testing = std.testing;
-    const font = BitmapFont{
-        .name = "Test",
-        .char_width = 8,
-        .char_height = 8,
-        .first_char = 0,
-        .last_char = 255,
-        .data = &@as([256 * 8]u8, @splat(0)),
-    };
-
-    // "A" is 1 byte, "©" is 2 bytes in UTF-8
-    const text = "A©";
-    const bounds = font.getTextBounds(text, 1.0);
-
-    // Both should be treated as 8px wide characters
-    try testing.expectEqual(@as(f32, 16.0), bounds.r);
-    try testing.expectEqual(@as(f32, 8.0), bounds.b);
-}
-
-test "getTextBoundsTight with Wide Font" {
-    const testing = std.testing;
-    // 16x8 font, 2 bytes per row
-    var data: [2 * 8]u8 = @splat(0);
-    // Set a pixel at (10, 2) - this is in the second byte of the 3rd row
-    data[2 * 2 + 1] = 1 << 2; // (10-8) = bit 2 of the second byte
-
-    const font = BitmapFont{
-        .name = "WideTest",
-        .char_width = 16,
-        .char_height = 8,
-        .first_char = 'A',
-        .last_char = 'A',
-        .data = &data,
-    };
-
-    const bounds = font.getTextBoundsTight("A", 1.0);
-    // Pixel is at (10, 2), so bounds should be (10, 2) to (11, 3)
-    try testing.expectEqual(@as(f32, 10.0), bounds.l);
-    try testing.expectEqual(@as(f32, 2.0), bounds.t);
-    try testing.expectEqual(@as(f32, 11.0), bounds.r);
-    try testing.expectEqual(@as(f32, 3.0), bounds.b);
-}
-
-test "getTextBoundsTight with Unicode" {
-    const testing = std.testing;
-    // Create a font where '©' (codepoint 0xA9) has a specific pattern
-    var data: [256 * 8]u8 = @splat(0);
-    // '©' at index 0xA9
-    const offset = 0xA9 * 8;
-    data[offset + 2] = 0x18; // 00011000 in row 2
-
-    const font = BitmapFont{
-        .name = "Test",
-        .char_width = 8,
-        .char_height = 8,
-        .first_char = 0,
-        .last_char = 255,
-        .data = &data,
-    };
-
-    // "©" is 2 bytes in UTF-8.
-    // Advance for 'A' (8px) + tight bounds of '©' (bits 3,4 at row 2)
-    // x position: 8 (from 'A') + 3 (min_x of '©') = 11
-    const text = "A©";
-    const bounds = font.getTextBoundsTight(text, 1.0);
-
-    // 'A' has no pixels in this test font. '©' has pixels at x=3,4 in its local space.
-    // 'A' is at x=0, '©' is at x=8.
-    // '©' pixels are at x=11 and x=12.
-    // Tight bounds: l=11, r=13, t=2, b=3.
-    try testing.expectEqual(@as(f32, 11.0), bounds.l);
-    try testing.expectEqual(@as(f32, 13.0), bounds.r);
-    try testing.expectEqual(@as(f32, 2.0), bounds.t);
-    try testing.expectEqual(@as(f32, 3.0), bounds.b);
-}

--- a/src/font/VectorFont.zig
+++ b/src/font/VectorFont.zig
@@ -271,8 +271,8 @@ pub fn lineHeight(self: VectorFont, size: f32) f32 {
     return as(f32, @as(i32, self.ascent) - self.descent + self.line_gap) * self.scaleFor(size);
 }
 
-/// Lays out `text` from a top-left origin with `\n` line breaks, yielding each glyph
-/// placed in device pixels.
+/// Lays out one line of `text` from its top-left origin, yielding each glyph placed in
+/// device pixels; `font.layout` breaks lines.
 pub const Layout = struct {
     pub const Item = struct {
         gid: u16,
@@ -285,7 +285,6 @@ pub const Layout = struct {
 
     font: VectorFont,
     scale: f32,
-    line_height: f32,
     iter: std.unicode.Utf8Iterator,
     x: f32 = 0,
     baseline: f32,
@@ -301,7 +300,6 @@ pub const Layout = struct {
         return .{
             .font = font,
             .scale = scale,
-            .line_height = font.lineHeight(size),
             .iter = .{ .bytes = text, .i = 0 },
             .baseline = as(f32, font.ascent) * scale,
         };
@@ -314,15 +312,8 @@ pub const Layout = struct {
         return null;
     }
 
-    /// Places `codepoint` at the pen and advances past it; `\n` starts the next line and
-    /// places nothing.
+    /// Places `codepoint` at the pen and advances past it.
     pub fn place(self: *Layout, codepoint: u21) ?Item {
-        if (codepoint == '\n') {
-            self.x = 0;
-            self.baseline += self.line_height;
-            self.prev = null;
-            return null;
-        }
         const gid = self.font.glyphIndex(codepoint);
         if (self.prev) |p| self.x += as(f32, self.font.kern(p, gid)) * self.scale;
         // One cache lookup serves both reads; `glyphIndex` keeps gid valid.
@@ -358,29 +349,6 @@ pub const Layout = struct {
     }
 };
 
-/// Box occupied by `text` at `size` pixels per em, relative to its top-left corner:
-/// the widest line's advance by the number of lines times the line height.
-pub fn getTextBounds(self: VectorFont, text: []const u8, size: f32) Rectangle(f32) {
-    var layout: Layout = .init(self, text, size);
-    layout.with_bounds = false;
-    var width: f32 = 0;
-    while (layout.next()) |_| width = @max(width, layout.x);
-    const lines = 1 + std.mem.count(u8, text, "\n");
-    return .{ .l = 0, .t = 0, .r = width, .b = as(f32, lines) * layout.line_height };
-}
-
-/// Union of the glyph boxes of `text`, relative to its top-left corner; empty when no
-/// glyph has ink.
-pub fn getTextBoundsTight(self: VectorFont, text: []const u8, size: f32) Rectangle(f32) {
-    var layout: Layout = .init(self, text, size);
-    var bounds: ?Rectangle(f32) = null;
-    while (layout.next()) |item| {
-        const box = layout.inkBounds(item) orelse continue;
-        bounds = if (bounds) |acc| acc.merge(box) else box;
-    }
-    return bounds orelse .{ .l = 0, .t = 0, .r = 0, .b = 0 };
-}
-
 pub fn format(self: VectorFont, writer: *Io.Writer) Io.Writer.Error!void {
     try writer.print("VectorFont{{ .units_per_em = {d}, .glyphs = {d}, .ascent = {d}, .descent = {d}", .{
         self.units_per_em,
@@ -394,6 +362,10 @@ pub fn format(self: VectorFont, writer: *Io.Writer) Io.Writer.Error!void {
 
 const testing = std.testing;
 const synthetic = @import("truetype/synthetic.zig");
+
+fn lineWidth(font: VectorFont, text: []const u8, size: f32) f32 {
+    return font_mod.layout.lineWidth(.{ .vector = font }, text, size, 0);
+}
 
 test "header metrics" {
     var buf: [synthetic.buffer_size]u8 = undefined;
@@ -433,22 +405,6 @@ test "glyph metrics incl. the hmtx tail" {
     try testing.expectEqual(GlyphMetrics{ .advance = 800, .lsb = 0 }, font.glyphMetrics(3));
     try testing.expectEqual(GlyphMetrics{ .advance = 800, .lsb = 100 }, font.glyphMetrics(6));
     try testing.expectEqual(GlyphMetrics{ .advance = 800, .lsb = 0 }, font.glyphMetrics(7));
-}
-
-test "text bounds" {
-    var buf: [synthetic.buffer_size]u8 = undefined;
-    const font = synthetic.font(&buf, .{});
-    // A then B: 800 + kern(1, 2) = -30, then 800; two lines of 1150 units.
-    const bounds = font.getTextBounds("AB\nA", 50);
-    try testing.expectApproxEqAbs(@as(f32, (800 - 30 + 800) * 0.05), bounds.r, 1e-4);
-    try testing.expectApproxEqAbs(@as(f32, 2 * 57.5), bounds.b, 1e-4);
-
-    const tight = font.getTextBoundsTight("A", 100);
-    try testing.expectApproxEqAbs(@as(f32, 10), tight.l, 1e-4);
-    try testing.expectApproxEqAbs(@as(f32, 70), tight.r, 1e-4);
-    try testing.expectApproxEqAbs(@as(f32, 90 - 70), tight.t, 1e-4);
-    try testing.expectApproxEqAbs(@as(f32, 90), tight.b, 1e-4);
-    try testing.expectEqual(@as(f32, 0), font.getTextBoundsTight("", 100).r);
 }
 
 test "rejects other formats and truncation without panicking" {
@@ -553,7 +509,7 @@ test "system font, when one is installed" {
     defer b.deinit(testing.allocator);
     try testing.expect(b.contourCount() >= 2);
     try testing.expect(font.kern(a, font.glyphIndex('V')) <= 0);
-    try testing.expect(font.getTextBounds("Hello", 24).r > 24);
+    try testing.expect(lineWidth(font, "Hello", 24) > 24);
 }
 
 test "system collection, when one is installed" {
@@ -582,7 +538,7 @@ test "system collection, when one is installed" {
     var cubics: usize = 0;
     for (o.points) |p| cubics += @intFromBool(p.kind == .cubic_control);
     try testing.expect(cubics > 0);
-    try testing.expect(font.getTextBounds("中文", 24).r > 24);
+    try testing.expect(lineWidth(font, "中文", 24) > 24);
 
     var last: VectorFont = try .loadFace(testing.io, testing.allocator, path, font.num_faces - 1);
     defer last.deinit(testing.allocator);
@@ -614,5 +570,5 @@ test "system CFF font, when one is installed" {
     const bounds = font.glyphBounds(font.glyphIndex('B')).?;
     try testing.expect(bounds.x_max > bounds.x_min and bounds.y_max > bounds.y_min);
     try testing.expect(font.kern(a, font.glyphIndex('V')) <= 0);
-    try testing.expect(font.getTextBounds("Hello", 24).r > 24);
+    try testing.expect(lineWidth(font, "Hello", 24) > 24);
 }

--- a/src/font/layout.zig
+++ b/src/font/layout.zig
@@ -1,6 +1,6 @@
-//! Line layout shared by every text drawing entry point: paragraphs, word wrap,
-//! alignment and spacing, for bitmap and vector fonts alike. Widths come from
-//! `Font.getTextBounds`, so vector kerning is honored when deciding breaks.
+//! Line layout and measuring shared by every text entry point: paragraphs, word wrap,
+//! alignment and spacing, for bitmap and vector fonts alike. Widths come from the per-font
+//! `Layout` pens, so vector kerning is honored when deciding breaks.
 
 const std = @import("std");
 
@@ -98,7 +98,7 @@ pub fn lineAdvance(font: Font, size: f32, layout: TextLayout) f32 {
 /// The lines of `text` at `size`: paragraphs split on `\n`, then wrapped greedily to
 /// `max_width` when one is given. A wrapped line ends at a word boundary, the spaces at
 /// the break are consumed, and a word wider than `max_width` breaks between codepoints.
-/// Empty text yields one empty line, like `getTextBounds`.
+/// Empty text yields one empty line, so it measures one line tall.
 pub const Lines = struct {
     pub const Line = struct {
         text: []const u8,
@@ -208,6 +208,34 @@ pub fn measure(font: Font, text: []const u8, size: f32, max_width: ?f32, layout:
     return .{ .l = 0, .t = 0, .r = width, .b = @as(f32, @floatFromInt(count)) * lineAdvance(font, size, layout) };
 }
 
+/// Box of the inked pixels of `text` from its top-left corner: the union of every glyph's
+/// ink, each line one line height below the last. Empty when nothing has ink.
+pub fn measureTight(font: Font, text: []const u8, size: f32) Rectangle(f32) {
+    var lines: Lines = .init(font, text, size, null, 0);
+    var bounds: ?Rectangle(f32) = null;
+    var top: f32 = 0;
+    while (lines.next()) |line| : (top += font.lineHeight(size)) {
+        const ink = switch (font) {
+            .bitmap => |b| lineInk(BitmapFont.Layout.init(b, line.text, b.scaleFor(size))),
+            .vector => |v| lineInk(VectorFont.Layout.init(v, line.text, size)),
+        } orelse continue;
+        const box = ink.translate(0, top);
+        bounds = if (bounds) |acc| acc.merge(box) else box;
+    }
+    return bounds orelse .{ .l = 0, .t = 0, .r = 0, .b = 0 };
+}
+
+/// Union of the ink boxes of the glyphs `layout` places.
+fn lineInk(layout: anytype) ?Rectangle(f32) {
+    var glyphs = layout;
+    var bounds: ?Rectangle(f32) = null;
+    while (glyphs.next()) |item| {
+        const box = glyphs.inkBounds(item) orelse continue;
+        bounds = if (bounds) |acc| acc.merge(box) else box;
+    }
+    return bounds;
+}
+
 const testing = std.testing;
 const font8x8 = @import("font8x8.zig");
 const synthetic = @import("truetype/synthetic.zig");
@@ -269,7 +297,60 @@ test "spacing and measure" {
     const box = measure(font, "aaa bbb ccc", 8, 64, spaced);
     try testing.expectEqual(Rectangle(f32){ .l = 0, .t = 0, .r = 28, .b = 36 }, box);
     try testing.expectEqual(Rectangle(f32){ .l = 0, .t = 0, .r = 0, .b = 8 }, measure(font, "", 8, null, .default));
-    try testing.expectEqual(font.getTextBounds("ab\ncd", 8), measure(font, "ab\ncd", 8, null, .default));
+}
+
+test "getTextBounds is measureText under the default layout" {
+    var buf: [synthetic.buffer_size]u8 = undefined;
+    const vector: Font = .{ .vector = synthetic.font(&buf, .{}) };
+    const bitmap: Font = .{ .bitmap = font8x8.basic };
+    for ([_]Font{ bitmap, vector }) |font| {
+        for ([_][]const u8{ "", "AB", "AB\nA", "AB  \n A ", "\n" }) |text| {
+            try testing.expectEqual(font.measureText(text, 50, null, .default), font.getTextBounds(text, 50));
+        }
+        // Trailing spaces are left out, leading ones and line breaks count.
+        try testing.expectEqual(font.getTextBounds("AB", 50), font.getTextBounds("AB  ", 50));
+        try testing.expectEqual(font.getTextBounds(" AB", 50).r, font.getTextBounds(" AB  ", 50).r);
+        try testing.expect(font.getTextBounds(" AB", 50).r > font.getTextBounds("AB", 50).r);
+        try testing.expectEqual(2 * font.lineHeight(50), font.getTextBounds("AB\nA", 50).b);
+        try testing.expectEqual(font.getTextBounds("AB", 50).r, font.getTextBounds("AB\nA", 50).r);
+    }
+    // A then B: 800 + kern(1, 2) = -30, then 800 units, on two lines of 1150 units.
+    const bounds = vector.getTextBounds("AB\nA", 50);
+    try testing.expectApproxEqAbs(@as(f32, (800 - 30 + 800) * 0.05), bounds.r, 1e-4);
+    try testing.expectApproxEqAbs(@as(f32, 2 * 57.5), bounds.b, 1e-4);
+    // Codepoints of any byte length are one character wide in a fixed bitmap font.
+    try testing.expectEqual(Rectangle(f32){ .l = 0, .t = 0, .r = 16, .b = 8 }, bitmap.getTextBounds("A©", 8));
+    try testing.expectEqual(Rectangle(f32){ .l = 0, .t = 0, .r = 20, .b = 24 }, bitmap.measureText("A©", 8, null, .{ .letter_spacing = 4, .line_spacing = 3 }));
+}
+
+test "getTextBoundsTight is the ink of every line" {
+    var buf: [synthetic.buffer_size]u8 = undefined;
+    const vector: Font = .{ .vector = synthetic.font(&buf, .{}) };
+    const tight = vector.getTextBoundsTight("A", 100);
+    try testing.expectApproxEqAbs(@as(f32, 10), tight.l, 1e-4);
+    try testing.expectApproxEqAbs(@as(f32, 70), tight.r, 1e-4);
+    try testing.expectApproxEqAbs(@as(f32, 90 - 70), tight.t, 1e-4);
+    try testing.expectApproxEqAbs(@as(f32, 90), tight.b, 1e-4);
+    try testing.expectEqual(@as(f32, 0), vector.getTextBoundsTight("", 100).r);
+    // The second line's ink sits one line height lower.
+    const two = vector.getTextBoundsTight("A\nA", 100);
+    try testing.expectApproxEqAbs(tight.t, two.t, 1e-4);
+    try testing.expectApproxEqAbs(tight.b + vector.lineHeight(100), two.b, 1e-4);
+
+    // A 16 px wide glyph with one pixel set at (10, 2), in the second byte of its row.
+    var wide: [2 * 8]u8 = @splat(0);
+    wide[2 * 2 + 1] = 1 << 2;
+    const wide_font: Font = .{ .bitmap = .{ .name = "Wide", .char_width = 16, .char_height = 8, .first_char = 'A', .last_char = 'A', .data = &wide } };
+    try testing.expectEqual(Rectangle(f32){ .l = 10, .t = 2, .r = 11, .b = 3 }, wide_font.getTextBoundsTight("A", 8));
+    try testing.expectEqual(Rectangle(f32){ .l = 20, .t = 4, .r = 22, .b = 6 }, wide_font.getTextBoundsTight("A", 16));
+    try testing.expectEqual(Rectangle(f32){ .l = 10, .t = 2, .r = 27, .b = 11 }, wide_font.getTextBoundsTight("A\nAA", 8));
+
+    // A blank 'A' followed by a '©' (two UTF-8 bytes) inked at x = 3..5 of row 2.
+    var data: [256 * 8]u8 = @splat(0);
+    data[0xA9 * 8 + 2] = 0x18;
+    const latin: Font = .{ .bitmap = .{ .name = "Latin", .char_width = 8, .char_height = 8, .first_char = 0, .last_char = 255, .data = &data } };
+    try testing.expectEqual(Rectangle(f32){ .l = 11, .t = 2, .r = 13, .b = 3 }, latin.getTextBoundsTight("A©", 8));
+    try testing.expectEqual(Rectangle(f32){ .l = 0, .t = 0, .r = 0, .b = 0 }, latin.getTextBoundsTight("A", 8));
 }
 
 test "pen walks bitmap and vector lines alike" {


### PR DESCRIPTION
`Font.getTextBounds` and `Font.measureText` disagreed: the former dispatched to per-type `BitmapFont`/`VectorFont` implementations that counted trailing spaces and ignored letter spacing, while the latter (and `Canvas.drawTextBox`, which aligns lines with it) measured through `layout.zig` without trailing spaces. This makes `layout.zig` the single measuring implementation.

## What changes

- `Font.getTextBounds(text, size)` is now `measureText(text, size, null, .default)`: trailing spaces are left out of the width, and it is exactly the box `drawTextBox` fills.
- `BitmapFont.getTextBounds`, `BitmapFont.getTextBoundsTight`, `VectorFont.getTextBounds` and `VectorFont.getTextBoundsTight` are removed; use `Font`. `examples/src/make_logo.zig` is updated accordingly.
- `Font.getTextBoundsTight` (ink bounds) lives in `layout.zig` as `measureTight`: it walks `layout.Lines` and offsets each line's ink box by `font.lineHeight(size)`, the same per-line offset the two old loops used. Both `Layout` types gain `inkBounds(item)`, so one generic `lineInk` serves bitmap and vector fonts.
- `VectorFont.Layout.place` no longer handles `\n` (and loses its `line_height` field); line breaking is `layout.Lines`' job.
- `Canvas.bitmapLineExtent` walks `BitmapFont.Layout` for the clip rect instead of calling the removed bounds, keeping the non-negative letter-spacing slack. **No rendering change: no MD5 in `src/canvas/tests/regression.zig` was touched.**
- Python: `Font.get_text_bounds` keeps working through `Font`; its docstring now says it matches `measure_text` with defaults and excludes trailing spaces. Stubs regenerate unchanged in shape.

## Tests

The deleted per-type tests (VectorFont "text bounds", BitmapFont "getTextBounds with Unicode" and the two tight-bounds tests) move to `Font`-level tests in `layout.zig`, plus new assertions that trailing spaces are excluded, that `getTextBounds` equals `measureText` under the default layout for both font kinds, and that multi-line tight bounds stack by the line height.

`zig build test`, `zig build python-bindings`, `zig build python-stubs` and the examples build all pass.

## Line delta

7 files changed, 124 insertions(+), 205 deletions(-): net −81 lines.
