### PR TITLE
refactor(font): one glyph table for bitmap fonts

### DIFF
--- a/src/canvas/Canvas.zig
+++ b/src/canvas/Canvas.zig
@@ -2334,21 +2334,21 @@ pub fn Canvas(comptime T: type) type {
 
         /// Blits one line of bitmap glyphs at `position`.
         fn blitBitmapLine(self: Self, text: []const u8, position: Point(2, f32), paint: Paint, font: BitmapFont, scale: f32, letter_spacing: f32, mode: DrawMode) void {
-            const text_rect = bitmapLineExtent(text, font, scale, letter_spacing).translate(position.x(), position.y());
-            const clip_rect = text_rect.intersect(self.imageRect()) orelse return;
-
             const y = position.y();
             var glyphs: BitmapFont.Layout = .init(font, text, scale);
             glyphs.x = position.x();
             glyphs.letter_spacing = letter_spacing;
-            while (glyphs.next()) |placed| {
-                if (scale == 1.0) {
-                    self.renderGlyphUnscaled(placed.glyph, placed.x, y, paint);
-                } else switch (mode) {
-                    .fast => self.renderGlyphFastScaled(placed.glyph, placed.x, y, scale, clip_rect, paint),
-                    .soft => self.renderGlyphSoftScaled(placed.glyph, placed.x, y, scale, paint),
-                }
+            // The 1:1 blit clips per pixel, so it skips the line's extent, a second pass over the text.
+            if (scale == 1.0) {
+                while (glyphs.next()) |placed| self.renderGlyphUnscaled(placed.glyph, placed.x, y, paint);
+                return;
             }
+            const text_rect = bitmapLineExtent(text, font, scale, letter_spacing).translate(position.x(), position.y());
+            const clip_rect = text_rect.intersect(self.imageRect()) orelse return;
+            while (glyphs.next()) |placed| switch (mode) {
+                .fast => self.renderGlyphFastScaled(placed.glyph, placed.x, y, scale, clip_rect, paint),
+                .soft => self.renderGlyphSoftScaled(placed.glyph, placed.x, y, scale, paint),
+            };
         }
 
         /// Blits a glyph 1:1. `x`/`y` are floored once, since floor commutes with adding the

--- a/src/font.zig
+++ b/src/font.zig
@@ -107,7 +107,7 @@ pub const Font = union(enum) {
 
     pub fn hasGlyph(self: Font, codepoint: u21) bool {
         return switch (self) {
-            .bitmap => |b| b.getGlyph(codepoint) != null,
+            .bitmap => |b| b.getEntry(codepoint) != null,
             .vector => |v| v.glyphIndex(codepoint) != 0,
         };
     }

--- a/src/font/BitmapFont.zig
+++ b/src/font/BitmapFont.zig
@@ -1,7 +1,6 @@
 //! Bitmap font type and rendering functionality
 //!
-//! A bitmap font containing character data and metrics.
-//! Supports both fixed-width and variable-width fonts.
+//! A bitmap font: a codepoint-sorted glyph table, each entry locating its bitmap in `data`.
 
 const std = @import("std");
 const Io = std.Io;
@@ -22,16 +21,23 @@ name: []const u8,
 char_width: u8,
 /// Height of each character in pixels
 char_height: u8,
-/// Fixed-layout fonts (no `glyphs`) store this ASCII range contiguously in `data`, one
-/// `char_height` by `bytesPerRow` bitmap per character.
-first_char: u8 = 0,
-last_char: u8 = 0,
 /// Raw bitmap data for all characters, LSB-first within each row byte.
 data: []const u8,
-/// Per-codepoint glyphs of a variable-width font, each locating its bitmap in `data`.
-glyphs: ?std.AutoHashMap(u32, GlyphData) = null,
+/// Glyphs sorted by codepoint, each locating its bitmap in `data`.
+glyphs: []const Entry,
 /// Optional: Original font ascent from the source font file (for accurate save)
 font_ascent: ?i16 = null,
+
+/// A glyph of the table: its codepoint and metrics.
+pub const Entry = struct {
+    codepoint: u21,
+    info: GlyphData,
+
+    /// A glyph filling its `width` by `height` cell: no bearings, advancing by `width`.
+    pub fn cell(codepoint: u21, width: u8, height: u8, bitmap_offset: usize) Entry {
+        return .{ .codepoint = codepoint, .info = .{ .width = width, .height = height, .x_offset = 0, .y_offset = 0, .device_width = width, .bitmap_offset = bitmap_offset } };
+    }
+};
 
 /// Loads a font from `file_path` with automatic format detection (BDF or PCF), keeping only
 /// characters that match `filter`.
@@ -70,9 +76,17 @@ pub fn scaleFor(self: BitmapFont, size: f32) f32 {
 }
 
 /// Glyphs in the font.
-pub fn glyphCount(self: BitmapFont) u32 {
-    if (self.glyphs) |map| return map.count();
-    return if (self.first_char <= self.last_char) @as(u32, self.last_char) - self.first_char + 1 else 0;
+pub fn glyphCount(self: BitmapFont) usize {
+    return self.glyphs.len;
+}
+
+/// Whether every glyph has the same width and advance.
+pub fn isMonospace(self: BitmapFont) bool {
+    for (self.glyphs) |entry| {
+        const first = self.glyphs[0].info;
+        if (entry.info.width != first.width or entry.info.device_width != first.device_width) return false;
+    }
+    return true;
 }
 
 /// A glyph resolved to its metadata and bitmap in a single lookup
@@ -110,28 +124,38 @@ pub const Glyph = struct {
     }
 };
 
-/// Resolve a codepoint to its glyph info and bitmap data with a single map lookup.
+/// The table entry of `codepoint`, null if the font lacks it. A contiguous table answers by
+/// index, inline so the text loops pay only that; any other falls back to the search.
+pub inline fn getEntry(self: BitmapFont, codepoint: u21) ?*const Entry {
+    const glyphs = self.glyphs;
+    if (glyphs.len == 0) return null;
+    // A codepoint below the first wraps past the length and misses like any other.
+    const index = codepoint -% glyphs[0].codepoint;
+    if (index < glyphs.len and glyphs[index].codepoint == codepoint) return &glyphs[index];
+    return search(glyphs, codepoint);
+}
+
+/// Binary search of the sorted table.
+fn search(glyphs: []const Entry, codepoint: u21) ?*const Entry {
+    var lo: usize = 0;
+    var hi: usize = glyphs.len;
+    while (lo < hi) {
+        const mid = lo + (hi - lo) / 2;
+        if (glyphs[mid].codepoint < codepoint) lo = mid + 1 else hi = mid;
+    }
+    return if (lo < glyphs.len and glyphs[lo].codepoint == codepoint) &glyphs[lo] else null;
+}
+
+/// The bitmap of a glyph of this font.
+pub fn bitmap(self: BitmapFont, info: GlyphData) []const u8 {
+    return self.data[info.bitmap_offset..][0..info.bitmapSize()];
+}
+
+/// Resolve a codepoint to its glyph info and bitmap data with a single lookup.
 /// Returns null if the character is not in the font.
 pub fn getGlyph(self: BitmapFont, codepoint: u21) ?Glyph {
-    if (self.glyphs) |map| {
-        const info = map.get(codepoint) orelse return null;
-        return .{ .info = info, .data = self.data[info.bitmap_offset..][0..info.bitmapSize()] };
-    }
-    // Fixed layout: the ASCII range, one bitmap after another.
-    if (codepoint > 255 or codepoint < self.first_char or codepoint > self.last_char) return null;
-    const index: u32 = @as(u8, @intCast(codepoint)) - self.first_char;
-    const bytes_per_char = @as(u32, self.char_height) * self.bytesPerRow();
-    return .{
-        .info = .{
-            .width = self.char_width,
-            .height = self.char_height,
-            .x_offset = 0,
-            .y_offset = 0,
-            .device_width = @intCast(self.char_width),
-            .bitmap_offset = index * bytes_per_char,
-        },
-        .data = self.data[index * bytes_per_char ..][0..bytes_per_char],
-    };
+    const info = (self.getEntry(codepoint) orelse return null).info;
+    return .{ .info = info, .data = self.bitmap(info) };
 }
 
 /// Get the bitmap data for a specific character
@@ -144,9 +168,8 @@ pub fn getCharData(self: BitmapFont, codepoint: u21) ?[]const u8 {
 /// Get the advance width for a character (how much to move the cursor)
 /// Returns per-character width if available, otherwise the default char_width
 pub fn getCharAdvanceWidth(self: BitmapFont, codepoint: u21) u16 {
-    const map = self.glyphs orelse return self.char_width;
-    const info = map.get(codepoint) orelse return self.char_width;
-    return info.advanceWidth();
+    const entry = self.getEntry(codepoint) orelse return self.char_width;
+    return entry.info.advanceWidth();
 }
 
 /// Lays out one line of text at `scale`, yielding each glyph with its pen position: the
@@ -213,34 +236,21 @@ pub fn save(self: BitmapFont, io: Io, allocator: Allocator, file_path: []const u
     };
 }
 
-/// Returns the sorted list of codepoints present in this font. Caller owns the slice.
-pub fn collectCodepoints(self: BitmapFont, gpa: Allocator) ![]u21 {
-    const keys = try gpa.alloc(u21, self.glyphCount());
-    if (self.glyphs) |map| {
-        var iter = map.keyIterator();
-        for (keys) |*cp| cp.* = @intCast(iter.next().?.*);
-        std.mem.sort(u21, keys, {}, std.sort.asc(u21));
-    } else for (keys, self.first_char..) |*cp, codepoint| {
-        cp.* = @intCast(codepoint);
-    }
-    return keys;
-}
-
-/// Displays the font information: name, dimensions, and character range.
+/// Displays the font information: name, dimensions, glyph count and spacing.
 pub fn format(self: BitmapFont, writer: *Io.Writer) Io.Writer.Error!void {
-    try writer.print("BitmapFont{{ .name = \"{s}\", .char_width = {d}, .char_height = {d}, .glyphs = {d}, .type = {s} }}", .{
+    try writer.print("BitmapFont{{ .name = \"{s}\", .char_width = {d}, .char_height = {d}, .glyphs = {d}, .spacing = {s} }}", .{
         self.name,
         self.char_width,
         self.char_height,
-        self.glyphCount(),
-        if (self.glyphs != null) "variable" else "fixed",
+        self.glyphs.len,
+        if (self.isMonospace()) "monospace" else "proportional",
     });
 }
 
 /// Free resources (if owned)
 pub fn deinit(self: *BitmapFont, allocator: std.mem.Allocator) void {
     allocator.free(self.name);
-    if (self.glyphs) |*map| map.deinit();
+    allocator.free(self.glyphs);
     allocator.free(self.data);
 }
 
@@ -249,8 +259,7 @@ pub const test_font: BitmapFont = .{
     .name = "TestFont",
     .char_width = 8,
     .char_height = 8,
-    .first_char = 'A',
-    .last_char = 'C',
+    .glyphs = &.{ .cell('A', 8, 8, 0), .cell('B', 8, 8, 8), .cell('C', 8, 8, 16) },
     .data = &.{
         0x18, 0x24, 0x42, 0x42, 0x7E, 0x42, 0x42, 0x00,
         0x7C, 0x42, 0x42, 0x7C, 0x42, 0x42, 0x7C, 0x00,
@@ -258,3 +267,25 @@ pub const test_font: BitmapFont = .{
     },
     .font_ascent = 7,
 };
+
+test "getEntry over a sparse table" {
+    const testing = std.testing;
+    const font: BitmapFont = .{
+        .name = "Sparse",
+        .char_width = 8,
+        .char_height = 8,
+        .glyphs = &.{ .cell('A', 8, 8, 0), .cell('C', 8, 8, 8), .cell('Z', 8, 8, 16) },
+        .data = &@as([3 * 8]u8, @splat(0)),
+    };
+    // 'A' by index; 'C' and 'Z', whose index holds another codepoint, by search.
+    try testing.expectEqual(@as(usize, 0), font.getEntry('A').?.info.bitmap_offset);
+    try testing.expectEqual(@as(usize, 8), font.getEntry('C').?.info.bitmap_offset);
+    try testing.expectEqual(@as(usize, 16), font.getEntry('Z').?.info.bitmap_offset);
+    for ([_]u21{ '@', 'B', 'D', 'Y', '[', 0x1F600 }) |missing| try testing.expectEqual(null, font.getEntry(missing));
+    try testing.expectEqual(3, font.glyphCount());
+    try testing.expect(font.isMonospace());
+
+    const empty: BitmapFont = .{ .name = "", .char_width = 8, .char_height = 8, .glyphs = &.{}, .data = &.{} };
+    try testing.expectEqual(null, empty.getEntry('A'));
+    try testing.expect(empty.isMonospace());
+}

--- a/src/font/bdf.zig
+++ b/src/font/bdf.zig
@@ -34,19 +34,12 @@ const BdfFont = struct {
     glyph_count: u32,
 };
 
-/// A parsed glyph: its metadata in the font's own layout (`y_offset` counted down from
-/// the top of the line) and its encoding.
-const BdfGlyph = struct {
-    encoding: u32,
-    info: GlyphData,
-};
-
-/// Single-pass BDF parser state
+/// Single-pass BDF parser state: the glyphs in file order, `y_offset` already counted down
+/// from the top of the line.
 const BdfParseState = struct {
     font: BdfFont,
-    glyphs: std.ArrayList(BdfGlyph),
+    glyphs: std.ArrayList(BitmapFont.Entry),
     bitmap_data: std.ArrayList(u8),
-    all_ascii: bool = true,
     fn deinit(self: *BdfParseState, gpa: Allocator) void {
         self.glyphs.deinit(gpa);
         self.bitmap_data.deinit(gpa);
@@ -78,9 +71,32 @@ pub fn parse(gpa: Allocator, bytes: []const u8, filter: LoadFilter) !BitmapFont 
         if (parsed_glyphs >= state.font.glyph_count) break;
     }
 
+    // Codepoint order, a later duplicate of an encoding replacing the earlier one.
+    std.mem.sort(BitmapFont.Entry, state.glyphs.items, {}, byCodepoint);
+    var kept: usize = 0;
+    for (state.glyphs.items) |entry| {
+        if (kept > 0 and state.glyphs.items[kept - 1].codepoint == entry.codepoint) kept -= 1;
+        state.glyphs.items[kept] = entry;
+        kept += 1;
+    }
+    state.glyphs.shrinkRetainingCapacity(kept);
+
     const bitmap_data = try state.bitmap_data.toOwnedSlice(gpa);
     errdefer gpa.free(bitmap_data);
-    return convertToBitmapFont(gpa, state.font, state.glyphs.items, bitmap_data, state.all_ascii);
+    const glyphs = try state.glyphs.toOwnedSlice(gpa);
+    errdefer gpa.free(glyphs);
+    return .{
+        .name = state.font.name,
+        .char_width = @intCast(@abs(state.font.bbox_width)),
+        .char_height = @intCast(@abs(state.font.bbox_height)),
+        .data = bitmap_data,
+        .glyphs = glyphs,
+        .font_ascent = state.font.ascent,
+    };
+}
+
+fn byCodepoint(_: void, a: BitmapFont.Entry, b: BitmapFont.Entry) bool {
+    return a.codepoint < b.codepoint;
 }
 
 /// The family of an XLFD name (`-foundry-family-weight-...`); any other name as is.
@@ -169,7 +185,7 @@ fn skipToEndChar(lines: *std.mem.TokenIterator(u8, .any)) void {
 /// Parses one glyph after its `STARTCHAR`; true when it was kept.
 fn parseGlyph(gpa: Allocator, lines: *std.mem.TokenIterator(u8, .any), state: *BdfParseState, filter: LoadFilter) !bool {
     var info: GlyphData = .{ .width = 0, .height = 0, .x_offset = 0, .y_offset = 0, .device_width = 0, .bitmap_offset = state.bitmap_data.items.len };
-    var encoding: ?u32 = null;
+    var encoding: ?u21 = null;
     // BDF's y offset: the bitmap's bottom edge relative to the baseline.
     var bbx_y: ?i16 = null;
 
@@ -183,7 +199,7 @@ fn parseGlyph(gpa: Allocator, lines: *std.mem.TokenIterator(u8, .any), state: *B
                 skipToEndChar(lines);
                 return false;
             }
-            encoding = try std.fmt.parseInt(u32, enc_str, 10);
+            encoding = try std.fmt.parseInt(u21, enc_str, 10);
         } else if (std.mem.startsWith(u8, trimmed, "DWIDTH ")) {
             var parts = std.mem.tokenizeAny(u8, trimmed[7..], " \t");
             info.device_width = try std.fmt.parseInt(i16, parts.next() orelse "0", 10);
@@ -228,8 +244,7 @@ fn parseGlyph(gpa: Allocator, lines: *std.mem.TokenIterator(u8, .any), state: *B
                 }
             }
 
-            try state.glyphs.append(gpa, .{ .encoding = codepoint, .info = info });
-            if (codepoint > 127) state.all_ascii = false;
+            try state.glyphs.append(gpa, .{ .codepoint = codepoint, .info = info });
             skipToEndChar(lines);
             return true;
         } else if (std.mem.eql(u8, trimmed, "ENDCHAR")) {
@@ -239,60 +254,6 @@ fn parseGlyph(gpa: Allocator, lines: *std.mem.TokenIterator(u8, .any), state: *B
     }
 
     return false;
-}
-
-/// A variable-width font from the parsed glyphs, taking `font.name` and `bitmap_data`.
-fn buildSparseFont(allocator: Allocator, font: BdfFont, glyphs: []const BdfGlyph, bitmap_data: []u8) !BitmapFont {
-    var map: std.AutoHashMap(u32, GlyphData) = .init(allocator);
-    errdefer map.deinit();
-    try map.ensureTotalCapacity(@intCast(glyphs.len));
-    for (glyphs) |glyph| map.putAssumeCapacity(glyph.encoding, glyph.info);
-    return .{
-        .name = font.name,
-        .char_width = @intCast(@abs(font.bbox_width)),
-        .char_height = @intCast(@abs(font.bbox_height)),
-        .data = bitmap_data,
-        .glyphs = map,
-        .font_ascent = font.ascent,
-    };
-}
-
-/// Convert parsed glyphs to BitmapFont format
-fn convertToBitmapFont(allocator: Allocator, font: BdfFont, glyphs: []const BdfGlyph, bitmap_data: []u8, all_ascii: bool) !BitmapFont {
-    // Unicode fonts and variable-width ASCII ones use the sparse layout.
-    if (!all_ascii or glyphs.len == 0) return buildSparseFont(allocator, font, glyphs, bitmap_data);
-    const char_width: u32 = @abs(font.bbox_width);
-    const char_height: u32 = @abs(font.bbox_height);
-    var min_char: u8 = 255;
-    var max_char: u8 = 0;
-    for (glyphs) |glyph| {
-        if (glyph.info.width != char_width) return buildSparseFont(allocator, font, glyphs, bitmap_data);
-        min_char = @min(min_char, @as(u8, @intCast(glyph.encoding)));
-        max_char = @max(max_char, @as(u8, @intCast(glyph.encoding)));
-    }
-
-    // Fixed-width ASCII font: one bitmap after another in encoding order.
-    const bytes_per_row = GlyphData.bytesForWidth(char_width);
-    const char_bitmap_size = char_height * bytes_per_row;
-    const contiguous_data = try allocator.alloc(u8, (max_char - min_char + 1) * char_bitmap_size);
-    @memset(contiguous_data, 0);
-    for (glyphs) |glyph| {
-        const dest = contiguous_data[(glyph.encoding - min_char) * char_bitmap_size ..];
-        // A glyph shorter than the font leaves its remaining rows blank.
-        const copy_bytes = @min(glyph.info.height, char_height) * bytes_per_row;
-        @memcpy(dest[0..copy_bytes], bitmap_data[glyph.info.bitmap_offset..][0..copy_bytes]);
-    }
-    allocator.free(bitmap_data);
-
-    return .{
-        .name = font.name,
-        .char_width = @intCast(char_width),
-        .char_height = @intCast(char_height),
-        .first_char = min_char,
-        .last_char = max_char,
-        .data = contiguous_data,
-        .font_ascent = font.ascent,
-    };
 }
 
 test "BDF to BitmapFont conversion" {
@@ -325,8 +286,8 @@ test "BDF to BitmapFont conversion" {
 
     // Test converted font
     try testing.expectEqual(@as(u8, 8), font.char_height);
-    try testing.expectEqual(@as(u8, 65), font.first_char);
-    try testing.expectEqual(@as(u8, 65), font.last_char);
+    try testing.expectEqual(1, font.glyphs.len);
+    try testing.expectEqual('A', font.glyphs[0].codepoint);
 
     // Test that 'A' was converted correctly
     const char_data = font.getCharData('A');
@@ -336,6 +297,42 @@ test "BDF to BitmapFont conversion" {
     // Check bitmap conversion
     try testing.expectEqual(@as(u8, 0x18), char_data.?[0]);
     try testing.expectEqual(@as(u8, 0x24), char_data.?[1]);
+}
+
+test "BDF sorts glyphs by encoding, the last duplicate winning" {
+    const unsorted_bdf =
+        \\STARTFONT 2.1
+        \\FONTBOUNDINGBOX 8 1 0 0
+        \\CHARS 3
+        \\STARTCHAR B
+        \\ENCODING 66
+        \\BBX 8 1 0 0
+        \\BITMAP
+        \\02
+        \\ENDCHAR
+        \\STARTCHAR A
+        \\ENCODING 65
+        \\BBX 8 1 0 0
+        \\BITMAP
+        \\01
+        \\ENDCHAR
+        \\STARTCHAR A2
+        \\ENCODING 65
+        \\BBX 8 1 0 0
+        \\BITMAP
+        \\03
+        \\ENDCHAR
+        \\ENDFONT
+    ;
+
+    var font = try parse(testing.allocator, unsorted_bdf, .all);
+    defer font.deinit(testing.allocator);
+
+    try testing.expectEqual(2, font.glyphs.len);
+    try testing.expectEqual('A', font.glyphs[0].codepoint);
+    try testing.expectEqual('B', font.glyphs[1].codepoint);
+    try testing.expectEqualSlices(u8, &.{@bitReverse(@as(u8, 0x03))}, font.getCharData('A').?);
+    try testing.expectEqualSlices(u8, &.{@bitReverse(@as(u8, 0x02))}, font.getCharData('B').?);
 }
 
 test "BDF parses glyph rows wider than 32 bits" {
@@ -404,10 +401,9 @@ fn expectRoundtrip(file_name: []const u8) !void {
     defer loaded.deinit(testing.allocator);
     try testing.expectEqual(font.char_width, loaded.char_width);
     try testing.expectEqual(font.char_height, loaded.char_height);
-    try testing.expectEqual(font.first_char, loaded.first_char);
-    try testing.expectEqual(font.last_char, loaded.last_char);
-    for (font.first_char..font.last_char + 1) |codepoint| {
-        try testing.expectEqualSlices(u8, font.getCharData(@intCast(codepoint)).?, loaded.getCharData(@intCast(codepoint)).?);
+    try testing.expectEqual(font.glyphs.len, loaded.glyphs.len);
+    for (font.glyphs) |entry| {
+        try testing.expectEqualSlices(u8, font.getCharData(entry.codepoint).?, loaded.getCharData(entry.codepoint).?);
     }
 }
 
@@ -427,11 +423,7 @@ pub fn save(io: Io, gpa: Allocator, font: BitmapFont, path: []const u8) !void {
 
     try writeBdfHeader(gpa, &bdf_content, font);
 
-    const codepoints = try font.collectCodepoints(gpa);
-    defer gpa.free(codepoints);
-    for (codepoints) |encoding| {
-        try writeBdfGlyph(gpa, &bdf_content, font, encoding);
-    }
+    for (font.glyphs) |entry| try writeBdfGlyph(gpa, &bdf_content, font, entry);
 
     try bdf_content.appendSlice(gpa, "ENDFONT\n");
 
@@ -468,17 +460,15 @@ fn writeBdfHeader(allocator: Allocator, list: *std.ArrayList(u8), font: BitmapFo
     // Use stored font_ascent if available, otherwise estimate from the defaulted height
     const font_ascent = font.font_ascent orelse @as(i16, height);
 
-    if (font.glyphs) |glyphs| {
-        var iter = glyphs.valueIterator();
-        while (iter.next()) |glyph| {
-            max_width = @max(max_width, glyph.width);
-            max_height = @max(max_height, glyph.height);
+    for (font.glyphs) |entry| {
+        const glyph = entry.info;
+        max_width = @max(max_width, glyph.width);
+        max_height = @max(max_height, glyph.height);
 
-            // Reverse the transformation: bdf_y_offset = font_ascent - (internal_y_offset + height)
-            const bdf_y_offset = font_ascent - (glyph.y_offset + @as(i16, glyph.height));
-            min_y_offset = @min(min_y_offset, bdf_y_offset);
-            min_x_offset = @min(min_x_offset, glyph.x_offset);
-        }
+        // Reverse the transformation: bdf_y_offset = font_ascent - (internal_y_offset + height)
+        const bdf_y_offset = font_ascent - (glyph.y_offset + @as(i16, glyph.height));
+        min_y_offset = @min(min_y_offset, bdf_y_offset);
+        min_x_offset = @min(min_x_offset, glyph.x_offset);
     }
 
     const font_descent = -min_y_offset;
@@ -495,10 +485,10 @@ fn writeBdfHeader(allocator: Allocator, list: *std.ArrayList(u8), font: BitmapFo
 }
 
 /// Write a single glyph
-fn writeBdfGlyph(allocator: Allocator, list: *std.ArrayList(u8), font: BitmapFont, encoding: u21) !void {
-    const glyph = font.getGlyph(encoding) orelse return BdfError.MissingRequired;
-    const glyph_info = glyph.info;
-    const glyph_data = glyph.data;
+fn writeBdfGlyph(allocator: Allocator, list: *std.ArrayList(u8), font: BitmapFont, entry: BitmapFont.Entry) !void {
+    const encoding = entry.codepoint;
+    const glyph_info = entry.info;
+    const glyph_data = font.bitmap(glyph_info);
 
     try list.print(allocator, "STARTCHAR U+{X:0>4}\n", .{encoding});
     try list.print(allocator, "ENCODING {d}\n", .{encoding});

--- a/src/font/font8x8.zig
+++ b/src/font/font8x8.zig
@@ -14,19 +14,23 @@ const std = @import("std");
 const LoadFilter = @import("../font.zig").LoadFilter;
 const BitmapFont = @import("BitmapFont.zig");
 const font_data = @import("font8x8_data.zig");
-const GlyphData = @import("GlyphData.zig");
 const unicode = @import("unicode.zig");
 
 /// Basic ASCII font (0x20-0x7E)
 /// This font is always available and requires no allocation
-/// Uses a slice of basic_latin starting at character 0x20
-pub const basic = BitmapFont{
+pub const basic: BitmapFont = .{
     .name = "8x8 Basic",
     .char_width = 8,
     .char_height = 8,
-    .first_char = 0x20, // Space
-    .last_char = 0x7E, // Tilde
-    .data = font_data.basic_latin[0x20 * 8 .. 0x7F * 8], // Slice from 0x20 to 0x7E (inclusive)
+    .glyphs = &basic_glyphs,
+    .data = font_data.basic_latin[0x20 * 8 .. 0x7F * 8],
+};
+
+/// One cell per printable ASCII character, in order over `basic`'s data.
+const basic_glyphs: [0x7F - 0x20]BitmapFont.Entry = blk: {
+    var table: [0x7F - 0x20]BitmapFont.Entry = undefined;
+    for (&table, 0..) |*entry, i| entry.* = .cell(0x20 + i, 8, 8, i * 8);
+    break :blk table;
 };
 
 /// Create an extended Latin font (ASCII + Latin-1 Supplement)
@@ -43,30 +47,32 @@ pub fn extended(allocator: std.mem.Allocator) !BitmapFont {
 /// This requires allocation and can fail
 /// The returned font must be freed with deinit()
 pub fn create(gpa: std.mem.Allocator, filter: LoadFilter) !BitmapFont {
-    var glyphs: std.AutoHashMap(u32, GlyphData) = .init(gpa);
-    errdefer glyphs.deinit();
+    var glyphs: std.ArrayList(BitmapFont.Entry) = .empty;
+    errdefer glyphs.deinit(gpa);
     var data: std.ArrayList(u8) = .empty;
     errdefer data.deinit(gpa);
 
-    // The data ranges are ascending and disjoint, so one pass yields the glyphs in order.
+    // The data ranges are ascending and disjoint, so one pass yields the table in order.
     for (font_data.ranges) |range| {
         var code = range.start;
         while (code <= range.end) : (code += 1) {
             if (!filter.matches(code)) continue;
-            try glyphs.putNoClobber(code, .{ .width = 8, .height = 8, .x_offset = 0, .y_offset = 0, .device_width = 8, .bitmap_offset = data.items.len });
+            try glyphs.append(gpa, .cell(code, 8, 8, data.items.len));
             try data.appendSlice(gpa, range.data[(code - range.start) * 8 ..][0..8]);
         }
     }
-    if (glyphs.count() == 0) return error.NoCharactersFound;
+    if (glyphs.items.len == 0) return error.NoCharactersFound;
 
     const name = try gpa.dupe(u8, "8x8 Unicode");
     errdefer gpa.free(name);
+    const table = try glyphs.toOwnedSlice(gpa);
+    errdefer gpa.free(table);
     return .{
         .name = name,
         .char_width = 8,
         .char_height = 8,
         .data = try data.toOwnedSlice(gpa),
-        .glyphs = glyphs,
+        .glyphs = table,
     };
 }
 
@@ -76,13 +82,16 @@ test "static font is available" {
     // Static font should be directly usable without allocation
     try testing.expectEqual(@as(u8, 8), basic.char_width);
     try testing.expectEqual(@as(u8, 8), basic.char_height);
-    try testing.expectEqual(@as(u8, 0x20), basic.first_char);
-    try testing.expectEqual(@as(u8, 0x7E), basic.last_char);
+    try testing.expectEqual(95, basic.glyphs.len);
+    try testing.expectEqual(0x20, basic.glyphs[0].codepoint);
+    try testing.expectEqual(0x7E, basic.glyphs[94].codepoint);
 
     // Test getting character data
     const char_data = basic.getCharData('A');
     try testing.expect(char_data != null);
     try testing.expectEqual(@as(u32, 8), char_data.?.len);
+    try testing.expectEqualSlices(u8, font_data.basic_latin['A' * 8 ..][0..8], char_data.?);
+    try testing.expectEqual(null, basic.getCharData(0x7F));
 }
 
 test "create ASCII font dynamically" {
@@ -94,10 +103,7 @@ test "create ASCII font dynamically" {
     try testing.expectEqual(@as(u8, 8), dynamic_font.char_width);
     try testing.expectEqual(@as(u8, 8), dynamic_font.char_height);
 
-    // Should have glyph map since it's dynamically created
-    try testing.expect(dynamic_font.glyphs != null);
-
-    // Test getting character data through glyph map
+    // Test getting character data through the glyph table
     const char_data = dynamic_font.getCharData('A');
     try testing.expect(char_data != null);
     try testing.expectEqual(@as(u32, 8), char_data.?.len);
@@ -150,7 +156,7 @@ test "create font with all available ranges" {
     defer all_font.deinit(testing.allocator);
 
     // Should have many characters available
-    try testing.expect(all_font.glyphs.?.count() > 200);
+    try testing.expect(all_font.glyphs.len > 200);
 
     // Test various ranges are included
     try testing.expect(all_font.getCharData('A') != null); // ASCII

--- a/src/font/layout.zig
+++ b/src/font/layout.zig
@@ -66,10 +66,17 @@ pub const Pen = struct {
     pub fn next(self: *Pen) ?Glyph {
         const codepoint = self.iter.nextCodepoint() orelse return null;
         switch (self.inner) {
-            inline else => |*layout| _ = layout.place(codepoint),
+            .bitmap => |*b| placeBitmap(b, codepoint),
+            .vector => |*v| _ = v.place(codepoint),
         }
         self.glyphs += 1;
         return .{ .codepoint = codepoint, .end = self.iter.i };
+    }
+
+    /// Out of line: inlined here, the bitmap lookup's size stopped the codepoint decoding
+    /// in `next` from being inlined and cost vector measuring 5%.
+    noinline fn placeBitmap(layout: *BitmapFont.Layout, codepoint: u21) void {
+        _ = layout.place(codepoint);
     }
 
     /// Width of what has been placed: the pen position less the trailing letter spacing,
@@ -340,15 +347,15 @@ test "getTextBoundsTight is the ink of every line" {
     // A 16 px wide glyph with one pixel set at (10, 2), in the second byte of its row.
     var wide: [2 * 8]u8 = @splat(0);
     wide[2 * 2 + 1] = 1 << 2;
-    const wide_font: Font = .{ .bitmap = .{ .name = "Wide", .char_width = 16, .char_height = 8, .first_char = 'A', .last_char = 'A', .data = &wide } };
+    const wide_font: Font = .{ .bitmap = .{ .name = "Wide", .char_width = 16, .char_height = 8, .glyphs = &.{.cell('A', 16, 8, 0)}, .data = &wide } };
     try testing.expectEqual(Rectangle(f32){ .l = 10, .t = 2, .r = 11, .b = 3 }, wide_font.getTextBoundsTight("A", 8));
     try testing.expectEqual(Rectangle(f32){ .l = 20, .t = 4, .r = 22, .b = 6 }, wide_font.getTextBoundsTight("A", 16));
     try testing.expectEqual(Rectangle(f32){ .l = 10, .t = 2, .r = 27, .b = 11 }, wide_font.getTextBoundsTight("A\nAA", 8));
 
     // A blank 'A' followed by a '©' (two UTF-8 bytes) inked at x = 3..5 of row 2.
-    var data: [256 * 8]u8 = @splat(0);
-    data[0xA9 * 8 + 2] = 0x18;
-    const latin: Font = .{ .bitmap = .{ .name = "Latin", .char_width = 8, .char_height = 8, .first_char = 0, .last_char = 255, .data = &data } };
+    var data: [2 * 8]u8 = @splat(0);
+    data[8 + 2] = 0x18;
+    const latin: Font = .{ .bitmap = .{ .name = "Latin", .char_width = 8, .char_height = 8, .glyphs = &.{ .cell('A', 8, 8, 0), .cell(0xA9, 8, 8, 8) }, .data = &data } };
     try testing.expectEqual(Rectangle(f32){ .l = 11, .t = 2, .r = 13, .b = 3 }, latin.getTextBoundsTight("A©", 8));
     try testing.expectEqual(Rectangle(f32){ .l = 0, .t = 0, .r = 0, .b = 0 }, latin.getTextBoundsTight("A", 8));
 }

--- a/src/font/pcf.zig
+++ b/src/font/pcf.zig
@@ -387,7 +387,8 @@ fn parseEncodings(allocator: std.mem.Allocator, data: []const u8, table: TableEn
     const rows: u32 = encoding.max_byte1 - encoding.min_byte1 + 1;
     const encodings_count = cols * rows;
 
-    if (encodings_count > max_glyph_count) {
+    // Both halves are bytes, so codepoints fit u16 and ascend with the table index.
+    if (encodings_count > max_glyph_count or encoding.max_byte1 > 0xFF or encoding.max_char_or_byte2 > 0xFF) {
         return PcfError.InvalidEncodingRange;
     }
 
@@ -486,7 +487,7 @@ fn convertToBitmapFont(
 ) !BitmapFont {
     // Determine which glyphs to include
     var glyph_list: std.ArrayList(struct {
-        codepoint: u32,
+        codepoint: u21,
         glyph_index: u32,
         metric: Metric,
     }) = .empty;
@@ -501,7 +502,7 @@ fn convertToBitmapFont(
 
         const row = encoding_index / chars_per_row;
         const col = encoding_index % chars_per_row;
-        const codepoint: u32 = @intCast(((encoding.min_byte1 + row) << 8) | (encoding.min_char_or_byte2 + col));
+        const codepoint: u21 = @intCast(((encoding.min_byte1 + row) << 8) | (encoding.min_char_or_byte2 + col));
 
         if (!filter.matches(codepoint)) continue;
         if (glyph_index >= metrics.len) continue;
@@ -519,11 +520,11 @@ fn convertToBitmapFont(
     defer converted_bitmaps.deinit(gpa);
     try converted_bitmaps.ensureTotalCapacity(gpa, total_bitmap_size);
 
-    var glyphs: std.AutoHashMap(u32, GlyphData) = .init(gpa);
-    errdefer glyphs.deinit();
-    try glyphs.ensureTotalCapacity(@intCast(glyph_list.items.len));
+    // The encoding table walks codepoints in ascending order, so the table comes out sorted.
+    const glyphs = try gpa.alloc(BitmapFont.Entry, glyph_list.items.len);
+    errdefer gpa.free(glyphs);
 
-    for (glyph_list.items) |glyph_info| {
+    for (glyph_list.items, glyphs) |glyph_info, *entry| {
         const metric = glyph_info.metric;
         const converted_offset = converted_bitmaps.items.len;
 
@@ -536,15 +537,18 @@ fn convertToBitmapFont(
         }
         convertGlyphBitmap(bitmap_info.bitmap_data, bitmap_offset, metric.width(), metric.height(), bitmap_info.flags, &converted_bitmaps);
 
-        glyphs.putAssumeCapacity(glyph_info.codepoint, .{
-            .width = @intCast(metric.width()),
-            .height = @intCast(metric.height()),
-            .x_offset = metric.left_sided_bearing,
-            // Adjust y_offset to account for font baseline
-            .y_offset = ascent - metric.ascent,
-            .device_width = metric.character_width,
-            .bitmap_offset = converted_offset,
-        });
+        entry.* = .{
+            .codepoint = glyph_info.codepoint,
+            .info = .{
+                .width = @intCast(metric.width()),
+                .height = @intCast(metric.height()),
+                .x_offset = metric.left_sided_bearing,
+                // Adjust y_offset to account for font baseline
+                .y_offset = ascent - metric.ascent,
+                .device_width = metric.character_width,
+                .bitmap_offset = converted_offset,
+            },
+        };
     }
 
     return .{
@@ -574,13 +578,12 @@ const GlyphEntry = struct {
 fn buildGlyphEntries(
     allocator: Allocator,
     font: BitmapFont,
-    codepoints: []const u21,
 ) !struct {
     entries: []GlyphEntry,
     bitmap_data: []u8,
     pad_sizes: [4]u32,
 } {
-    var entries = try allocator.alloc(GlyphEntry, codepoints.len);
+    const entries = try allocator.alloc(GlyphEntry, font.glyphs.len);
     errdefer allocator.free(entries);
 
     var bitmap_buffer: std.ArrayList(u8) = .empty;
@@ -590,8 +593,7 @@ fn buildGlyphEntries(
 
     const font_ascent = font.ascent();
 
-    for (codepoints, 0..) |cp, idx| {
-        const glyph = font.getGlyph(cp) orelse return PcfError.MissingRequired;
+    for (font.glyphs, entries) |glyph, *entry| {
         const glyph_info = glyph.info;
         const width = glyph_info.width;
         const height = glyph_info.height;
@@ -600,7 +602,7 @@ fn buildGlyphEntries(
         const glyph_ascent = font_ascent - glyph_info.y_offset;
 
         const bitmap_offset: u32 = @intCast(bitmap_buffer.items.len);
-        try bitmap_buffer.appendSlice(allocator, glyph.data);
+        try bitmap_buffer.appendSlice(allocator, font.bitmap(glyph_info));
 
         // Accumulate table sizes for each PCF padding option (1, 2, 4, 8 bytes)
         for (&pad_sizes, 0..) |*size, pad_idx| {
@@ -608,8 +610,8 @@ fn buildGlyphEntries(
             size.* += padded_row * height;
         }
 
-        entries[idx] = GlyphEntry{
-            .codepoint = cp,
+        entry.* = .{
+            .codepoint = glyph.codepoint,
             .metrics = .{
                 .left_sided_bearing = left,
                 .right_sided_bearing = @as(i16, width) + left,
@@ -747,7 +749,7 @@ fn writePropertiesTable(allocator: Allocator, font: BitmapFont) ![]u8 {
     try props.append(allocator, .{ .name = "POINT_SIZE", .value = .{ .integer = @as(i32, font.char_height) * 10 } });
     try props.append(allocator, .{ .name = "RESOLUTION_X", .value = .{ .integer = 75 } });
     try props.append(allocator, .{ .name = "RESOLUTION_Y", .value = .{ .integer = 75 } });
-    try props.append(allocator, .{ .name = "SPACING", .value = .{ .string = if (font.glyphs != null) "P" else "C" } });
+    try props.append(allocator, .{ .name = "SPACING", .value = .{ .string = if (font.isMonospace()) "C" else "P" } });
 
     if (font.font_ascent) |asc| {
         try props.append(allocator, .{ .name = "FONT_ASCENT", .value = .{ .integer = asc } });
@@ -838,10 +840,7 @@ fn writeAcceleratorsTable(allocator: Allocator, glyphs: []const GlyphEntry, font
 
 /// Save a BitmapFont to a PCF file
 pub fn save(io: Io, gpa: Allocator, font: BitmapFont, path: []const u8) !void {
-    const codepoints = try font.collectCodepoints(gpa);
-    defer gpa.free(codepoints);
-
-    const glyph_data = try buildGlyphEntries(gpa, font, codepoints);
+    const glyph_data = try buildGlyphEntries(gpa, font);
     defer gpa.free(glyph_data.entries);
     defer gpa.free(glyph_data.bitmap_data);
 
@@ -1044,8 +1043,8 @@ fn expectRoundtrip(file_name: []const u8) !void {
     try testing.expectEqual(font.char_width, loaded.char_width);
     try testing.expectEqual(font.char_height, loaded.char_height);
     try testing.expectEqual(font.glyphCount(), loaded.glyphCount());
-    for (font.first_char..font.last_char + 1) |codepoint| {
-        try testing.expectEqualSlices(u8, font.getCharData(@intCast(codepoint)).?, loaded.getCharData(@intCast(codepoint)).?);
+    for (font.glyphs) |entry| {
+        try testing.expectEqualSlices(u8, font.getCharData(entry.codepoint).?, loaded.getCharData(entry.codepoint).?);
     }
 }
 


### PR DESCRIPTION
## One glyph table for bitmap fonts

`BitmapFont` had two representations: a fixed layout (`first_char`/`last_char`, bitmaps contiguous in `data`, `glyphs == null`) so that `font8x8.basic` could be a comptime constant, and a sparse `AutoHashMap(u32, GlyphData)`. Every consumer branched on which one it held. Both are now **one table**:

```zig
glyphs: []const Entry,   // sorted by codepoint
pub const Entry = struct { codepoint: u21, info: GlyphData };
```

- `getEntry(codepoint)` answers a contiguous table by index (one inline check, O(1) for `basic`) and any other by an out-of-line binary search; `getGlyph` slices the bitmap on top of it; `getCharAdvanceWidth` reads the entry without building a `Glyph`.
- `font8x8.basic` is a comptime-built table over `0x20..0x7E`; `test_font` a three-entry literal via `Entry.cell`.
- Loaders produce sorted tables: bdf sorts by encoding with a later duplicate winning (as the map did, tested); pcf's encoding table already walks codepoints in ascending order, now guaranteed by rejecting byte ranges above 0xFF; `font8x8.create` walks its ranges in order.
- The savers iterate the table directly, so `collectCodepoints` goes; pcf writes `SPACING "C"` when every glyph has the same width and advance (`isMonospace`, which `format` also reports as `.spacing`).
- bdf's fixed-width repacking, `first_char`/`last_char` and every `glyphs != null` branch are deleted.

### API break
Anyone constructing a `BitmapFont` by hand: `first_char`/`last_char` are gone, `glyphs` is a required sorted `[]const Entry`, `glyphCount()` returns `usize`, `format` prints `.spacing = monospace|proportional` instead of `.type = fixed|variable`. Python bindings and examples only use `font8x8.basic`/`create` and are unaffected (`zig build python-bindings` builds).

### Line delta
`+242 / -240` overall across six files; non-test code is **-30 lines** (bdf -45, BitmapFont +10, font8x8 +6, pcf -1), the difference being two new tests (`getEntry` over a sparse table, bdf sort/dedupe).

### Performance
The canvas's 1:1 bitmap blit no longer computes the line extent: it clips per pixel and only the scaled paths use the rect. The old fixed path let LLVM hoist that extent out of the bench loop (`getTextBounds` was 0.6% of samples); a table lookup per character cannot be, and the walk was a second pass over the text for nothing. Without this, `text` measured 1.4x slower; `text_halo` (whose stamping path never computed the extent) was flat throughout, which is what pointed at it.

ReleaseFast, min of 7 interleaved runs, on a machine shared with other builds (noisy; please re-measure serially):



`zig build test` passes, no MD5 fixture in `src/canvas/tests/regression.zig` changed.



ReleaseFast, 512² RGB, min of 7 interleaved runs vs `master`, quiet machine:

| benchmark | old ms | new ms | speedup |
|---|---|---|---|
| text (200 bitmap lines, 1:1) | 0.243 | 0.232 | 1.05x |
| text_halo (100 bitmap halos) | 0.511 | 0.515 | 0.99x |
| vmeasure / vwrap (vector, untouched paths) | | | 1.00x |



**Rebased on #425** (one-file conflict in the tests, resolved by keeping only the new `getEntry` test since the per-type `getTextBounds*` tests moved to `Font` level). Re-gated pinned to a P-core with `perf stat` (cycles, old/new): `text` 1.06×, `text_halo` 1.01×, `vwrap` 0.99×, `vtext_soft` 1.00×, `vmeasure` 1.00×. The first rebase measured `vmeasure` 0.95×: the bigger bitmap `place` inlined into `Pen.next`'s union switch stopped LLVM inlining the UTF-8 decoder there, taxing the vector path; `Pen.next` now inlines the vector arm and calls the bitmap arm out of line (`placeBitmap`), which restores it.
