### PR TITLE
fix(canvas): never read untouched cells of the area accumulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
 - **`RunningStats` now takes a config argument** (breaking): `RunningStats(T)` → `RunningStats(T, config)`, where `RunningStatsConfig` (`.all` / `.variance` / `.summary`) selects which quantities are tracked. Use `.all` for the previous behavior.
 - **Terminal graphics encoders grouped under `terminal`** (breaking): the sixel, kitty, and iterm2 encoders moved out of the top-level namespace into `terminal.*` (`zignal.sixel` → `zignal.terminal.sixel`, `zignal.kitty` → `zignal.terminal.kitty`, `zignal.iterm2` → `zignal.terminal.iterm2`). The source files now live in `src/terminal/`. Detection helpers (`terminal.isSixelSupported`, `terminal.aspectScale`, …) and the `DisplayFormat` tags are unchanged.
 
+### Bug Fixes
+- **Antialiased fills could read a previous fill's coverage**: the nonzero area rasterizer zeroes its accumulator lazily, block by block, but resolved a row by reading every block once the running coverage was nonzero — untouched interior blocks included. Its scratch is reused between fills, so in release builds a shape whose interior crossed a block the previous fill had deposited into could inherit that coverage. Untouched blocks now carry the coverage across without being read.
+
 ## [0.10.0] - 2026-04-15
 
 ### Major Changes

--- a/src/canvas/Canvas.zig
+++ b/src/canvas/Canvas.zig
@@ -57,6 +57,10 @@ const CoverageMax = struct {
         const coverage: u8 = @round(@min(alpha, 1) * 255);
         dest.* = @max(dest.*, coverage);
     }
+
+    inline fn coverRun(sink: CoverageMax, dest: []u8, alpha: f32) void {
+        for (dest) |*px| sink.cover(px, alpha);
+    }
 };
 
 /// How text glyphs are painted.
@@ -253,6 +257,11 @@ pub fn Canvas(comptime T: type) type {
                 if (alpha <= 0) return;
                 if (p.opaqueOver(dest)) return p.mixOpaque(dest, @trunc(255 * alpha));
                 assignPixel(dest, p.rgba.fade(alpha), p.blending);
+            }
+
+            /// `cover` over a run of pixels at one coverage; a full opaque run is a memset.
+            inline fn coverRun(p: Paint, dest: []T, alpha: f32) void {
+                if (alpha >= 1 and p.overwrite) @memset(dest, p.solid) else for (dest) |*px| p.cover(px, alpha);
             }
 
             /// `cover` with 8-bit coverage, as stored in masks; the byte is used as is rather
