### PR TITLE
fix(numerics): skewness/kurtosis, perlin normalisation, matrix pivoting

### DIFF
--- a/bindings/python/tests/test_running_stats.py
+++ b/bindings/python/tests/test_running_stats.py
@@ -25,8 +25,7 @@ def _expected_skewness(values: list[float]) -> float:
     if math.isclose(m2, 0.0):
         return 0.0
     variance = m2 / (n - 1)
-    skew = (n / ((n - 1) * (n - 2))) * (m3 / (m2 / n))
-    return skew / (variance**1.5)
+    return (n / ((n - 1) * (n - 2))) * m3 / (variance**1.5)
 
 
 def _expected_excess_kurtosis(values: list[float]) -> float:
@@ -37,7 +36,8 @@ def _expected_excess_kurtosis(values: list[float]) -> float:
     if math.isclose(m2, 0.0):
         return 0.0
     n1 = n - 1
-    kurt = ((n * (n + 1)) / (n1 * (n - 2) * (n - 3))) * (m4 / ((m2 * m2) / (n * n)))
+    variance = m2 / n1
+    kurt = ((n * (n + 1)) / (n1 * (n - 2) * (n - 3))) * (m4 / (variance * variance))
     kurt -= (3 * n1 * n1) / ((n - 2) * (n - 3))
     return kurt
 

--- a/src/matrix.zig
+++ b/src/matrix.zig
@@ -1,13 +1,13 @@
-//! This module provides a generic, fixed-size Matrix struct for floating-point types
-//! and a collection of common linear algebra operations such as addition, multiplication,
-//! dot product, transpose, norm computation, determinant, and inverse (for small matrices).
+//! Dynamic (`Matrix`) and compile-time sized (`SMatrix`) matrices with the usual linear
+//! algebra: elementwise ops, products, norms, LU/QR/Cholesky/SVD/symmetric-eigen
+//! decompositions, solve, inverse and pseudo-inverse.
 
 // Re-export all matrix functionality
 pub const SMatrix = @import("matrix/SMatrix.zig").SMatrix;
 pub const Matrix = @import("matrix/Matrix.zig").Matrix;
+pub const Chain = @import("matrix/Chain.zig").Chain;
 pub const MatrixError = @import("matrix/Matrix.zig").MatrixError;
 pub const cholesky = @import("matrix/Matrix.zig").cholesky;
