### PR TITLE
Convolution cleanup and a few speedups

### DIFF
--- a/src/image/channel_ops.zig
+++ b/src/image/channel_ops.zig
@@ -88,6 +88,21 @@ pub fn splitChannelsWithUniform(comptime T: type, image: Image(T), allocator: st
     };
 }
 
+/// SIMD lanes for (de)interleaving a padding-free struct row viewed as a flat field array;
+/// null when the struct has padding and the row cannot be reinterpreted.
+fn interleaveLanes(comptime T: type) ?usize {
+    if (@sizeOf(T) != Image(T).channels() * @sizeOf(FieldTypeOf(T))) return null;
+    return std.simd.suggestVectorLength(FieldTypeOf(T)) orelse null;
+}
+
+/// Position of each field inside the flat field array (fields may be laid out in any order).
+fn fieldSlots(comptime T: type) [Image(T).channels()]usize {
+    const fields = meta.structFields(T);
+    var slots: [fields.len]usize = undefined;
+    for (fields, &slots) |field, *slot| slot.* = @offsetOf(T, field.name) / @sizeOf(FieldTypeOf(T));
+    return slots;
+}
+
 /// Separate all channels from a struct image into individual planes.
 /// Allocates and fills channel planes for all fields.
 /// The caller is responsible for freeing the returned slices.