@@ -1397,11 +1406,20 @@ pub fn Canvas(comptime T: type) type {
                 const row_px = self.image.data[(row_start + r) * self.image.stride ..];
                 var sum: f32 = 0;
                 for (row_touched, 0..) |flag, b| {
-                    if (flag == 0 and @abs(sum) <= threshold) continue;
+                    const held = @abs(sum);
+                    if (flag == 0 and held <= threshold) continue;
                     // Cells before the visible range only feed the sum.
                     const lo = b * area_block;
                     const hi = @min(lo + area_block, visible_hi);
-                    const paint_from = @max(lo, visible_lo);
+                    const paint_from = clamp(visible_lo, lo, lo + area_block);
+                    if (flag == 0) {
+                        // An untouched block was never zeroed, so its cells are not read: it
+                        // holds no deposits and the coverage carries across it unchanged.
+                        if (paint_from >= hi) continue;
+                        const px_base: usize = @intCast(col_start + @as(i64, @intCast(paint_from)));
+                        sink.coverRun(row_px[px_base..][0 .. hi - paint_from], if (held >= 1 - threshold) 1 else held);
+                        continue;
+                    }
                     for (row_acc[lo..paint_from]) |a| sum += a;
                     if (paint_from >= hi) continue;
                     const px_base: usize = @intCast(col_start + @as(i64, @intCast(paint_from)));

--- a/src/canvas/tests/drawing.zig
+++ b/src/canvas/tests/drawing.zig
@@ -931,3 +931,27 @@ test "text boxes on a grayscale canvas" {
     for (img.data) |px| lit += @intFromBool(px > 0);
     try expect(lit > 0);
 }
+
+test "a soft fill is unaffected by the fill before it" {
+    // The area accumulator is stack scratch reused across fills; a shape whose interior
+    // crosses a block the previous fill deposited into must not read those cells.
+    const allocator = testing.allocator;
+    var alone: Image(Rgba) = try .init(allocator, 120, 120);
+    defer alone.deinit(allocator);
+    var after: Image(Rgba) = try .init(allocator, 120, 120);
+    defer after.deinit(allocator);
+    alone.fill(Rgba.white);
+    after.fill(Rgba.white);
+    const canvas_alone: Canvas(Rgba) = .init(allocator, alone);
+    const canvas_after: Canvas(Rgba) = .init(allocator, after);
+
+    // A tall triangle whose slanted edge sweeps every block of its rows, then a wide quad
+    // whose interior spans untouched blocks on the same rows.
+    const triangle = [_]Point(2, f32){ .init(.{ 5, 5 }), .init(.{ 110, 8 }), .init(.{ 7, 112 }) };
+    const quad = [_]Point(2, f32){ .init(.{ 10, 20 }), .init(.{ 100, 24 }), .init(.{ 104, 96 }), .init(.{ 12, 100 }) };
+    try canvas_after.fillPolygons(&.{&triangle}, Rgba.black, .nonzero, .soft);
+    after.fill(Rgba.white);
+    try canvas_after.fillPolygons(&.{&quad}, Rgba.black, .nonzero, .soft);
+    try canvas_alone.fillPolygons(&.{&quad}, Rgba.black, .nonzero, .soft);
+    try testing.expectEqualSlices(Rgba, alone.data, after.data);
+}


### PR DESCRIPTION
## The bug

`fillPolygonArea` zeroes its accumulator lazily (a block of 8 cells the first time an edge deposits into it), and the resolve skips an untouched block only while the running coverage is zero. Inside a shape the coverage is nonzero, so:

- every untouched interior block between two walls was read cell by cell, and
- for a shape starting left of the image, the pre-visible sum ran from the block's first cell up to the first visible cell — past the block's end.

Those cells were never written by the current fill. The scratch is the same stack buffer on every call, so they hold the previous fill's deposits: a lone edge crossing left there leaks a full unit of coverage into the next shape's interior, which then keeps painting past its own far wall for the rest of that row.

Master mostly gets away with it because a fill larger than the stack scratch lands on freshly mapped heap pages, and shapes that fit tend to have both walls within one block (deposits cancel). A ReleaseFast probe (draw a random polygon alone vs. right after another fill, all within the scratch) found **187/300** rendering differently; Debug builds pattern-fill `undefined` stack memory on each call and never show it.

## The fix

An untouched block now carries the held coverage across without being read (its visible cells are painted at that value, a memset via `Paint.coverRun` when opaque; `CoverageMax.coverRun` for masks), and the pre-visible sum stops at the block's end. Everything else in `Canvas.zig` is byte-identical to master.

- Regression test: `"a soft fill is unaffected by the fill before it"` in `src/canvas/tests/drawing.zig` (wide quad after a tall triangle whose slanted edge touched every block of its rows, compared to the quad alone). Because Debug builds refresh the scratch on every call, it guards the release behaviour by construction rather than failing on master in Debug; the ReleaseFast probe is 0/300 with the fix.
- All 45 fixtures keep their master hashes (`-Dprint-md5sums=true`). `zig build test` and `zig build python-bindings` pass.
- CHANGELOG: one Bug Fixes bullet.

## Tried and dropped (for the record)

This branch started as routing thick `drawLine` through the stroker, then as a rasterizer speedup; both were measured and dropped, leaving only the correctness fix.

- **Thick lines through `strokePath`** (one nonzero fill, exact round caps, no double-blended caps): even after the rasterizer work it lost on the common cases — `thick_soft` 0.85×, `thick_fast` 0.83×, `axis_soft` 0.64×, `short_soft` 0.56× — and won only on wide or translucent lines (`thick_soft_w12` 1.2×, `thick_soft_blend` 1.5×). The distance/rectangle line renderers stay.
- **Row banding of the accumulator, per-row touched spans, branch-free block clearing, NaN-free clamps, exact cap-arc end**: pinned to a P-core with `perf stat` (unpinned wall-clock on this hybrid CPU had shown 1.2–1.3× that was core migration), vs master: `vtext_soft` 1.07× faster in cycles but +5% instructions, `vwrap` 1.06× *slower* (+5.7% instructions and cycles), `spline4` +51% instructions and 1.03× slower, `tri_soft`/`polygon1` identical. Not worth the code; dropped.

## Diff

`src/canvas/Canvas.zig` +20/−2, `src/canvas/tests/drawing.zig` +24, `CHANGELOG.md` +3.