-pub const Chain = @import("matrix/Chain.zig").Chain;
 
 test {
     _ = @import("matrix/SMatrix.zig");

--- a/src/matrix/Matrix.zig
+++ b/src/matrix/Matrix.zig
@@ -138,6 +138,8 @@ pub fn Matrix(comptime T: type) type {
             tolerance: ?T = null,
             /// Optional pointer that receives the effective numerical rank (#σ > tol).
             effective_rank: ?*u32 = null,
+
+            pub const default: PinvOptions = .{};
         };
 
         pub fn init(allocator: std.mem.Allocator, rows: u32, cols: u32) !Self {
@@ -372,25 +374,31 @@ pub fn Matrix(comptime T: type) type {
         }
 
         /// Inverts the matrix using analytical formulas for small matrices (≤3x3)
-        /// and Gauss-Jordan elimination for larger matrices
+        /// and a pivoted LU solve for larger matrices
         pub fn inv(self: Self) MatrixError!Self {
             if (self.rows != self.cols) return error.NotSquare;
+            if (self.rows == 0) return error.DimensionMismatch;
 
             const n = self.rows;
+            // A determinant is "zero" when it is below the rounding noise of the products
+            // that formed it, so small-magnitude matrices are not mistaken for singular ones.
+            const eps = std.math.floatEps(T) * 100;
 
             // Use analytical formulas for small matrices (more efficient)
             if (n <= 3) {
                 switch (n) {
                     1 => {
                         const d = self.at(0, 0).*;
-                        if (@abs(d) < std.math.floatEps(T)) return error.Singular;
+                        if (d == 0) return error.Singular;
                         var ans: Matrix(T) = try .init(self.allocator, n, n);
                         ans.at(0, 0).* = 1 / d;
                         return ans;
                     },
                     2 => {
-                        const d = self.at(0, 0).* * self.at(1, 1).* - self.at(0, 1).* * self.at(1, 0).*;
-                        if (@abs(d) < std.math.floatEps(T)) return error.Singular;
+                        const p0 = self.at(0, 0).* * self.at(1, 1).*;
+                        const p1 = self.at(0, 1).* * self.at(1, 0).*;
+                        const d = p0 - p1;
+                        if (@abs(d) <= (@abs(p0) + @abs(p1)) * eps) return error.Singular;
                         var ans: Matrix(T) = try .init(self.allocator, n, n);
                         ans.at(0, 0).* = self.at(1, 1).* / d;
                         ans.at(0, 1).* = -self.at(0, 1).* / d;
@@ -404,7 +412,13 @@ pub fn Matrix(comptime T: type) type {
                         const c02 = self.at(0, 1).* * self.at(1, 2).* - self.at(0, 2).* * self.at(1, 1).*;
 
                         const d = self.at(0, 0).* * c00 + self.at(1, 0).* * c01 + self.at(2, 0).* * c02;
-                        if (@abs(d) < std.math.floatEps(T)) return error.Singular;
+                        const magnitude = @abs(self.at(0, 0).* * self.at(1, 1).* * self.at(2, 2).*) +
+                            @abs(self.at(0, 0).* * self.at(1, 2).* * self.at(2, 1).*) +
+                            @abs(self.at(1, 0).* * self.at(0, 2).* * self.at(2, 1).*) +
+                            @abs(self.at(1, 0).* * self.at(0, 1).* * self.at(2, 2).*) +
+                            @abs(self.at(2, 0).* * self.at(0, 1).* * self.at(1, 2).*) +
+                            @abs(self.at(2, 0).* * self.at(0, 2).* * self.at(1, 1).*);
+                        if (@abs(d) <= magnitude * eps) return error.Singular;
 
                         var ans: Matrix(T) = try .init(self.allocator, n, n);
                         ans.at(0, 0).* = c00 / d;
@@ -421,8 +435,13 @@ pub fn Matrix(comptime T: type) type {
                     else => unreachable,
                 }
             } else {
-                // Use Gauss-Jordan elimination for larger matrices
-                return self.inverseGaussJordan();
+                // A⁻¹ = solve(A, I) through the pivoted LU, which carries the
+                // scale-relative singularity test.
+                var lu_result = try self.lu();
+                defer lu_result.deinit();
+                var ident: Matrix(T) = try .identity(self.allocator, n, n);
+                defer ident.deinit();
+                return lu_result.solve(ident);
             }
         }
 
@@ -506,80 +525,6 @@ pub fn Matrix(comptime T: type) type {
             }
 
             return v_sigma.dotTranspose(svd_result.u);
-        }
-
-        /// Inverts the matrix using Gauss-Jordan elimination with partial pivoting
-        /// This is a general method that works for any size square matrix
-        fn inverseGaussJordan(self: Self) MatrixError!Self {
-            const n = self.rows;
-
-            // Create augmented matrix [A | I]
-            var augmented: Matrix(T) = try .init(self.allocator, n, 2 * n);
-            defer augmented.deinit();
-
-            // Copy original matrix to left half and identity to right half
-            for (0..n) |i| {
-                for (0..n) |j| {
-                    augmented.at(i, j).* = self.at(i, j).*;
-                    augmented.at(i, n + j).* = if (i == j) 1.0 else 0.0;
-                }
-            }
-
-            // Perform Gauss-Jordan elimination
-            for (0..n) |pivot_col| {
-                // Find pivot (partial pivoting for numerical stability)
-                var max_row = pivot_col;
-                var max_val = @abs(augmented.at(pivot_col, pivot_col).*);
-
-                for (pivot_col + 1..n) |row_idx| {
-                    const val = @abs(augmented.at(row_idx, pivot_col).*);
-                    if (val > max_val) {
-                        max_val = val;
-                        max_row = row_idx;
-                    }
-                }
-
-                // Check for singular matrix
-                if (max_val < std.math.floatEps(T) * 10) return error.Singular;
-
-                // Columns before pivot_col in the left half are already reduced
-                // to unit columns (exact zeros in the rows below), so the row
-                // operations can start at pivot_col.
-
-                // Swap rows if needed
-                if (max_row != pivot_col) {
-                    for (pivot_col..2 * n) |j| {
-                        std.mem.swap(T, augmented.at(pivot_col, j), augmented.at(max_row, j));
-                    }
-                }
-
-                // Scale pivot row
-                const pivot = augmented.at(pivot_col, pivot_col).*;
-                for (pivot_col..2 * n) |j| {
-                    augmented.at(pivot_col, j).* /= pivot;
-                }
-
-                // Eliminate column in all other rows
-                for (0..n) |row_idx| {
-                    if (row_idx != pivot_col) {
-                        const factor = augmented.at(row_idx, pivot_col).*;
-                        for (pivot_col..2 * n) |j| {
-                            augmented.at(row_idx, j).* -= factor * augmented.at(pivot_col, j).*;
-                        }
-                    }
-                }
-            }
-
-            // Extract inverse from right half of augmented matrix
-            var ans: Matrix(T) = try .init(self.allocator, n, n);
-
-            for (0..n) |i| {
-                for (0..n) |j| {
-                    ans.at(i, j).* = augmented.at(i, n + j).*;
-                }
-            }
-
-            return ans;
         }
 
         /// Extract a submatrix - changes dimensions
@@ -1294,9 +1239,10 @@ pub fn Matrix(comptime T: type) type {
                     u.at(pivot_col, j).* = work.at(pivot_col, j).*;
                 }
 
-                // Compute L column and eliminate
+                // Compute L column and eliminate. An exactly-zero pivot means the whole
+                // column below it is zero too (it was the max), so there is nothing to do.
                 for (pivot_col + 1..n) |row_idx| {
-                    if (@abs(work.at(pivot_col, pivot_col).*) > std.math.floatEps(T)) {
+                    if (work.at(pivot_col, pivot_col).* != 0) {
                         const factor = work.at(row_idx, pivot_col).* / work.at(pivot_col, pivot_col).*;
                         l.at(row_idx, pivot_col).* = factor;
 

--- a/src/matrix/SMatrix.zig
+++ b/src/matrix/SMatrix.zig
@@ -677,7 +677,28 @@ pub fn SMatrix(comptime T: type, comptime rows: u32, comptime cols: u32) type {
                     self.items[0][2] * self.items[1][1] * self.items[2][0] -
                     self.items[0][1] * self.items[1][0] * self.items[2][2] -
                     self.items[0][0] * self.items[1][2] * self.items[2][1],
-                else => @compileError("Matrix(T).det() is not implemented for sizes above 3"),
+                else => blk: {
+                    // Gaussian elimination with partial pivoting on a copy.
+                    var a = self.items;
+                    var d: T = 1;
+                    for (0..rows) |c| {
+                        var p = c;
+                        for (c + 1..rows) |r| {
+                            if (@abs(a[r][c]) > @abs(a[p][c])) p = r;
+                        }
+                        if (a[p][c] == 0) break :blk 0;
+                        if (p != c) {
+                            std.mem.swap([cols]T, &a[c], &a[p]);
+                            d = -d;
+                        }
+                        d *= a[c][c];
+                        for (c + 1..rows) |r| {
+                            const f = a[r][c] / a[c][c];
+                            for (c..cols) |k| a[r][k] -= f * a[c][k];
+                        }
+                    }
+                    break :blk d;
+                },
             };
         }
 
@@ -717,7 +738,7 @@ pub fn SMatrix(comptime T: type, comptime rows: u32, comptime cols: u32) type {
                     ans.items[2][1] = (self.items[0][1] * self.items[2][0] - self.items[0][0] * self.items[2][1]) / d;
                     ans.items[2][2] = (self.items[0][0] * self.items[1][1] - self.items[0][1] * self.items[1][0]) / d;
                 },
-                else => @compileError("Matrix(T).inv() is not implemented for sizes above 3"),
+                else => return self.solve(Self.identity()),
             }
             return ans;
         }
@@ -1246,4 +1267,29 @@ test "SMatrix svd basic" {
             try std.testing.expect(s.at(i - 1, 0).* >= s.at(i, 0).*);
         }
     }
+}
+
+test "SMatrix det and inv beyond 3x3" {
+    const a: SMatrix(f64, 4, 4) = .init(.{
+        .{ 4, 1, 2, 0 },
+        .{ 1, 5, 0, 3 },
+        .{ 2, 0, 6, 1 },
+        .{ 0, 3, 1, 7 },
+    });
+    // Symmetric positive definite; det = 447 (numpy).
+    try std.testing.expectApproxEqAbs(447.0, a.det(), 1e-9);
+    const inv = a.inv().?;
+    const prod = a.dot(inv);
+    for (0..4) |r| for (0..4) |c| {
+        const want: f64 = if (r == c) 1 else 0;
+        try std.testing.expectApproxEqAbs(want, prod.at(r, c).*, 1e-12);
+    };
+    const singular: SMatrix(f64, 4, 4) = .init(.{
+        .{ 1, 2, 3, 4 },
+        .{ 2, 4, 6, 8 },
+        .{ 0, 1, 0, 1 },
+        .{ 1, 0, 1, 0 },
+    });
+    try std.testing.expectEqual(0.0, singular.det());
+    try std.testing.expect(singular.inv() == null);
 }

--- a/src/matrix/eigen.zig
+++ b/src/matrix/eigen.zig
@@ -30,7 +30,7 @@ pub fn Result(comptime T: type) type {
 /// returned ascending, with `vectors`' columns the matching unit eigenvectors. The caller owns the
 /// returned matrices. Returns `error.NotSymmetric` if `a` is not symmetric within a magnitude-relative
 /// tolerance (a general non-symmetric eigendecomposition, with its complex spectrum, is out of scope),
-/// or `error.NotFinite` if any entry is NaN or infinite.
+/// `error.NotFinite` if any entry is NaN or infinite, or `error.NotConverged` after 100 sweeps.
 pub fn eigh(comptime T: type, allocator: std.mem.Allocator, a: Matrix(T)) !Result(T) {
     comptime assert(@typeInfo(T) == .float);
     if (a.rows != a.cols) return error.NotSquare;
@@ -67,12 +67,13 @@ pub fn eigh(comptime T: type, allocator: std.mem.Allocator, a: Matrix(T)) !Resul
     const off_tol = frob_sq * eps * eps;
 
     var sweep: usize = 0;
-    while (sweep < 100) : (sweep += 1) {
+    while (true) : (sweep += 1) {
         var off: T = 0;
         for (0..n) |p| for (p + 1..n) |q| {
             off += work.at(p, q).* * work.at(p, q).*;
         };
         if (off <= off_tol) break;
+        if (sweep == 100) return error.NotConverged;
 
         for (0..n) |p| {
             for (p + 1..n) |q| {

--- a/src/matrix/svd.zig
+++ b/src/matrix/svd.zig
@@ -36,6 +36,8 @@ pub const Options = struct {
     with_v: bool = false,
     /// Controls computation and size of the U matrix.
     mode: Mode = .full_u,
+
+    pub const default: Options = .{};
 };
 
 /// Result type for SVD decomposition: A = U × Σ × V^T

--- a/src/matrix/test_ops_inverse.zig
+++ b/src/matrix/test_ops_inverse.zig
@@ -257,3 +257,34 @@ test "Matrix pseudo-inverse zero matrix" {
     }
     try std.testing.expectEqual(@as(u32, 0), rank);
 }
+
+test "Matrix inverse/solve - singularity is relative to the matrix scale" {
+    var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena.deinit();
+    const gpa = arena.allocator();
+
+    // Entries far below floatEps(f32) are still a perfectly conditioned matrix.
+    inline for (.{ 2, 3, 4 }) |n| {
+        var a: Matrix(f32) = try .identity(gpa, n, n);
+        for (0..n) |i| a.at(i, i).* = 1e-9 * @as(f32, @floatFromInt(i + 1));
+        a.at(0, n - 1).* = 2e-9;
+        const a_inv = try a.inv();
+        const prod = try a.dot(a_inv);
+        for (0..n) |i| for (0..n) |j| {
+            const want: f32 = if (i == j) 1 else 0;
+            try std.testing.expectApproxEqAbs(want, prod.at(i, j).*, 1e-5);
+        };
+        // solve() goes through lu(); it must not skip small pivots.
+        const b: Matrix(f32) = try .initAll(gpa, n, 1, 1e-9);
+        const x = try a.solve(b);
+        const ax = try a.dot(x);
+        for (0..n) |i| try std.testing.expectApproxEqAbs(1e-9, ax.at(i, 0).*, 1e-14);
+    }
+
+    // A genuinely singular small-scale matrix is still rejected.
+    var s: Matrix(f64) = try .fromSlice(gpa, 2, 2, &.{ 1e-9, 2e-9, 2e-9, 4e-9 });
+    try std.testing.expectError(error.Singular, s.inv());
+
+    var empty: Matrix(f64) = try .init(gpa, 0, 0);
+    try std.testing.expectError(error.DimensionMismatch, empty.inv());
+}

--- a/src/pca.zig
+++ b/src/pca.zig
@@ -405,11 +405,13 @@ pub fn Pca(
             // Project eigenvectors back to feature space. The Gram matrix is
             // n_samples × n_samples and `fit` clamps num_components to at most
             // n_samples - 1, so every requested component has a backing eigenvector.
+            // Rank cutoff relative to the leading eigenvalue, so tiny-scale data keeps its components.
+            const tol = result.s.at(0, 0).* * @as(T, @floatFromInt(n)) * std.math.floatEps(T);
             for (0..num_components) |i| {
                 const eigenval = result.s.at(i, 0).*;
                 self.eigenvalues[i] = eigenval;
 
-                if (eigenval > 1e-12) {
+                if (eigenval > tol) {
                     // Principal component: X^T u_i / sqrt((n-1) * eigenval)
                     for (0..self.dim) |j| {
                         var sum: T = 0;

--- a/src/perlin.zig
+++ b/src/perlin.zig
@@ -19,6 +19,8 @@ pub fn PerlinOptions(T: type) type {
         /// It should be greater than one, and 2.0 is a good choice.
         lacunarity: T = 2,
 
+        pub const default: PerlinOptions(T) = .{};
+
         /// Initializes PerlinOptions while checking the ranges are correct.
         pub fn init(amplitude: T, frequency: T, octaves: usize, persistence: T, lacunarity: T) PerlinOptions(T) {
             {
@@ -48,11 +50,23 @@ pub fn perlin(T: type, x: T, y: T, z: T, opts: PerlinOptions(T)) T {
     var cur_frequency: T = opts.frequency;
     for (0..opts.octaves) |_| {
         total_noise += noise(T, x * cur_frequency, y * cur_frequency, z * cur_frequency) * cur_amplitude;
+        max_amplitude += cur_amplitude;
         cur_amplitude *= opts.persistence;
         cur_frequency *= opts.lacunarity;
-        max_amplitude += cur_amplitude;
     }
     return total_noise / max_amplitude * opts.amplitude;
+}
+
+test "perlin: octaves are normalised to the amplitude" {
+    const x, const y, const z = .{ 0.1, 0.37, 0.52 };
+    // One octave is the raw noise; the ramp must not scale it by 1/persistence.
+    try expectEqual(noise(f64, x, y, z), perlin(f64, x, y, z, .{}));
+    try expectEqual(3 * noise(f64, x, y, z), perlin(f64, x, y, z, .{ .amplitude = 3 }));
+    // Three octaves at persistence 0.5: (n1 + n2/2 + n3/4) / 1.75.
+    const expected = (noise(f64, x, y, z) + 0.5 * noise(f64, 2 * x, 2 * y, 2 * z) + 0.25 * noise(f64, 4 * x, 4 * y, 4 * z)) / 1.75;
+    try std.testing.expectApproxEqAbs(expected, perlin(f64, x, y, z, .{ .octaves = 3 }), 1e-15);
+    // persistence 0 is a single octave, not NaN.
+    try expectEqual(noise(f64, x, y, z), perlin(f64, x, y, z, .{ .octaves = 4, .persistence = 0 }));
 }
 
 // The functions below are ported from: https://mrl.cs.nyu.edu/~perlin/noise/

--- a/src/stats.zig
+++ b/src/stats.zig
@@ -139,10 +139,9 @@ pub fn RunningStats(comptime T: type, comptime config: RunningStatsConfig) type 
             const variance_val = self.variance();
             if (variance_val == 0) return 0;
 
+            // G1 = n / ((n-1)(n-2)) · Σ(x-μ)³ / s³ with s² the sample variance.
             const n = @as(T, @floatFromInt(self.n));
-            const skew = (n / ((n - 1) * (n - 2))) *
-                (self.m3 / (self.m2 / n));
-            return skew / std.math.pow(T, variance_val, 1.5);
+            return (n / ((n - 1) * (n - 2))) * self.m3 / std.math.pow(T, variance_val, 1.5);
         }
 
         /// Compute the excess kurtosis (requires n > 3)
@@ -153,14 +152,11 @@ pub fn RunningStats(comptime T: type, comptime config: RunningStatsConfig) type 
             const variance_val = self.variance();
             if (variance_val == 0) return 0;
 
+            // G2 = n(n+1) / ((n-1)(n-2)(n-3)) · Σ(x-μ)⁴ / s⁴ − 3(n-1)² / ((n-2)(n-3)).
             const n: T = @floatFromInt(self.n);
             const n1 = n - 1;
-
-            const kurt = ((n * (n + 1)) / (n1 * (n - 2) * (n - 3))) *
-                (self.m4 / (self.m2 * self.m2 / (n * n))) -
+            return ((n * (n + 1)) / (n1 * (n - 2) * (n - 3))) * (self.m4 / (variance_val * variance_val)) -
                 (3 * n1 * n1) / ((n - 2) * (n - 3));
-
-            return kurt;
         }
 
         /// Get the minimum value seen so far
@@ -364,6 +360,16 @@ test "RunningStats: skewness and kurtosis" {
     try testing.expect(@abs(stats.exKurtosis()) < 1.0);
 }
 
+test "RunningStats: skewness and kurtosis exact values, scale invariant" {
+    // {0,0,0,1}: G1 = 2, G2 = 4 (scipy.stats.skew/kurtosis with bias=False).
+    for ([_]f64{ 1, 10, 1e-3 }) |scale| {
+        var stats: RunningStats(f64, .all) = .init();
+        for ([_]f64{ 0, 0, 0, scale }) |v| stats.add(v);
+        try testing.expectApproxEqAbs(2.0, stats.skewness(), 1e-12);
+        try testing.expectApproxEqAbs(4.0, stats.exKurtosis(), 1e-12);
+    }
+}
+
 test "RunningStats: combine" {
     var stats1: RunningStats(f64, .all) = .init();
     var stats2: RunningStats(f64, .all) = .init();
@@ -432,45 +438,69 @@ test "RunningStats: edge cases" {
     try testing.expectEqual(@as(f64, 0), stats.exKurtosis());
 }
 
+/// Two-pass sample skewness and excess kurtosis (G1, G2) of `values`, as a reference.
+fn referenceMoments(values: []const f64) struct { skew: f64, kurt: f64 } {
+    const n: f64 = @floatFromInt(values.len);
+    var mean_val: f64 = 0;
+    for (values) |v| mean_val += v;
+    mean_val /= n;
+    var m2: f64 = 0;
+    var m3: f64 = 0;
+    var m4: f64 = 0;
+    for (values) |v| {
+        const d = v - mean_val;
+        m2 += d * d;
+        m3 += d * d * d;
+        m4 += d * d * d * d;
+    }
+    const s2 = m2 / (n - 1);
+    return .{
+        .skew = n / ((n - 1) * (n - 2)) * m3 / std.math.pow(f64, s2, 1.5),
+        .kurt = n * (n + 1) / ((n - 1) * (n - 2) * (n - 3)) * m4 / (s2 * s2) - 3 * (n - 1) * (n - 1) / ((n - 2) * (n - 3)),
+    };
+}
+
 test "RunningStats: normal distribution approximation" {
     var stats: RunningStats(f64, .all) = .init();
-
-    // Generate standard normal data using Zig's built-in normal random generator
-    var prng = std.Random.DefaultPrng.init(42); // Fixed seed for deterministic test
+    var prng = std.Random.DefaultPrng.init(42);
     const rand = prng.random();
-
-    var i: usize = 0;
-    while (i < 100) : (i += 1) {
-        const value = rand.floatNorm(f64);
-        stats.add(value);
+    var values: [100]f64 = undefined;
+    for (&values) |*v| {
+        v.* = rand.floatNorm(f64);
+        stats.add(v.*);
     }
 
     try testing.expectEqual(100, stats.currentN());
-    try testing.expectApproxEqAbs(0, @abs(stats.mean()), 0.1); // Should be near 0
-    try testing.expectApproxEqAbs(1.0, stats.variance(), 0.04); // Should be near 1
-    try testing.expectApproxEqAbs(1.0, stats.stdDev(), 0.04); // Should be near 1
-    try testing.expectApproxEqAbs(0, @abs(stats.skewness()), 0.25); // Should be near 0 for symmetric
-    try testing.expectApproxEqAbs(0, @abs(stats.exKurtosis()), 0.15); // Should be near 0 for normal-like
+    try testing.expectApproxEqAbs(0, @abs(stats.mean()), 0.1);
+    try testing.expectApproxEqAbs(1.0, stats.variance(), 0.04);
+    try testing.expectApproxEqAbs(1.0, stats.stdDev(), 0.04);
+    // The running estimate must match the two-pass reference; the sample itself is only
+    // loosely normal (standard errors at n=100: skew ≈ 0.24, kurtosis ≈ 0.49).
+    const ref = referenceMoments(&values);
+    try testing.expectApproxEqAbs(ref.skew, stats.skewness(), 1e-10);
+    try testing.expectApproxEqAbs(ref.kurt, stats.exKurtosis(), 1e-10);
+    try testing.expect(@abs(stats.skewness()) < 0.5);
+    try testing.expect(@abs(stats.exKurtosis()) < 1.0);
 }
 
 test "RunningStats: skewed distribution" {
     var stats: RunningStats(f64, .all) = .init();
-
-    // Generate right-skewed data using Zig's exponential random generator
-    var prng = std.Random.DefaultPrng.init(123); // Fixed seed for deterministic test
+    var prng = std.Random.DefaultPrng.init(123);
     const rand = prng.random();
-
-    var i: usize = 0;
-    while (i < 100) : (i += 1) {
-        const value = rand.floatExp(f64); // Exponential distribution: mean 1, skewed right
-        stats.add(value);
+    var values: [100]f64 = undefined;
+    for (&values) |*v| {
+        v.* = rand.floatExp(f64); // mean 1, skew 2, excess kurtosis 6
+        stats.add(v.*);
     }
 
     try testing.expectEqual(@as(usize, 100), stats.currentN());
-    try testing.expectApproxEqAbs(@as(f64, 1.0), stats.mean(), 0.05); // Should be near 1
-    try testing.expectApproxEqAbs(@as(f64, 1.0), stats.variance(), 0.12); // Should be near 1
-    try testing.expect(stats.skewness() > 1.9); // Positive skewness expected for exponential
-    try testing.expect(stats.exKurtosis() > 3.1); // High excess kurtosis for exponential
+    try testing.expectApproxEqAbs(@as(f64, 1.0), stats.mean(), 0.05);
+    try testing.expectApproxEqAbs(@as(f64, 1.0), stats.variance(), 0.12);
+    const ref = referenceMoments(&values);
+    try testing.expectApproxEqAbs(ref.skew, stats.skewness(), 1e-10);
+    try testing.expectApproxEqAbs(ref.kurt, stats.exKurtosis(), 1e-10);
+    try testing.expect(stats.skewness() > 1.0);
+    try testing.expect(stats.exKurtosis() > 1.5);
 }
 
 test "RunningStats: scaling/z-score" {


### PR DESCRIPTION
- `RunningStats.skewness` divided by both `m2/n` and `var^1.5` (not scale-invariant); `exKurtosis` used `m2²/n²` instead of `s⁴`. The Python test had copied the same formulas.
- `perlin` summed `max_amplitude` after the decay: output scaled by 1/persistence, NaN at persistence 0.
- `Matrix.lu/inv/solve/det` used absolute `floatEps` pivots, giving wrong results or false `Singular` for small-magnitude matrices. `inv(n>3)` is now the pivoted LU solve; Gauss-Jordan is gone.
- `eigh` returns `error.NotConverged` instead of partial results; PCA's Gram cutoff is relative; `SMatrix.det/inv` work beyond 3×3.