@@ -99,16 +114,26 @@ pub fn splitChannels(comptime T: type, image: Image(T), allocator: std.mem.Alloc
 
     const channels = try allocPlanes(FieldType, num_channels, allocator, plane_size);
 
-    // Branch-free deinterleave over one contiguous row at a time (rows handle views).
+    // One contiguous row at a time (rows handle views): SIMD deinterleave, scalar tail.
     var idx: usize = 0;
     for (0..image.rows) |r| {
         const row = image.data[r * image.stride ..][0..image.cols];
-        for (row) |pixel| {
-            inline for (fields, 0..) |field, i| {
-                channels[i][idx] = @field(pixel, field.name);
+        var c: usize = 0;
+        if (comptime interleaveLanes(T)) |lanes| {
+            const slots = comptime fieldSlots(T);
+            const flat: [*]const FieldType = @ptrCast(row.ptr);
+            while (c + lanes <= row.len) : (c += lanes) {
+                const v: @Vector(num_channels * lanes, FieldType) = flat[c * num_channels ..][0 .. num_channels * lanes].*;
+                const planes = std.simd.deinterlace(num_channels, v);
+                inline for (slots, 0..) |slot, i| channels[i][idx + c ..][0..lanes].* = planes[slot];
             }
-            idx += 1;
         }
+        for (row[c..], c..) |pixel, cc| {
+            inline for (fields, 0..) |field, i| {
+                channels[i][idx + cc] = @field(pixel, field.name);
+            }
+        }
+        idx += row.len;
     }
 
     return channels;
@@ -116,19 +141,31 @@ pub fn splitChannels(comptime T: type, image: Image(T), allocator: std.mem.Alloc
 
 /// Combine channels back into struct image.
 pub fn mergeChannels(comptime T: type, channels: [Image(T).channels()][]const FieldTypeOf(T), out: Image(T)) void {
+    const num_channels = comptime Image(T).channels();
     const fields = comptime meta.structFields(T);
+    const FieldType = FieldTypeOf(T);
 
     var idx: usize = 0;
     for (0..out.rows) |r| {
         const row = out.data[r * out.stride ..][0..out.cols];
-        for (row) |*pixel| {
+        var c: usize = 0;
+        if (comptime interleaveLanes(T)) |lanes| {
+            const slots = comptime fieldSlots(T);
+            const flat: [*]FieldType = @ptrCast(row.ptr);
+            while (c + lanes <= row.len) : (c += lanes) {
+                var planes: [num_channels]@Vector(lanes, FieldType) = undefined;
+                inline for (slots, 0..) |slot, i| planes[slot] = channels[i][idx + c ..][0..lanes].*;
+                flat[c * num_channels ..][0 .. num_channels * lanes].* = std.simd.interlace(planes);
+            }
+        }
+        for (row[c..], c..) |*pixel, cc| {
             var result_pixel: T = undefined;
             inline for (fields, 0..) |field, i| {
-                @field(result_pixel, field.name) = channels[i][idx];
+                @field(result_pixel, field.name) = channels[i][idx + cc];
             }
             pixel.* = result_pixel;
-            idx += 1;
         }
+        idx += row.len;
     }
 }
 

--- a/src/image/convolution.zig
+++ b/src/image/convolution.zig
@@ -777,12 +777,14 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
             }
         }
 
-        /// Column-tiled 1D pass along rows (src -> dst); tiling keeps the working set cache-resident.
+        /// Column-tiled 1D pass along rows (src -> dst); tiling keeps the working set cache-resident
+        /// and, unlike per-row bases, lets LLVM hoist the tap offsets (row-major measured 0.9x on f32).
         fn vertical(src: Image(SrcT), dst: Image(DstT), allocator: Allocator, kernel: []const KernelT, border_mode: BorderMode) !void {
             const half = kernel.len / 2;
             const rows = src.rows;
             const cols = src.cols;
             const tile_width = @max(vec_len, 16);
+            const folded = isSymmetric(kernel);
 
             if (rows > 2 * half) {
                 const safe_end_r = rows - half;
@@ -794,10 +796,24 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
 
                     while (c + vec_len <= tile_end) : (c += vec_len) {
                         for (half..safe_end_r) |r| {
+                            const base = (r - half) * src.stride + c;
                             var acc: @Vector(vec_len, AccumT) = @splat(0);
-                            for (kernel, 0..) |k, ki| {
-                                if (!isNegligible(k)) {
-                                    acc += loadVec(src.data[(r + ki - half) * src.stride + c ..].ptr) * splatK(k);
+                            if (folded) {
+                                for (kernel[0..half], 0..) |k, i| {
+                                    if (!isNegligible(k)) {
+                                        const a = loadVec(src.data[base + i * src.stride ..].ptr);
+                                        const b = loadVec(src.data[base + (kernel.len - 1 - i) * src.stride ..].ptr);
+                                        acc += (a + b) * splatK(k);
+                                    }
+                                }
+                                if (!isNegligible(kernel[half])) {
+                                    acc += loadVec(src.data[base + half * src.stride ..].ptr) * splatK(kernel[half]);
+                                }
+                            } else {
+                                for (kernel, 0..) |k, ki| {
+                                    if (!isNegligible(k)) {
+                                        acc += loadVec(src.data[base + ki * src.stride ..].ptr) * splatK(k);
+                                    }
                                 }
                             }
                             storeVec(acc, dst.data[r * dst.stride + c ..].ptr);

--- a/src/image/convolution.zig
+++ b/src/image/convolution.zig
@@ -100,17 +100,29 @@ fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usiz
             return result;
         }
 
-        fn convolvePixelWithBorder(comptime n: usize, src: Image(T), dsts: [n]Image(T), r: usize, c: usize, kernels: [n][size]Scalar, border_mode: BorderMode) void {
-            const ir: isize = @intCast(r);
-            const ic: isize = @intCast(c);
+        /// Resolved source columns of one border column's taps; null = zero (.zero border).
+        const ColTaps = [cols]?usize;
+
+        fn colTaps(c: usize, src_cols: usize, border_mode: BorderMode) ColTaps {
+            var taps: ColTaps = undefined;
+            inline for (0..cols) |kx| {
+                taps[kx] = border.resolveIndex(@as(isize, @intCast(c)) + @as(isize, kx) - half_w, @intCast(src_cols), border_mode);
+            }
+            return taps;
+        }
+
+        /// One border-column pixel from pre-resolved row offsets and column taps.
+        fn convolveBorderPixel(comptime n: usize, src: Image(T), dsts: [n]Image(T), row_offsets: RowOffsets(true), col_taps: ColTaps, kernels: [n][size]Scalar, r: usize, c: usize) void {
             var results: [n]Scalar = @splat(0);
             inline for (0..rows) |ky| {
-                inline for (0..cols) |kx| {
-                    const iry = ir + @as(isize, ky) - half_h;
-                    const icx = ic + @as(isize, kx) - half_w;
-                    const pixel_val: Scalar = border.getPixel(T, src, iry, icx, border_mode);
-                    inline for (0..n) |i| {
-                        results[i] += pixel_val * kernels[i][ky * cols + kx];
+                if (row_offsets[ky]) |base| {
+                    inline for (0..cols) |kx| {
+                        if (col_taps[kx]) |sc| {
+                            const pixel_val = Pixels.promote(src.data[base + sc]);
+                            inline for (0..n) |i| {
+                                results[i] += pixel_val * kernels[i][ky * cols + kx];
+                            }
+                        }
                     }
                 }
             }
@@ -191,33 +203,34 @@ fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usiz
                 }
             }
 
+            // Border columns [0, low_end) and [high_start, cols) resolve the same taps on every
+            // row, so they are resolved once per call; table ordinal = low positions first.
+            const low_end = @min(half_w, src.cols);
+            const high_start = if (src.cols > 2 * half_w) src.cols - half_w else low_end;
+            var col_taps: [2 * half_w]ColTaps = undefined;
+            for (0..low_end) |c| col_taps[c] = colTaps(c, src.cols, border_mode);
+            for (high_start..src.cols) |c| col_taps[low_end + c - high_start] = colTaps(c, src.cols, border_mode);
+
             for (0..src.rows) |r| {
-                var c: usize = 0;
-                while (c < @min(half_w, src.cols)) : (c += 1) {
-                    convolvePixelWithBorder(n, src, dsts, r, c, kernels, border_mode);
+                const ir: isize = @intCast(r);
+                var offs: RowOffsets(true) = undefined;
+                inline for (0..rows) |ky| {
+                    const resolved = border.resolveIndex(ir + @as(isize, ky) - half_h, @intCast(src.rows), border_mode);
+                    offs[ky] = if (resolved) |sr| sr * src.stride else null;
                 }
 
-                const safe_end = src.cols -| half_w;
-                const row_in_band = r >= half_h and r + half_h < src.rows;
-                if (row_in_band) {
-                    var offs: RowOffsets(false) = undefined;
-                    inline for (0..rows) |ky| {
-                        offs[ky] = (r + ky - half_h) * src.stride;
-                    }
-                    convolveRowSpan(n, false, src, dsts, offs, kernels, &kernel_vecs, r, c, safe_end);
+                for (0..low_end) |c| {
+                    convolveBorderPixel(n, src, dsts, offs, col_taps[c], kernels, r, c);
+                }
+                if (r >= half_h and r + half_h < src.rows) {
+                    var in_band: RowOffsets(false) = undefined;
+                    inline for (0..rows) |ky| in_band[ky] = offs[ky].?;
+                    convolveRowSpan(n, false, src, dsts, in_band, kernels, &kernel_vecs, r, low_end, high_start);
                 } else {
-                    const ir: isize = @intCast(r);
-                    var offs: RowOffsets(true) = undefined;
-                    inline for (0..rows) |ky| {
-                        const resolved = border.resolveIndex(ir + @as(isize, ky) - half_h, @intCast(src.rows), border_mode);
-                        offs[ky] = if (resolved) |sr| sr * src.stride else null;
-                    }
-                    convolveRowSpan(n, true, src, dsts, offs, kernels, &kernel_vecs, r, c, safe_end);
+                    convolveRowSpan(n, true, src, dsts, offs, kernels, &kernel_vecs, r, low_end, high_start);
                 }
-
-                c = @max(c, safe_end);
-                while (c < src.cols) : (c += 1) {
-                    convolvePixelWithBorder(n, src, dsts, r, c, kernels, border_mode);
+                for (high_start..src.cols) |c| {
+                    convolveBorderPixel(n, src, dsts, offs, col_taps[low_end + c - high_start], kernels, r, c);
                 }
             }
         }

--- a/src/image/convolution.zig
+++ b/src/image/convolution.zig
@@ -39,64 +39,33 @@ inline fn divClampU8Vec(
     return @intCast(@max(zero_vec, @min(max_vec, shifted)));
 }
 
-/// Quantizes an f32 kernel weight to `fixed_point_scale` fixed-point.
-inline fn quantizeWeight(weight: f32) i32 {
-    return @round(weight * fixed_point_scale);
-}
-
-/// Corrects independently-rounded taps so their sum matches the f32 kernel's intended
-/// gain: the residual lands on the largest-magnitude tap (relative error <= 1/|k_max|).
-/// Without this, correlated rounding drifts the overall gain — a uniform 1/30 kernel
-/// quantizes to 30*9 = 270/256, brightening by +5.5% and clipping highlights.
+/// Quantizes f32 weights to `fixed_point_scale` fixed-point taps, then corrects the
+/// independently-rounded taps so their sum matches the f32 kernel's intended gain: the
+/// residual lands on the largest-magnitude tap (relative error <= 1/|k_max|). Without
+/// this, correlated rounding drifts the overall gain — a uniform 1/30 kernel quantizes
+/// to 30*9 = 270/256, brightening by +5.5% and clipping highlights.
 /// For all-equal taps the strict `>` puts the residual on tap 0 — `isUniformBody`
 /// relies on that shape to detect uniform kernels after quantization.
-fn renormalizeQuantized(taps: []i32, weight_sum: f64) void {
+fn quantizeKernel(taps: []i32, weights: []const f32) void {
     if (taps.len == 0) return;
-    const target: i64 = @round(fixed_point_scale * weight_sum);
+    var weight_sum: f64 = 0;
     var sum: i64 = 0;
     var largest: usize = 0;
-    for (taps, 0..) |k, i| {
-        sum += k;
-        if (@abs(k) > @abs(taps[largest])) largest = i;
+    for (taps, weights, 0..) |*t, w, i| {
+        t.* = @round(w * fixed_point_scale);
+        weight_sum += w;
+        sum += t.*;
+        if (@abs(t.*) > @abs(taps[largest])) largest = i;
     }
+    const target: i64 = @round(fixed_point_scale * weight_sum);
     taps[largest] += @intCast(target - sum);
 }
 
-fn PixelIO(comptime T: type, comptime vec_len: usize, comptime scale: comptime_int) type {
-    if (T != u8 and T != f32) {
-        @compileError("PixelIO only supports u8 and f32 types");
-    }
-
-    return struct {
-        // i32 is safe for any u8 2D kernel: |accum| <= 255 * sum|k| stays within i32 for
-        // kernel magnitude sums up to ~8.4M fixed-point units (~32k in weight units).
-        const Scalar = if (T == u8) i32 else f32;
-
-        inline fn load(value: T) Scalar {
-            return value;
-        }
-
-        inline fn loadVec(src: []const T, offset: usize) @Vector(vec_len, Scalar) {
-            if (T == u8) {
-                const u8_vec: @Vector(vec_len, u8) = src[offset..][0..vec_len].*;
-                return @intCast(u8_vec);
-            } else {
-                return src[offset..][0..vec_len].*;
-            }
-        }
-
-        inline fn store(accum: Scalar) T {
-            return if (T == u8) divClampU8(scale, accum) else accum;
-        }
-
-        inline fn storeVec(accum_vec: @Vector(vec_len, Scalar), dst: []T, offset: usize) void {
-            if (T == u8) {
-                dst[offset..][0..vec_len].* = divClampU8Vec(scale, accum_vec);
-            } else {
-                dst[offset..][0..vec_len].* = accum_vec;
-            }
-        }
-    };
+/// Sum of quantized taps in `fixed_point_scale` units.
+fn sumTaps(taps: []const i32) i64 {
+    var sum: i64 = 0;
+    for (taps) |k| sum += k;
+    return sum;
 }
 
 fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usize) type {
@@ -109,45 +78,39 @@ fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usiz
         const half_h = rows / 2;
         const half_w = cols / 2;
 
-        const KernelScalar = if (T == u8) i32 else f32;
-        const AccumScalar = if (T == u8) i32 else f32;
-
-        const vec_len = std.simd.suggestVectorLength(AccumScalar) orelse 1;
-
-        const Pixels = PixelIO(T, vec_len, fixed_point_scale);
+        /// Load/store policy shared with the single separable pass (same src/dst type).
+        const Pixels = SeparablePass(T, T, i32);
+        /// Taps and accumulators share one scalar: i32 fixed-point for u8 (|accum| <= 255 *
+        /// sum|k| fits for kernel magnitude sums up to ~32k in weight units), f32 otherwise.
+        const Scalar = Pixels.AccumT;
+        const vec_len = Pixels.vec_len;
 
         /// Flattens a 2D kernel into a 1D array; for `u8` images, values are scaled by
         /// `fixed_point_scale`, rounded, and sum-corrected to preserve the kernel's gain.
-        fn flatten(kernel: anytype) [size]KernelScalar {
-            var result: [size]KernelScalar = undefined;
-            var weight_sum: f64 = 0;
-            var idx: usize = 0;
+        fn flatten(kernel: anytype) [size]Scalar {
+            var weights: [size]f32 = undefined;
             inline for (0..rows) |kr| {
                 inline for (0..cols) |kx| {
-                    const val = as(f32, kernel[kr][kx]);
-                    result[idx] = if (T == u8) quantizeWeight(val) else val;
-                    weight_sum += val;
-                    idx += 1;
+                    weights[kr * cols + kx] = as(f32, kernel[kr][kx]);
                 }
             }
-            if (T == u8) {
-                renormalizeQuantized(&result, weight_sum);
-            }
+            if (T == f32) return weights;
+            var result: [size]i32 = undefined;
+            quantizeKernel(&result, &weights);
             return result;
         }
 
-        fn convolvePixelWithBorder(comptime n: usize, src: Image(T), dsts: [n]Image(T), r: usize, c: usize, kernels: [n][size]KernelScalar, border_mode: BorderMode) void {
+        fn convolvePixelWithBorder(comptime n: usize, src: Image(T), dsts: [n]Image(T), r: usize, c: usize, kernels: [n][size]Scalar, border_mode: BorderMode) void {
             const ir: isize = @intCast(r);
             const ic: isize = @intCast(c);
-            var results: [n]AccumScalar = @splat(0);
+            var results: [n]Scalar = @splat(0);
             inline for (0..rows) |ky| {
                 inline for (0..cols) |kx| {
                     const iry = ir + @as(isize, ky) - half_h;
                     const icx = ic + @as(isize, kx) - half_w;
-                    const pixel_val: AccumScalar = border.getPixel(T, src, iry, icx, border_mode);
+                    const pixel_val: Scalar = border.getPixel(T, src, iry, icx, border_mode);
                     inline for (0..n) |i| {
-                        const k_val: AccumScalar = kernels[i][ky * cols + kx];
-                        results[i] += pixel_val * k_val;
+                        results[i] += pixel_val * kernels[i][ky * cols + kx];
                     }
                 }
             }
@@ -171,46 +134,43 @@ fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usiz
             src: Image(T),
             dsts: [n]Image(T),
             row_offsets: RowOffsets(maybe_zero),
-            kernels: [n][size]KernelScalar,
-            kernel_vecs: *const [n][size]@Vector(vec_len, AccumScalar),
+            kernels: [n][size]Scalar,
+            kernel_vecs: *const [n][size]@Vector(vec_len, Scalar),
             r: usize,
             c_start: usize,
             c_end: usize,
         ) void {
             var c = c_start;
 
-            if (src.cols >= vec_len + 2 * half_w) {
-                while (c + vec_len <= c_end) : (c += vec_len) {
-                    var result_vecs: [n]@Vector(vec_len, AccumScalar) = @splat(@splat(0));
-                    inline for (0..rows) |ky| {
-                        // Runtime `continue` is not allowed in an inline for; the wrapping
-                        // `if` folds away at comptime when `maybe_zero` is false.
-                        if (if (maybe_zero) row_offsets[ky] != null else true) {
-                            const base = if (maybe_zero) row_offsets[ky].? else row_offsets[ky];
-                            inline for (0..cols) |kx| {
-                                const pixel_vec = Pixels.loadVec(src.data, base + c + kx - half_w);
-                                inline for (0..n) |i| {
-                                    result_vecs[i] += pixel_vec * kernel_vecs[i][ky * cols + kx];
-                                }
+            while (c + vec_len <= c_end) : (c += vec_len) {
+                var result_vecs: [n]@Vector(vec_len, Scalar) = @splat(@splat(0));
+                inline for (0..rows) |ky| {
+                    // Runtime `continue` is not allowed in an inline for; the wrapping
+                    // `if` folds away at comptime when `maybe_zero` is false.
+                    if (if (maybe_zero) row_offsets[ky] != null else true) {
+                        const base = if (maybe_zero) row_offsets[ky].? else row_offsets[ky];
+                        inline for (0..cols) |kx| {
+                            const pixel_vec = Pixels.loadVec(src.data[base + c + kx - half_w ..].ptr);
+                            inline for (0..n) |i| {
+                                result_vecs[i] += pixel_vec * kernel_vecs[i][ky * cols + kx];
                             }
                         }
                     }
-                    inline for (0..n) |i| {
-                        Pixels.storeVec(result_vecs[i], dsts[i].data, r * dsts[i].stride + c);
-                    }
+                }
+                inline for (0..n) |i| {
+                    Pixels.storeVec(result_vecs[i], dsts[i].data[r * dsts[i].stride + c ..].ptr);
                 }
             }
 
             while (c < c_end) : (c += 1) {
-                var results: [n]AccumScalar = @splat(0);
+                var results: [n]Scalar = @splat(0);
                 inline for (0..rows) |ky| {
                     if (if (maybe_zero) row_offsets[ky] != null else true) {
                         const base = if (maybe_zero) row_offsets[ky].? else row_offsets[ky];
                         inline for (0..cols) |kx| {
-                            const pixel_val = Pixels.load(src.data[base + c + kx - half_w]);
+                            const pixel_val = Pixels.promote(src.data[base + c + kx - half_w]);
                             inline for (0..n) |i| {
-                                const k_val: AccumScalar = kernels[i][ky * cols + kx];
-                                results[i] += pixel_val * k_val;
+                                results[i] += pixel_val * kernels[i][ky * cols + kx];
                             }
                         }
                     }
@@ -223,12 +183,11 @@ fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usiz
 
         /// Applies `n` same-shaped kernels in a single pass over `src`; each source pixel is
         /// loaded once and feeds every kernel's accumulator.
-        fn convolveMulti(comptime n: usize, src: Image(T), dsts: [n]Image(T), kernels: [n][size]KernelScalar, border_mode: BorderMode) void {
-            var kernel_vecs: [n][size]@Vector(vec_len, AccumScalar) = undefined;
+        fn convolveMulti(comptime n: usize, src: Image(T), dsts: [n]Image(T), kernels: [n][size]Scalar, border_mode: BorderMode) void {
+            var kernel_vecs: [n][size]@Vector(vec_len, Scalar) = undefined;
             inline for (0..n) |i| {
                 inline for (0..size) |j| {
-                    const k_val: AccumScalar = kernels[i][j];
-                    kernel_vecs[i][j] = @splat(k_val);
+                    kernel_vecs[i][j] = @splat(kernels[i][j]);
                 }
             }
 
@@ -261,10 +220,6 @@ fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usiz
                     convolvePixelWithBorder(n, src, dsts, r, c, kernels, border_mode);
                 }
             }
-        }
-
-        fn convolve(src: Image(T), dst: Image(T), kernel: [size]KernelScalar, border_mode: BorderMode) void {
-            convolveMulti(1, src, .{dst}, .{kernel}, border_mode);
         }
     };
 }
@@ -306,27 +261,21 @@ pub fn convolve(comptime T: type, self: Image(T), out: Image(T), allocator: Allo
     switch (T) {
         u8, f32 => {
             const Kernel = ConvolutionKernel(T, kernel_height, kernel_width);
-            const flat_kernel = Kernel.flatten(kernel);
-            Kernel.convolve(self, out, flat_kernel, border_mode);
+            Kernel.convolveMulti(1, self, .{out}, .{Kernel.flatten(kernel)}, border_mode);
         },
         else => switch (@typeInfo(T)) {
             .@"struct" => {
                 if (comptime meta.allFieldsAreU8(T)) {
                     const Kernel = ConvolutionKernel(u8, kernel_height, kernel_width);
                     const kernel_int = Kernel.flatten(kernel);
-                    var kernel_sum: i64 = 0;
-                    inline for (kernel_int) |weight| {
-                        kernel_sum += weight;
-                    }
-
                     const PlaneCtx = struct {
-                        kernel: [Kernel.size]Kernel.KernelScalar,
+                        kernel: [Kernel.size]i32,
 
                         fn convolvePlane(ctx: @This(), src: Image(u8), dst: Image(u8), mode: BorderMode) !void {
-                            Kernel.convolve(src, dst, ctx.kernel, mode);
+                            Kernel.convolveMulti(1, src, .{dst}, .{ctx.kernel}, mode);
                         }
                     };
-                    try convolvePlanes(T, self, out, allocator, kernel_sum, fixed_point_scale, border_mode, PlaneCtx{ .kernel = kernel_int });
+                    try convolvePlanes(T, self, out, allocator, sumTaps(&kernel_int), fixed_point_scale, border_mode, PlaneCtx{ .kernel = kernel_int });
                 } else {
                     @compileError("Convolution only supports structs where all fields are u8. Type " ++ @typeName(T) ++ " is not supported.");
                 }
@@ -400,31 +349,22 @@ fn convolvePlanes(
 
 fn scaleKernelToInt(allocator: Allocator, kernel: []const f32) ![]i32 {
     const result = try allocator.alloc(i32, kernel.len);
-    var weight_sum: f64 = 0;
-    for (result, kernel) |*r, k| {
-        r.* = quantizeWeight(k);
-        weight_sum += k;
-    }
-    renormalizeQuantized(result, weight_sum);
+    quantizeKernel(result, kernel);
     return result;
 }
 
-/// A 1-tap identity kernel makes its whole pass a copy; detected on the raw f32 kernel so
-/// the check is shared by every pixel-type arm.
-inline fn isIdentityKernel(kernel: []const f32) bool {
-    return kernel.len == 1 and kernel[0] == 1;
+/// A 1-tap identity kernel makes its whole pass a copy. In quantized units the identity
+/// tap is exactly `fixed_point_scale` (1.0 quantizes to it with no residual).
+inline fn isIdentityKernel(kernel: anytype) bool {
+    const one = if (@TypeOf(kernel[0]) == i32) fixed_point_scale else 1;
+    return kernel.len == 1 and kernel[0] == one;
 }
 
 /// True when all taps except possibly the first are equal — the shape of a quantized
-/// uniform kernel after `renormalizeQuantized` parks the rounding residual on tap 0.
+/// uniform kernel after `quantizeKernel` parks the rounding residual on tap 0.
 /// Such kernels (axis-aligned motion blur) collapse to an O(1)/pixel running sum.
-fn isUniformBody(kernel: anytype) bool {
-    if (kernel.len < 2) return false;
-    const k = kernel[1];
-    for (kernel[2..]) |tap| {
-        if (tap != k) return false;
-    }
-    return true;
+fn isUniformBody(kernel: []const i32) bool {
+    return kernel.len >= 2 and channel_ops.findUniformValue(i32, kernel[1..]) != null;
 }
 
 /// True when i32 accumulators cannot overflow for these quantized kernels: the horizontal
@@ -462,10 +402,9 @@ fn convolveSeparableAuto(
 }
 
 /// Per-plane separable driver owning the strategy choice: identity axes skip their pass
-/// entirely (a u8 single pass carries one `fixed_point_scale`, exact because
-/// divTrunc(256*S ± 32768, 65536) == divTrunc(S ± 128, 256)), uniform-body kernels take
-/// the O(1)/pixel running-sum box passes, large planes take the fused ring path, and
-/// everything else runs the standard two-pass over a temp plane.
+/// entirely, uniform-body kernels take the O(1)/pixel running-sum box passes, large
+/// planes take the fused ring path, and everything else runs the standard two-pass over
+/// a temp plane.
 /// `cached_temp` lets struct-pixel callers reuse one temp allocation across planes.
 fn convolveSeparableAutoImpl(
     comptime PixelT: type,
@@ -479,11 +418,9 @@ fn convolveSeparableAutoImpl(
     border_mode: BorderMode,
     cached_temp: ?*[]TempT,
 ) !void {
-    // In TempT units a 1-tap identity is exactly `one` (1.0 quantizes to fixed_point_scale).
-    const one: TempT = if (TempT == i32) fixed_point_scale else 1;
-    const identity_x = kernel_x.len == 1 and kernel_x[0] == one;
-    const identity_y = kernel_y.len == 1 and kernel_y[0] == one;
-    const SinglePass = SeparablePass(PixelT, PixelT, if (PixelT == u8) fixed_point_scale else 1, AccumIntT);
+    const identity_x = isIdentityKernel(kernel_x);
+    const identity_y = isIdentityKernel(kernel_y);
+    const SinglePass = SeparablePass(PixelT, PixelT, AccumIntT);
 
     if (identity_x and identity_y) {
         src.copy(dst);
@@ -501,13 +438,12 @@ fn convolveSeparableAutoImpl(
         }
     } else if (useFusedSeparable(TempT, src.rows, src.cols, kernel_y.len, border_mode)) {
         try convolveSeparablePlaneFused(PixelT, TempT, AccumIntT, src, dst, allocator, kernel_x, kernel_y, border_mode);
-    } else if (cached_temp) |temp_slot| {
+    } else {
+        var owned: []TempT = &.{};
+        defer allocator.free(owned);
+        const temp_slot = cached_temp orelse &owned;
         if (temp_slot.len == 0) temp_slot.* = try allocator.alloc(TempT, @as(usize, src.rows) * src.cols);
         const temp = Image(TempT).initFromSlice(src.rows, src.cols, temp_slot.*);
-        try convolveSeparablePlane(PixelT, TempT, AccumIntT, src, dst, temp, allocator, kernel_x, kernel_y, border_mode);
-    } else {
-        var temp = try Image(TempT).initLike(allocator, src);
-        defer temp.deinit(allocator);
         try convolveSeparablePlane(PixelT, TempT, AccumIntT, src, dst, temp, allocator, kernel_x, kernel_y, border_mode);
     }
 }
@@ -523,54 +459,40 @@ pub fn convolveSeparable(
     kernel_y: []const f32,
     border_mode: BorderMode,
 ) !void {
+    comptime if (T != u8 and T != f32 and !(@typeInfo(T) == .@"struct" and meta.allFieldsAreU8(T))) {
+        @compileError("Separable convolution only supports u8, f32, and structs with all u8 fields. Type " ++ @typeName(T) ++ " is not supported.");
+    };
+
     if (isIdentityKernel(kernel_x) and isIdentityKernel(kernel_y)) {
         image.copy(out);
-        return;
-    }
+    } else if (T == f32) {
+        try convolveSeparableAuto(f32, f32, image, out, allocator, kernel_x, kernel_y, border_mode, null);
+    } else {
+        // u8 planes, bare or struct fields, run on quantized kernels.
+        const kernel_x_int = try scaleKernelToInt(allocator, kernel_x);
+        defer allocator.free(kernel_x_int);
+        const kernel_y_int = try scaleKernelToInt(allocator, kernel_y);
+        defer allocator.free(kernel_y_int);
 
-    switch (T) {
-        u8 => {
-            const kernel_x_int = try scaleKernelToInt(allocator, kernel_x);
-            defer allocator.free(kernel_x_int);
-            const kernel_y_int = try scaleKernelToInt(allocator, kernel_y);
-            defer allocator.free(kernel_y_int);
-
+        if (T == u8) {
             try convolveSeparableAuto(u8, i32, image, out, allocator, kernel_x_int, kernel_y_int, border_mode, null);
-        },
-        f32 => try convolveSeparableAuto(f32, f32, image, out, allocator, kernel_x, kernel_y, border_mode, null),
-        else => switch (@typeInfo(T)) {
-            .@"struct" => {
-                if (comptime meta.allFieldsAreU8(T)) {
-                    const kernel_x_int = try scaleKernelToInt(allocator, kernel_x);
-                    defer allocator.free(kernel_x_int);
-                    const kernel_y_int = try scaleKernelToInt(allocator, kernel_y);
-                    defer allocator.free(kernel_y_int);
+        } else {
+            const PlaneCtx = struct {
+                allocator: Allocator,
+                kernel_x: []const i32,
+                kernel_y: []const i32,
+                temp: []i32 = &.{},
 
-                    // Separable kernel sum is the product of 1D sums; each 1D sum is scaled by fixed_point_scale.
-                    var kx_sum: i64 = 0;
-                    for (kernel_x_int) |w| kx_sum += w;
-                    var ky_sum: i64 = 0;
-                    for (kernel_y_int) |w| ky_sum += w;
-
-                    const PlaneCtx = struct {
-                        allocator: Allocator,
-                        kernel_x: []const i32,
-                        kernel_y: []const i32,
-                        temp: []i32 = &.{},
-
-                        fn convolvePlane(ctx: *@This(), src: Image(u8), dst: Image(u8), mode: BorderMode) !void {
-                            try convolveSeparableAuto(u8, i32, src, dst, ctx.allocator, ctx.kernel_x, ctx.kernel_y, mode, &ctx.temp);
-                        }
-                    };
-                    var ctx: PlaneCtx = .{ .allocator = allocator, .kernel_x = kernel_x_int, .kernel_y = kernel_y_int };
-                    defer allocator.free(ctx.temp);
-                    try convolvePlanes(T, image, out, allocator, kx_sum * ky_sum, fixed_point_scale_sq, border_mode, &ctx);
-                } else {
-                    @compileError("Separable convolution only supports structs where all fields are u8. Type " ++ @typeName(T) ++ " is not supported.");
+                fn convolvePlane(ctx: *@This(), src: Image(u8), dst: Image(u8), mode: BorderMode) !void {
+                    try convolveSeparableAuto(u8, i32, src, dst, ctx.allocator, ctx.kernel_x, ctx.kernel_y, mode, &ctx.temp);
                 }
-            },
-            else => @compileError("Separable convolution only supports u8, f32, and structs with all u8 fields. Type " ++ @typeName(T) ++ " is not supported."),
-        },
+            };
+            var ctx: PlaneCtx = .{ .allocator = allocator, .kernel_x = kernel_x_int, .kernel_y = kernel_y_int };
+            defer allocator.free(ctx.temp);
+            // The separable kernel sum is the product of the 1D sums, one `fixed_point_scale` each.
+            const kernel_sum = sumTaps(kernel_x_int) * sumTaps(kernel_y_int);
+            try convolvePlanes(T, image, out, allocator, kernel_sum, fixed_point_scale_sq, border_mode, &ctx);
+        }
     }
 }
 
@@ -596,24 +518,16 @@ const BorderIndexTable = struct {
         const n_positions = low_end + (axis_len - high_start);
         const indices = try allocator.alloc(usize, n_positions * kernel_len);
         var w: usize = 0;
-        for (0..low_end) |pos| {
-            for (0..kernel_len) |i| {
-                indices[w] = resolveTap(pos, i, half, axis_len, border_mode);
-                w += 1;
-            }
-        }
-        for (high_start..axis_len) |pos| {
-            for (0..kernel_len) |i| {
-                indices[w] = resolveTap(pos, i, half, axis_len, border_mode);
-                w += 1;
+        for ([_][2]usize{ .{ 0, low_end }, .{ high_start, axis_len } }) |range| {
+            for (range[0]..range[1]) |pos| {
+                for (0..kernel_len) |tap| {
+                    const idx = @as(isize, @intCast(pos + tap)) - @as(isize, @intCast(half));
+                    indices[w] = border.resolveIndex(idx, @intCast(axis_len), border_mode) orelse zero_sentinel;
+                    w += 1;
+                }
             }
         }
         return .{ .indices = indices, .kernel_len = kernel_len, .low_end = low_end, .high_start = high_start };
-    }
-
-    fn resolveTap(pos: usize, tap: usize, half: usize, axis_len: usize, border_mode: BorderMode) usize {
-        const idx: isize = @as(isize, @intCast(pos)) + @as(isize, @intCast(tap)) - @as(isize, @intCast(half));
-        return border.resolveIndex(idx, @intCast(axis_len), border_mode) orelse zero_sentinel;
     }
 
     fn deinit(self: BorderIndexTable, allocator: Allocator) void {
@@ -631,13 +545,9 @@ const BorderIndexTable = struct {
 };
 
 /// One direction of a separable convolution with load/store policies derived from the
-/// source and destination scalar types. `dst_scale` is the fixed-point divisor applied
-/// when storing to u8; pass 1 for i32/f32 destinations. `AccumIntT` selects the integer
-/// accumulator width (i32 when `narrowAccumFits`, else i64); ignored for f32 passes.
-fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: comptime_int, comptime AccumIntT: type) type {
-    if (DstT != u8 and dst_scale != 1) {
-        @compileError("dst_scale only applies to u8 destinations");
-    }
+/// source and destination scalar types. `AccumIntT` selects the integer accumulator
+/// width (i32 when `narrowAccumFits`, else i64); ignored for f32 passes.
+fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: type) type {
     if (AccumIntT != i32 and AccumIntT != i64) {
         @compileError("AccumIntT must be i32 or i64");
     }
@@ -646,6 +556,10 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
         const KernelT = if (SrcT == f32 or DstT == f32) f32 else i32;
         const AccumT = if (KernelT == f32) f32 else AccumIntT;
         const vec_len = std.simd.suggestVectorLength(KernelT) orelse 1;
+        /// Fixed-point divisor when storing to u8: one `fixed_point_scale` per quantized pass
+        /// (u8 -> u8 single pass carries one, i32 -> u8 second pass carries two). A single
+        /// pass is exact because divTrunc(256*S ± 32768, 65536) == divTrunc(S ± 128, 256).
+        const dst_scale = if (DstT != u8) 1 else if (SrcT == u8) fixed_point_scale else fixed_point_scale_sq;
 
         inline fn isNegligible(k: KernelT) bool {
             return if (KernelT == f32) @abs(k) < 1e-10 else k == 0;
@@ -657,7 +571,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
         fn isSymmetric(kernel: []const KernelT) bool {
             // Folding measured slower past ~32 taps (two opposing load streams); the
             // dense multiply win only holds for short-to-medium kernels.
-            if (kernel.len % 2 == 0 or kernel.len > 32) return false;
+            if (KernelT != i32 or kernel.len % 2 == 0 or kernel.len > 32) return false;
             for (kernel[0 .. kernel.len / 2], 0..) |k, i| {
                 if (k != kernel[kernel.len - 1 - i]) return false;
             }
@@ -671,6 +585,10 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
         inline fn loadVec(ptr: [*]const SrcT) @Vector(vec_len, AccumT) {
             const v: @Vector(vec_len, SrcT) = ptr[0..vec_len].*;
             return promote(v);
+        }
+
+        inline fn splatK(k: KernelT) @Vector(vec_len, AccumT) {
+            return @splat(promote(k));
         }
 
         inline fn store(val: AccumT) DstT {
@@ -711,7 +629,8 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
         }
 
         /// One row of the horizontal pass into a caller-provided contiguous row buffer.
-        fn horizontalRow(src: Image(SrcT), dst_row: []DstT, r: usize, kernel: []const KernelT, table: BorderIndexTable, folded: bool) void {
+        /// Kept out of line: inlined into the fused driver it measured 4-8% slower.
+        noinline fn horizontalRow(src: Image(SrcT), dst_row: []DstT, r: usize, kernel: []const KernelT, table: BorderIndexTable, folded: bool) void {
             const half = kernel.len / 2;
             const cols = src.cols;
             const src_offset = r * src.stride;
@@ -732,13 +651,11 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
                             if (!isNegligible(k)) {
                                 const a = loadVec(src.data[base + i ..].ptr);
                                 const b = loadVec(src.data[base + (kernel.len - 1 - i) ..].ptr);
-                                const k_vec: @Vector(vec_len, AccumT) = @splat(promote(k));
-                                acc += (a + b) * k_vec;
+                                acc += (a + b) * splatK(k);
                             }
                         }
                         if (!isNegligible(kernel[half])) {
-                            const k_vec: @Vector(vec_len, AccumT) = @splat(promote(kernel[half]));
-                            acc += loadVec(src.data[base + half ..].ptr) * k_vec;
+                            acc += loadVec(src.data[base + half ..].ptr) * splatK(kernel[half]);
                         }
                         storeVec(acc, dst_row[c..].ptr);
                     }
@@ -747,9 +664,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
                         var acc: @Vector(vec_len, AccumT) = @splat(0);
                         for (kernel, 0..) |k, ki| {
                             if (!isNegligible(k)) {
-                                const vec = loadVec(src.data[src_offset + c + ki - half ..].ptr);
-                                const k_vec: @Vector(vec_len, AccumT) = @splat(promote(k));
-                                acc += vec * k_vec;
+                                acc += loadVec(src.data[src_offset + c + ki - half ..].ptr) * splatK(k);
                             }
                         }
                         storeVec(acc, dst_row[c..].ptr);
@@ -778,7 +693,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
             const cols = src.cols;
             const table: BorderIndexTable = try .init(allocator, cols, kernel.len, border_mode);
             defer table.deinit(allocator);
-            const folded = KernelT == i32 and isSymmetric(kernel);
+            const folded = isSymmetric(kernel);
 
             for (0..src.rows) |r| {
                 horizontalRow(src, dst.data[r * dst.stride ..][0..cols], r, kernel, table, folded);
@@ -810,8 +725,9 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
         /// One vertical-pass output row combined from per-tap source row base offsets
         /// (`BorderIndexTable.zero_sentinel` = row of zeros). Border rows keep the full
         /// kernel with explicit zero adds; interior rows skip negligible taps — both
-        /// matching the standard vertical pass per pixel.
-        fn verticalRowFromBases(comptime border_row: bool, src_data: []const SrcT, bases: []const usize, dst: Image(DstT), r: usize, kernel: []const KernelT, folded: bool) void {
+        /// matching the standard vertical pass per pixel. Out of line for the same reason
+        /// as `horizontalRow`.
+        noinline fn verticalRowFromBases(comptime border_row: bool, src_data: []const SrcT, bases: []const usize, dst: Image(DstT), r: usize, kernel: []const KernelT, folded: bool) void {
             const cols = dst.cols;
             const dst_offset = r * dst.stride;
             const half = kernel.len / 2;
@@ -825,13 +741,11 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
                         if (!isNegligible(k)) {
                             const a = loadVec(src_data[bases[i] + c ..].ptr);
                             const b = loadVec(src_data[bases[kernel.len - 1 - i] + c ..].ptr);
-                            const k_vec: @Vector(vec_len, AccumT) = @splat(promote(k));
-                            acc += (a + b) * k_vec;
+                            acc += (a + b) * splatK(k);
                         }
                     }
                     if (!isNegligible(kernel[half])) {
-                        const k_vec: @Vector(vec_len, AccumT) = @splat(promote(kernel[half]));
-                        acc += loadVec(src_data[bases[half] + c ..].ptr) * k_vec;
+                        acc += loadVec(src_data[bases[half] + c ..].ptr) * splatK(kernel[half]);
                     }
                 } else {
                     for (kernel, bases) |k, base| {
@@ -840,12 +754,9 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
                                 @splat(0)
                             else
                                 loadVec(src_data[base + c ..].ptr);
-                            const k_vec: @Vector(vec_len, AccumT) = @splat(promote(k));
-                            acc += vec * k_vec;
+                            acc += vec * splatK(k);
                         } else if (!isNegligible(k)) {
-                            const vec = loadVec(src_data[base + c ..].ptr);
-                            const k_vec: @Vector(vec_len, AccumT) = @splat(promote(k));
-                            acc += vec * k_vec;
+                            acc += loadVec(src_data[base + c ..].ptr) * splatK(k);
                         }
                     }
                 }
@@ -886,9 +797,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime dst_scale: c
                             var acc: @Vector(vec_len, AccumT) = @splat(0);
                             for (kernel, 0..) |k, ki| {
                                 if (!isNegligible(k)) {
-                                    const vec = loadVec(src.data[(r + ki - half) * src.stride + c ..].ptr);
-                                    const k_vec: @Vector(vec_len, AccumT) = @splat(promote(k));
-                                    acc += vec * k_vec;
+                                    acc += loadVec(src.data[(r + ki - half) * src.stride + c ..].ptr) * splatK(k);
                                 }
                             }
                             storeVec(acc, dst.data[r * dst.stride + c ..].ptr);
@@ -1050,8 +959,8 @@ fn convolveSeparablePlaneFused(
     kernel_y: []const TempT,
     border_mode: BorderMode,
 ) !void {
-    const HPass = SeparablePass(PixelT, TempT, 1, AccumIntT);
-    const VPass = SeparablePass(TempT, PixelT, if (PixelT == u8) fixed_point_scale_sq else 1, AccumIntT);
+    const HPass = SeparablePass(PixelT, TempT, AccumIntT);
+    const VPass = SeparablePass(TempT, PixelT, AccumIntT);
 
     const rows = src_img.rows;
     const cols = src_img.cols;
@@ -1063,8 +972,8 @@ fn convolveSeparablePlaneFused(
     const v_table: BorderIndexTable = try .init(allocator, rows, klen_y, border_mode);
     defer v_table.deinit(allocator);
 
-    const h_folded = HPass.KernelT == i32 and HPass.isSymmetric(kernel_x);
-    const v_folded = VPass.KernelT == i32 and VPass.isSymmetric(kernel_y);
+    const h_folded = HPass.isSymmetric(kernel_x);
+    const v_folded = VPass.isSymmetric(kernel_y);
 
     // Temp row `tr` always lives in ring slot `tr % klen_y`.
     const ring = try allocator.alloc(TempT, klen_y * cols);
@@ -1072,28 +981,23 @@ fn convolveSeparablePlaneFused(
     const bases = try allocator.alloc(usize, klen_y);
     defer allocator.free(bases);
 
-    var produced: usize = @min(klen_y, rows);
-    for (0..produced) |tr| {
-        HPass.horizontalRow(src_img, ring[(tr % klen_y) * cols ..][0..cols], tr, kernel_x, h_table, h_folded);
-    }
-
+    var produced: usize = 0;
     for (0..rows) |r| {
+        // Interior rows tap temp rows up to klen_y - 1 - half_y below r; top border rows tap
+        // the initial window and bottom border rows the final one.
+        const need = @min(rows - 1, @max(klen_y - 1, r + klen_y - 1 - half_y));
+        while (produced <= need) : (produced += 1) {
+            HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table, h_folded);
+        }
         if (r >= half_y and r + half_y < rows) {
-            // Highest temp row this output row taps (klen_y - 1 - half_y above r).
-            const need = r + klen_y - 1 - half_y;
-            while (produced <= need) : (produced += 1) {
-                HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table, h_folded);
+            // Consecutive temp rows occupy consecutive ring slots, wrapping at most once.
+            var slot = (r - half_y) % klen_y;
+            for (bases) |*b| {
+                b.* = slot * cols;
+                slot = if (slot + 1 == klen_y) 0 else slot + 1;
             }
-            for (bases, 0..) |*b, i| b.* = ((r + i - half_y) % klen_y) * cols;
             VPass.verticalRowFromBases(false, ring, bases, dst_img, r, kernel_y, v_folded);
         } else {
-            // Bottom border rows read the final window; make sure it is complete. Top
-            // border rows only tap the initial window, which prefill already produced.
-            if (r >= v_table.high_start) {
-                while (produced < rows) : (produced += 1) {
-                    HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table, h_folded);
-                }
-            }
             for (bases, v_table.taps(v_table.ordinalOf(r))) |*b, resolved| {
                 b.* = if (resolved == BorderIndexTable.zero_sentinel)
                     BorderIndexTable.zero_sentinel
@@ -1118,8 +1022,8 @@ fn convolveSeparablePlane(
     kernel_y: []const TempT,
     border_mode: BorderMode,
 ) !void {
-    try SeparablePass(PixelT, TempT, 1, AccumIntT).horizontal(src_img, temp_img, allocator, kernel_x, border_mode);
-    try SeparablePass(TempT, PixelT, if (PixelT == u8) fixed_point_scale_sq else 1, AccumIntT).vertical(temp_img, dst_img, allocator, kernel_y, border_mode);
+    try SeparablePass(PixelT, TempT, AccumIntT).horizontal(src_img, temp_img, allocator, kernel_x, border_mode);
+    try SeparablePass(TempT, PixelT, AccumIntT).vertical(temp_img, dst_img, allocator, kernel_y, border_mode);
 }
 
 test "fused separable matches standard path" {

--- a/src/image/convolution.zig
+++ b/src/image/convolution.zig
@@ -574,8 +574,15 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
         /// pass is exact because divTrunc(256*S ± 32768, 65536) == divTrunc(S ± 128, 256).
         const dst_scale = if (DstT != u8) 1 else if (SrcT == u8) fixed_point_scale else fixed_point_scale_sq;
 
-        inline fn isNegligible(k: KernelT) bool {
-            return if (KernelT == f32) @abs(k) < 1e-10 else k == 0;
+        /// With `dense` the per-tap skip branch is compiled out: for kernels without
+        /// negligible taps (every gaussian) it measured 1.10-1.26x across the passes.
+        inline fn isNegligible(comptime dense: bool, k: KernelT) bool {
+            return !dense and (if (KernelT == f32) @abs(k) < 1e-10 else k == 0);
+        }
+
+        fn isDense(kernel: []const KernelT) bool {
+            for (kernel) |k| if (isNegligible(false, k)) return false;
+            return true;
         }
 
         /// Odd, mirror-symmetric kernels (every gaussian) can fold mirrored taps:
@@ -643,7 +650,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
 
         /// One row of the horizontal pass into a caller-provided contiguous row buffer.
         /// Kept out of line: inlined into the fused driver it measured 4-8% slower.
-        noinline fn horizontalRow(src: Image(SrcT), dst_row: []DstT, r: usize, kernel: []const KernelT, table: BorderIndexTable, folded: bool) void {
+        noinline fn horizontalRow(comptime dense: bool, src: Image(SrcT), dst_row: []DstT, r: usize, kernel: []const KernelT, table: BorderIndexTable, folded: bool) void {
             const half = kernel.len / 2;
             const cols = src.cols;
             const src_offset = r * src.stride;
@@ -661,13 +668,13 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
                         const base = src_offset + c - half;
                         var acc: @Vector(vec_len, AccumT) = @splat(0);
                         for (kernel[0..half], 0..) |k, i| {
-                            if (!isNegligible(k)) {
+                            if (!isNegligible(dense, k)) {
                                 const a = loadVec(src.data[base + i ..].ptr);
                                 const b = loadVec(src.data[base + (kernel.len - 1 - i) ..].ptr);
                                 acc += (a + b) * splatK(k);
                             }
                         }
-                        if (!isNegligible(kernel[half])) {
+                        if (!isNegligible(dense, kernel[half])) {
                             acc += loadVec(src.data[base + half ..].ptr) * splatK(kernel[half]);
                         }
                         storeVec(acc, dst_row[c..].ptr);
@@ -676,7 +683,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
                     while (c + vec_len <= interior_end) : (c += vec_len) {
                         var acc: @Vector(vec_len, AccumT) = @splat(0);
                         for (kernel, 0..) |k, ki| {
-                            if (!isNegligible(k)) {
+                            if (!isNegligible(dense, k)) {
                                 acc += loadVec(src.data[src_offset + c + ki - half ..].ptr) * splatK(k);
                             }
                         }
@@ -688,7 +695,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
                     var result: AccumT = 0;
                     const c0 = c - half;
                     for (kernel, 0..) |k, i| {
-                        if (!isNegligible(k)) {
+                        if (!isNegligible(dense, k)) {
                             result += promote(src.data[src_offset + c0 + i]) * promote(k);
                         }
                     }
@@ -707,9 +714,11 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
             const table: BorderIndexTable = try .init(allocator, cols, kernel.len, border_mode);
             defer table.deinit(allocator);
             const folded = isSymmetric(kernel);
+            const dense = isDense(kernel);
 
             for (0..src.rows) |r| {
-                horizontalRow(src, dst.data[r * dst.stride ..][0..cols], r, kernel, table, folded);
+                const dst_row = dst.data[r * dst.stride ..][0..cols];
+                if (dense) horizontalRow(true, src, dst_row, r, kernel, table, folded) else horizontalRow(false, src, dst_row, r, kernel, table, folded);
             }
         }
 
@@ -730,7 +739,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
                     for (bases, table.taps(table.ordinalOf(r))) |*b, idx| {
                         b.* = if (idx == BorderIndexTable.zero_sentinel) idx else idx * src.stride;
                     }
-                    verticalRowFromBases(true, src.data, bases, dst, r, kernel, false);
+                    verticalRowFromBases(true, false, src.data, bases, dst, r, kernel, false);
                 }
             }
         }
@@ -740,7 +749,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
         /// kernel with explicit zero adds; interior rows skip negligible taps — both
         /// matching the standard vertical pass per pixel. Out of line for the same reason
         /// as `horizontalRow`.
-        noinline fn verticalRowFromBases(comptime border_row: bool, src_data: []const SrcT, bases: []const usize, dst: Image(DstT), r: usize, kernel: []const KernelT, folded: bool) void {
+        noinline fn verticalRowFromBases(comptime border_row: bool, comptime dense: bool, src_data: []const SrcT, bases: []const usize, dst: Image(DstT), r: usize, kernel: []const KernelT, folded: bool) void {
             const cols = dst.cols;
             const dst_offset = r * dst.stride;
             const half = kernel.len / 2;
@@ -751,13 +760,13 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
                 var acc: @Vector(vec_len, AccumT) = @splat(0);
                 if (folded) {
                     for (kernel[0..half], 0..) |k, i| {
-                        if (!isNegligible(k)) {
+                        if (!isNegligible(dense, k)) {
                             const a = loadVec(src_data[bases[i] + c ..].ptr);
                             const b = loadVec(src_data[bases[kernel.len - 1 - i] + c ..].ptr);
                             acc += (a + b) * splatK(k);
                         }
                     }
-                    if (!isNegligible(kernel[half])) {
+                    if (!isNegligible(dense, kernel[half])) {
                         acc += loadVec(src_data[bases[half] + c ..].ptr) * splatK(kernel[half]);
                     }
                 } else {
@@ -768,7 +777,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
                             else
                                 loadVec(src_data[base + c ..].ptr);
                             acc += vec * splatK(k);
-                        } else if (!isNegligible(k)) {
+                        } else if (!isNegligible(dense, k)) {
                             acc += loadVec(src_data[base + c ..].ptr) * splatK(k);
                         }
                     }
@@ -782,7 +791,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
                     if (border_row) {
                         const pv: SrcT = if (base == BorderIndexTable.zero_sentinel) 0 else src_data[base + c];
                         result += promote(pv) * promote(k);
-                    } else if (!isNegligible(k)) {
+                    } else if (!isNegligible(dense, k)) {
                         result += promote(src_data[base + c]) * promote(k);
                     }
                 }
@@ -793,6 +802,14 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
         /// Column-tiled 1D pass along rows (src -> dst); tiling keeps the working set cache-resident
         /// and, unlike per-row bases, lets LLVM hoist the tap offsets (row-major measured 0.9x on f32).
         fn vertical(src: Image(SrcT), dst: Image(DstT), allocator: Allocator, kernel: []const KernelT, border_mode: BorderMode) !void {
+            if (isDense(kernel)) {
+                try verticalImpl(true, src, dst, allocator, kernel, border_mode);
+            } else {
+                try verticalImpl(false, src, dst, allocator, kernel, border_mode);
+            }
+        }
+
+        fn verticalImpl(comptime dense: bool, src: Image(SrcT), dst: Image(DstT), allocator: Allocator, kernel: []const KernelT, border_mode: BorderMode) !void {
             const half = kernel.len / 2;
             const rows = src.rows;
             const cols = src.cols;
@@ -813,18 +830,18 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
                             var acc: @Vector(vec_len, AccumT) = @splat(0);
                             if (folded) {
                                 for (kernel[0..half], 0..) |k, i| {
-                                    if (!isNegligible(k)) {
+                                    if (!isNegligible(dense, k)) {
                                         const a = loadVec(src.data[base + i * src.stride ..].ptr);
                                         const b = loadVec(src.data[base + (kernel.len - 1 - i) * src.stride ..].ptr);
                                         acc += (a + b) * splatK(k);
                                     }
                                 }
-                                if (!isNegligible(kernel[half])) {
+                                if (!isNegligible(dense, kernel[half])) {
                                     acc += loadVec(src.data[base + half * src.stride ..].ptr) * splatK(kernel[half]);
                                 }
                             } else {
                                 for (kernel, 0..) |k, ki| {
-                                    if (!isNegligible(k)) {
+                                    if (!isNegligible(dense, k)) {
                                         acc += loadVec(src.data[base + ki * src.stride ..].ptr) * splatK(k);
                                     }
                                 }
@@ -838,7 +855,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
                             var result: AccumT = 0;
                             const r0 = r - half;
                             for (kernel, 0..) |k, i| {
-                                if (isNegligible(k)) continue;
+                                if (isNegligible(dense, k)) continue;
                                 result += promote(src.data[(r0 + i) * src.stride + c]) * promote(k);
                             }
                             dst.data[r * dst.stride + c] = store(result);
@@ -1003,6 +1020,8 @@ fn convolveSeparablePlaneFused(
 
     const h_folded = HPass.isSymmetric(kernel_x);
     const v_folded = VPass.isSymmetric(kernel_y);
+    const h_dense = HPass.isDense(kernel_x);
+    const v_dense = VPass.isDense(kernel_y);
 
     // Temp row `tr` always lives in ring slot `tr % klen_y`.
     const ring = try allocator.alloc(TempT, klen_y * cols);
@@ -1016,7 +1035,8 @@ fn convolveSeparablePlaneFused(
         // the initial window and bottom border rows the final one.
         const need = @min(rows - 1, @max(klen_y - 1, r + klen_y - 1 - half_y));
         while (produced <= need) : (produced += 1) {
-            HPass.horizontalRow(src_img, ring[(produced % klen_y) * cols ..][0..cols], produced, kernel_x, h_table, h_folded);
+            const temp_row = ring[(produced % klen_y) * cols ..][0..cols];
+            if (h_dense) HPass.horizontalRow(true, src_img, temp_row, produced, kernel_x, h_table, h_folded) else HPass.horizontalRow(false, src_img, temp_row, produced, kernel_x, h_table, h_folded);
         }
         if (r >= half_y and r + half_y < rows) {
             // Consecutive temp rows occupy consecutive ring slots, wrapping at most once.
@@ -1025,7 +1045,7 @@ fn convolveSeparablePlaneFused(
                 b.* = slot * cols;
                 slot = if (slot + 1 == klen_y) 0 else slot + 1;
             }
-            VPass.verticalRowFromBases(false, ring, bases, dst_img, r, kernel_y, v_folded);
+            if (v_dense) VPass.verticalRowFromBases(false, true, ring, bases, dst_img, r, kernel_y, v_folded) else VPass.verticalRowFromBases(false, false, ring, bases, dst_img, r, kernel_y, v_folded);
         } else {
             for (bases, v_table.taps(v_table.ordinalOf(r))) |*b, resolved| {
                 b.* = if (resolved == BorderIndexTable.zero_sentinel)
@@ -1033,7 +1053,7 @@ fn convolveSeparablePlaneFused(
                 else
                     (resolved % klen_y) * cols;
             }
-            VPass.verticalRowFromBases(true, ring, bases, dst_img, r, kernel_y, false);
+            VPass.verticalRowFromBases(true, false, ring, bases, dst_img, r, kernel_y, false);
         }
     }
 }


### PR DESCRIPTION
Started as a cleanup pass over convolution.zig, then went through the things that were flagged but skipped and kept the ones that measured faster (or same speed with less code).

Cleanup:
- PixelIO is gone, the 2D kernel uses SeparablePass for its load/store policy
- dst_scale is derived from the pass types instead of passed in
- one quantizeKernel instead of quantizeWeight + renormalizeQuantized
- identity/uniform/symmetric checks each live in one place
- fused path has a single ring-production loop
- horizontalRow / verticalRowFromBases are noinline: once the fused driver had one call site LLVM inlined them and u8 gaussians got ~10% slower

Speedups:
- 2D border columns are resolved once per call instead of going through border.getPixel per tap
- symmetric taps are folded in the tiled vertical pass too
- kernels with no negligible taps compile the per-tap skip branch out (comptime dense flag)
- splitChannels / mergeChannels use std.simd deinterlace/interlace

Tried and dropped: row-major vertical pass (0.9x on f32), @mulAdd in the f32 loops (fewer instructions but slower, longer accumulator chain), ?usize instead of the zero sentinel (fewer lines but 0.95x).

Numbers from examples/convolution_bench, pinned to one core, old/new cycles:

    convolve 7x7            1.50x
    convolve 3x3            1.13x
    gaussianBlur u8 s=1     1.20x
    gaussianBlur u8 s=3     1.11x
    gaussianBlur u8 s=8     1.06x
    gaussianBlur Rgb s=3    1.26x
    motionBlur              1.38x
    convolveSeparable 9-tap 1.00x
    sobel                   1.00x
    medianBlur (untouched)  1.00x

Output is unchanged, all tests pass.
