### PR TITLE
fix: harden canvas, codecs, fonts and CLI against bad input

### DIFF
--- a/src/canvas/Canvas.zig
+++ b/src/canvas/Canvas.zig
@@ -64,6 +64,48 @@ const CoverageMax = struct {
 };
 
 /// How text glyphs are painted.
+/// Non-finite coordinates draw nothing rather than trip a float→int conversion.
+fn finitePoint(p: Point(2, f32)) bool {
+    return std.math.isFinite(p.x()) and std.math.isFinite(p.y());
+}
+
+fn finiteRect(rect: Rectangle(f32)) bool {
+    return std.math.isFinite(rect.l) and std.math.isFinite(rect.t) and std.math.isFinite(rect.r) and std.math.isFinite(rect.b);
+}
+
+/// Liang–Barsky: the part of segment p1–p2 inside `rect`, or null when it misses. A segment
+/// already inside comes back untouched, so its rasterization is unchanged. Computed in f64:
+/// for endpoints far outside, the f32 parameters would round onto each other.
+fn clipSegment(p1: Point(2, f32), p2: Point(2, f32), rect: Rectangle(f32)) ?[2]Point(2, f32) {
+    const x1: f64 = p1.x();
+    const y1: f64 = p1.y();
+    const dx = @as(f64, p2.x()) - x1;
+    const dy = @as(f64, p2.y()) - y1;
+    var t0: f64 = 0;
+    var t1: f64 = 1;
+    const ps = [_]f64{ -dx, dx, -dy, dy };
+    const qs = [_]f64{ x1 - rect.l, rect.r - x1, y1 - rect.t, rect.b - y1 };
+    for (ps, qs) |p, q| {
+        if (p == 0) {
+            if (q < 0) return null;
+            continue;
+        }
+        const t = q / p;
+        if (p < 0) {
+            if (t > t1) return null;
+            t0 = @max(t0, t);
+        } else {
+            if (t < t0) return null;
+            t1 = @min(t1, t);
+        }
+    }
+    if (t0 == 0 and t1 == 1) return .{ p1, p2 };
+    return .{
+        .init(.{ @as(f32, @floatCast(x1 + t0 * dx)), @as(f32, @floatCast(y1 + t0 * dy)) }),
+        .init(.{ @as(f32, @floatCast(x1 + t1 * dx)), @as(f32, @floatCast(y1 + t1 * dy)) }),
+    };
+}
+
 const GlyphStyle = union(enum) {
     fill,
     /// Stroke width in pixels.
@@ -295,17 +337,22 @@ pub fn Canvas(comptime T: type) type {
         /// rectangle+caps; `.soft` antialiases via Wu (width 1) or distance-based rendering.
         pub fn drawLine(self: Self, p1: Point(2, f32), p2: Point(2, f32), color: anytype, width: u32, opts: DrawOptions) void {
             comptime assert(isColor(@TypeOf(color)));
-            if (width == 0) return;
+            if (width == 0 or !finitePoint(p1) or !finitePoint(p2)) return;
 
+            if (width == 1) {
+                // Pixel lines walk their whole length, so bound the ones that shoot far past
+                // the image; anything within the margin keeps its exact rasterization.
+                const margin = as(f32, self.image.rows + self.image.cols) + 2;
+                const box: Rectangle(f32) = .{ .l = -margin, .t = -margin, .r = as(f32, self.image.cols) + margin, .b = as(f32, self.image.rows) + margin };
+                const ends = clipSegment(p1, p2, box) orelse return;
+                return switch (opts.mode) {
+                    .fast => self.drawLineBresenham(ends[0], ends[1], color, opts.blending),
+                    .soft => self.drawLineXiaolinWu(ends[0], ends[1], color, opts.blending),
+                };
+            }
             switch (opts.mode) {
-                .fast => if (width == 1)
-                    self.drawLineBresenham(p1, p2, color, opts.blending)
-                else
-                    self.drawLineRectangle(p1, p2, width, color, opts),
-                .soft => if (width == 1)
-                    self.drawLineXiaolinWu(p1, p2, color, opts.blending)
-                else
-                    self.drawLineDistance(p1, p2, width, color, opts),
+                .fast => self.drawLineRectangle(p1, p2, width, color, opts),
+                .soft => self.drawLineDistance(p1, p2, width, color, opts),
             }
         }
 
@@ -593,6 +640,7 @@ pub fn Canvas(comptime T: type) type {
         /// Supports alpha blending for RGBA images with the normal blend mode.
         /// For rotation, scaling, or custom blend modes, users should access the canvas's image field directly.
         pub fn drawImage(self: Self, source: anytype, position: Point(2, f32), source_rect_opt: ?Rectangle(u32), blend_mode: Blending) void {
+            if (!finitePoint(position)) return;
             const full_rect = source.getRectangle();
             const src_rect = full_rect.intersect(source_rect_opt orelse full_rect) orelse return;
 
@@ -637,7 +685,7 @@ pub fn Canvas(comptime T: type) type {
         /// axis-aligned rectangles, exact and in one pass.
         pub fn drawRectangle(self: Self, rect: Rectangle(f32), color: anytype, width: u32, opts: DrawOptions) void {
             comptime assert(isColor(@TypeOf(color)));
-            if (width == 0) return;
+            if (width == 0 or !finiteRect(rect)) return;
             const l = rect.l;
             const t = rect.t;
             const r = rect.r - 1;
@@ -819,6 +867,7 @@ pub fn Canvas(comptime T: type) type {
         /// Fractional edges are truncated to whole pixels, so `opts.mode` has no effect here.
         pub fn fillRectangle(self: Self, rect: Rectangle(f32), color: anytype, opts: DrawOptions) void {
             comptime assert(isColor(@TypeOf(color)));
+            if (!finiteRect(rect)) return;
 
             const bounds = self.clampRectToImage(rect) orelse return;
             const paint: Paint = .init(color, opts.blending);
@@ -832,7 +881,7 @@ pub fn Canvas(comptime T: type) type {
         /// Use DrawMode.soft for anti-aliased edges or DrawMode.fast for fast aliased edges.
         pub fn drawCircle(self: Self, center: Point(2, f32), radius: f32, color: anytype, width: u32, opts: DrawOptions) void {
             comptime assert(isColor(@TypeOf(color)));
-            if (radius <= 0 or width == 0) return;
+            if (!(radius > 0) or !std.math.isFinite(radius) or !finitePoint(center) or width == 0) return;
             self.strokeRing(center, radius, .full, width, color, opts);
         }
 
@@ -846,7 +895,7 @@ pub fn Canvas(comptime T: type) type {
         /// ```
         pub fn drawArc(self: Self, center: Point(2, f32), radius: f32, start_angle: f32, end_angle: f32, color: anytype, width: u32, opts: DrawOptions) !void {
             comptime assert(isColor(@TypeOf(color)));
-            if (radius <= 0 or width == 0) return;
+            if (!(radius > 0) or !std.math.isFinite(radius) or !finitePoint(center) or width == 0) return;
             const arc = ArcRange.fromAngles(start_angle, end_angle) orelse return;
             self.strokeRing(center, radius, arc, width, color, opts);
         }
@@ -1269,6 +1318,9 @@ pub fn Canvas(comptime T: type) type {
         /// wider ones go through `strokePolylines`.
         fn strokePath(self: Self, polys: []const []const Point(2, f32), closed: bool, width: u32, color: anytype, opts: DrawOptions) void {
             if (width == 0) return;
+            for (polys) |points| {
+                for (points) |p| if (!finitePoint(p)) return;
+            }
             if (width == 1) {
                 for (polys) |points| {
                     if (points.len == 0) continue;
@@ -1292,6 +1344,7 @@ pub fn Canvas(comptime T: type) type {
             var bounds: ?Rectangle(f32) = null;
             for (contours) |polygon| {
                 if (polygon.len < 3) continue;
+                for (polygon) |p| if (!finitePoint(p)) return;
                 vertices += polygon.len;
                 const box: Rectangle(f32) = .fromPoints(polygon);
                 bounds = if (bounds) |acc| acc.merge(box) else box;
@@ -1340,8 +1393,10 @@ pub fn Canvas(comptime T: type) type {
             // Pixel (r, c) spans [c - 0.5, c + 0.5) x [r - 0.5, r + 0.5); in accumulation space
             // it is the unit cell at (r - row_start, c - col_start).
             const frows: f32 = @floatFromInt(self.image.rows);
+            const row_end_f = @min(frows, bounds.b + 0.5);
+            if (row_end_f <= 0) return; // entirely above the image
             const row_start: usize = @floor(@max(0, bounds.t + 0.5));
-            const row_end: usize = @ceil(@min(frows, bounds.b + 0.5));
+            const row_end: usize = @ceil(row_end_f);
             if (row_start >= row_end) return;
             const height = row_end - row_start;
             const col_start: i64 = @floor(bounds.l + 0.5);
@@ -1748,7 +1803,7 @@ pub fn Canvas(comptime T: type) type {
         /// Use DrawMode.soft for anti-aliased edges or DrawMode.fast for hard edges.
         pub fn fillCircle(self: Self, center: Point(2, f32), radius: f32, color: anytype, opts: DrawOptions) void {
             comptime assert(isColor(@TypeOf(color)));
-            if (radius <= 0) return;
+            if (!(radius > 0) or !std.math.isFinite(radius) or !finitePoint(center)) return;
 
             switch (opts.mode) {
                 .fast => self.fillCircleFast(center, radius, color, opts.blending),
@@ -1766,7 +1821,7 @@ pub fn Canvas(comptime T: type) type {
         /// ```
         pub fn fillArc(self: Self, center: Point(2, f32), radius: f32, start_angle: f32, end_angle: f32, color: anytype, opts: DrawOptions) !void {
             comptime assert(isColor(@TypeOf(color)));
-            if (radius <= 0) return;
+            if (!(radius > 0) or !std.math.isFinite(radius) or !finitePoint(center)) return;
             const arc = ArcRange.fromAngles(start_angle, end_angle) orelse return;
             if (arc.isFull()) return self.fillCircle(center, radius, color, opts);
             switch (opts.mode) {
@@ -2079,6 +2134,7 @@ pub fn Canvas(comptime T: type) type {
         /// `font.defaultSize()`, a bitmap font's native size. `\n` starts a new line.
         pub fn drawText(self: Self, text: []const u8, position: Point(2, f32), color: anytype, font: Font, font_size: ?f32, opts: DrawOptions) !void {
             comptime assert(isColor(@TypeOf(color)));
+            if (!finitePoint(position)) return;
             return self.renderText(text, unboundedBox(position), .init(color, opts.blending), font, font_size, .default, .fill, opts.mode);
         }
 
@@ -2087,6 +2143,7 @@ pub fn Canvas(comptime T: type) type {
         /// is clipped by the image only, not the box.
         pub fn drawTextBox(self: Self, text: []const u8, box: Rectangle(f32), color: anytype, font: Font, font_size: ?f32, layout: TextLayout, opts: DrawOptions) !void {
             comptime assert(isColor(@TypeOf(color)));
+            if (!finiteRect(box)) return;
             return self.renderText(text, box, .init(color, opts.blending), font, font_size, layout, .fill, opts.mode);
         }
 
@@ -2095,12 +2152,14 @@ pub fn Canvas(comptime T: type) type {
         /// diameter; draw the text over it for a readable label.
         pub fn drawTextOutline(self: Self, text: []const u8, position: Point(2, f32), color: anytype, font: Font, font_size: ?f32, width: f32, opts: DrawOptions) !void {
             comptime assert(isColor(@TypeOf(color)));
+            if (!finitePoint(position)) return;
             return self.renderText(text, unboundedBox(position), .init(color, opts.blending), font, font_size, .default, .{ .outline = width }, opts.mode);
         }
 
         /// `drawTextBox` stroking the glyphs as `drawTextOutline` does.
         pub fn drawTextBoxOutline(self: Self, text: []const u8, box: Rectangle(f32), color: anytype, font: Font, font_size: ?f32, width: f32, layout: TextLayout, opts: DrawOptions) !void {
             comptime assert(isColor(@TypeOf(color)));
+            if (!finiteRect(box)) return;
             return self.renderText(text, box, .init(color, opts.blending), font, font_size, layout, .{ .outline = width }, opts.mode);
         }
 
@@ -2120,7 +2179,7 @@ pub fn Canvas(comptime T: type) type {
         /// the one wrapping pass, since placing the block needs their count first.
         fn renderText(self: Self, text: []const u8, box: Rectangle(f32), paint: Paint, font: Font, font_size: ?f32, layout: TextLayout, style: GlyphStyle, mode: DrawMode) !void {
             const px = font_size orelse font.defaultSize();
-            if (px <= 0) return;
+            if (!(px > 0) or !std.math.isFinite(px)) return;
             const max_width: ?f32 = if (layout.wrap) box.width() else null;
             var lines: text_layout.Lines = .init(font, text, px, max_width, layout.letter_spacing);
             var stack: [lines_scratch_size]u8 align(16) = undefined;
@@ -2235,7 +2294,9 @@ pub fn Canvas(comptime T: type) type {
         /// coverage mask, dilates it by the stroke radius and blits it once, so the halo
         /// composites like any other shape.
         fn drawTextBitmap(self: Self, text: []const u8, position: Point(2, f32), paint: Paint, font: BitmapFont, scale: f32, letter_spacing: f32, style: GlyphStyle, mode: DrawMode) !void {
-            const radius: u32 = @ceil(style.reach());
+            const reach = style.reach();
+            if (!std.math.isFinite(reach)) return;
+            const radius: u32 = @ceil(@max(0, reach));
             if (radius == 0) return self.blitBitmapLine(text, position, paint, font, scale, letter_spacing, mode);
             // A few overwriting stamps of the unscaled (hard-edged) glyphs cannot double-blend
             // and beat the mask. Stamping per glyph, not per line, keeps the text walk to one.

--- a/src/canvas/tests/drawing.zig
+++ b/src/canvas/tests/drawing.zig
@@ -955,3 +955,38 @@ test "a soft fill is unaffected by the fill before it" {
     try canvas_alone.fillPolygons(&.{&quad}, Rgba.black, .nonzero, .soft);
     try testing.expectEqualSlices(Rgba, alone.data, after.data);
 }
+
+test "shapes off the image or with non-finite input draw nothing" {
+    const allocator = testing.allocator;
+    var img = try Image(u8).init(allocator, 10, 10);
+    defer img.deinit(allocator);
+    img.fill(0);
+    const canvas = Canvas(u8).init(allocator, img);
+    const white: u8 = 255;
+    const nan = std.math.nan(f32);
+    const inf = std.math.inf(f32);
+    const above: []const Point(2, f32) = &.{ .init(.{ 1, -50 }), .init(.{ 8, -50 }), .init(.{ 8, -40 }), .init(.{ 1, -40 }) };
+    const nan_poly: []const Point(2, f32) = &.{ .init(.{ 1, nan }), .init(.{ 8, 1 }), .init(.{ 8, 8 }) };
+    for ([_]DrawOptions{ .soft, .fast }) |opts| {
+        canvas.drawPolygon(above, white, 3, opts);
+        try canvas.fillPolygons(&.{above}, white, .nonzero, opts);
+        try canvas.fillPolygon(above, white, opts);
+        canvas.drawPolygon(nan_poly, white, 3, opts);
+        try canvas.fillPolygon(nan_poly, white, opts);
+        canvas.drawLine(.init(.{ nan, 0 }), .init(.{ 5, 5 }), white, 1, opts);
+        canvas.drawLine(.init(.{ -1e9, -50 }), .init(.{ 1e9, -40 }), white, 1, opts);
+        canvas.drawCircle(.init(.{ nan, 5 }), 3, white, 1, opts);
+        canvas.fillCircle(.init(.{ 5, 5 }), inf, white, opts);
+        canvas.drawRectangle(.{ .l = nan, .t = 0, .r = 5, .b = 5 }, white, 1, opts);
+        canvas.fillRectangle(.{ .l = 0, .t = 0, .r = inf, .b = nan }, white, opts);
+        try canvas.drawArc(.init(.{ 5, nan }), 3, 0, 1, white, 1, opts);
+        try canvas.fillArc(.init(.{ 5, 5 }), nan, 0, 1, white, opts);
+    }
+    for (img.data) |px| try expect(px == 0);
+
+    // A pixel line that shoots far past the image still draws its visible part.
+    canvas.drawLine(.init(.{ -1e9, 5 }), .init(.{ 1e9, 5 }), white, 1, .fast);
+    try expectEqual(@as(u8, 255), img.at(5, 5).*);
+    canvas.drawLine(.init(.{ 2, -1e9 }), .init(.{ 3, 1e9 }), white, 1, .soft);
+    try expect(img.at(0, 2).* > 0 or img.at(0, 3).* > 0);
+}

--- a/src/cli/diff.zig
+++ b/src/cli/diff.zig
@@ -50,7 +50,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     if (parsed.positionals.len != 2) {
         std.log.err("expected exactly two input images.", .{});
         try args.printHelp(writer, help);
-        return;
+        return error.InvalidArguments;
     }
 
     const path1 = parsed.positionals[0];
@@ -61,14 +61,14 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     std.log.debug("loading first image: {s}", .{path1});
     var img1 = zignal.Image(zignal.Rgba(u8)).load(io, gpa, path1) catch |err| {
         std.log.err("failed to load image '{s}': {t}", .{ path1, err });
-        return;
+        return err;
     };
     defer img1.deinit(gpa);
 
     std.log.debug("loading second image: {s}", .{path2});
     var img2 = zignal.Image(zignal.Rgba(u8)).load(io, gpa, path2) catch |err| {
         std.log.err("failed to load image '{s}': {t}", .{ path2, err });
-        return;
+        return err;
     };
     defer img2.deinit(gpa);
 
@@ -76,7 +76,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
         std.log.err("dimension mismatch: {d}x{d} vs {d}x{d}", .{
             img1.cols, img1.rows, img2.cols, img2.rows,
         });
-        return;
+        return error.DimensionMismatch;
     }
 
     const scale = parsed.options.scale orelse 1.0;

--- a/src/cli/fdm.zig
+++ b/src/cli/fdm.zig
@@ -34,9 +34,14 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     const parsed = try args.parse(Args, gpa, iterator);
     defer parsed.deinit(gpa);
 
-    if (parsed.help or parsed.positionals.len < 2 or parsed.positionals.len > 3) {
+    if (parsed.help) {
         try args.printHelp(writer, help);
         return;
+    }
+    if (parsed.positionals.len < 2 or parsed.positionals.len > 3) {
+        std.log.err("expected a source image, a target image and an optional output path.", .{});
+        try args.printHelp(writer, help);
+        return error.InvalidArguments;
     }
 
     const source_path = parsed.positionals[0];

--- a/src/cli/metrics.zig
+++ b/src/cli/metrics.zig
@@ -29,7 +29,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     if (parsed.positionals.len < 2) {
         std.log.err("not enough arguments, need at least two images (reference and target).", .{});
         try args.printHelp(writer, help);
-        return;
+        return error.InvalidArguments;
     }
 
     const ref_path = parsed.positionals[0];

--- a/src/codecs/bmp.zig
+++ b/src/codecs/bmp.zig
@@ -45,6 +45,8 @@ pub const DecodeLimits = struct {
     max_pixels: u64 = max_pixels_default,
     /// Maximum number of palette entries.
     max_palette_entries: u32 = max_palette_entries_default,
+
+    pub const default: DecodeLimits = .{};
 };
 
 /// DIB header variants, discriminated by the leading 4-byte size field.
@@ -262,10 +264,19 @@ fn readDibHeader(reader: *Io.Reader) !Header {
         const remaining = dib_size - 56;
         if (remaining > 0) _ = try reader.discard(.limited(remaining));
     } else if (dib_size > 40) {
-        // v2 (52) / v3 (56): some vendors put masks here. Skip past them — we
-        // re-read them as v3 BI_BITFIELDS trailing data below if relevant.
-        const skip = dib_size - 40;
-        _ = try reader.discard(.limited(skip));
+        // v2 (52) / v3 (56) carry the RGB (and for 56, alpha) masks in the header.
+        const extra = dib_size - 40;
+        if ((compression == .bitfields or compression == .alphabitfields) and extra >= 12) {
+            const r = try reader.takeInt(u32, .little);
+            const g = try reader.takeInt(u32, .little);
+            const b = try reader.takeInt(u32, .little);
+            const a: u32 = if (extra >= 16) try reader.takeInt(u32, .little) else 0;
+            header.masks = .{ .r = r, .g = g, .b = b, .a = a };
+            const rest = extra - @as(u32, if (extra >= 16) 16 else 12);
+            if (rest > 0) _ = try reader.discard(.limited(rest));
+        } else {
+            _ = try reader.discard(.limited(extra));
+        }
     }
 
     return header;

--- a/src/codecs/gif.zig
+++ b/src/codecs/gif.zig
@@ -54,6 +54,8 @@ pub const DecodeLimits = struct {
     max_frames: u32 = max_frames_default,
     /// Total composed pixels across all frames (decoder-bomb guard).
     max_total_pixels: u64 = max_total_pixels_default,
+
+    pub const default: DecodeLimits = .{};
 };
 
 /// GIF metadata returned by `getInfo`. `frame_count` and `loop_count` are
@@ -793,17 +795,33 @@ pub fn encode(comptime T: type, allocator: Allocator, image: Image(T), options: 
     const height: u16 = @intCast(image.rows);
     const num_pixels: usize = @as(usize, width) * @as(usize, height);
 
-    // 1) Resolve palette and produce per-pixel indices.
+    // 1) Resolve palette and produce per-pixel indices. Like the animated encoder, an
+    // Rgba image with transparent pixels reserves the last palette slot for them.
     var palette_buf: [256]Rgb = undefined;
     var palette: []const Rgb = palette_buf[0..0];
 
     const indices = try allocator.alloc(u8, num_pixels);
     defer allocator.free(indices);
+    const has_transparent = T == Rgba and blk: {
+        for (0..image.rows) |r| {
+            for (0..image.cols) |c| if (image.at(r, c).a < 128) break :blk true;
+        }
+        break :blk false;
+    };
+    var transparent_index: u8 = 0;
 
     if (options.palette) |custom| {
         if (custom.len < 2 or custom.len > 256) return error.PaletteTooSmall;
-        palette = custom;
-        try mapImageToPalette(T, allocator, image, palette, indices, options.dither, null);
+        if (has_transparent) {
+            if (custom.len >= 256) return error.PaletteTooLarge;
+            @memcpy(palette_buf[0..custom.len], custom);
+            palette_buf[custom.len] = .{ .r = 0, .g = 0, .b = 0 };
+            palette = palette_buf[0 .. custom.len + 1];
+            transparent_index = @intCast(custom.len);
+        } else {
+            palette = custom;
+        }
+        try mapImageToPalette(T, allocator, image, palette, indices, options.dither, if (has_transparent) transparent_index else null);
     } else if (T == u8) {
         // u8 → 256-entry linear gray palette; indices are the pixel values.
         @memcpy(&palette_buf, &quantize.linear_gray_256);
@@ -819,16 +837,21 @@ pub fn encode(comptime T: type, allocator: Allocator, image: Image(T), options: 
             }
         }
     } else {
-        const max_colors = @max(@as(u16, 2), @min(options.max_colors, 256));
-        const palette_size = try quantize.medianCut(T, allocator, image, &palette_buf, max_colors);
+        const reserve: u16 = if (has_transparent) 1 else 0;
+        const max_colors = @max(@as(u16, 2), @min(options.max_colors, 256) -| reserve);
+        var palette_size = try quantize.medianCut(T, allocator, image, &palette_buf, max_colors);
         if (palette_size < 2) {
             // GIF requires at least 2 entries (min_code_size floor).
             palette_buf[1] = palette_buf[0];
-            palette = palette_buf[0..2];
-        } else {
-            palette = palette_buf[0..palette_size];
+            palette_size = 2;
         }
-        try mapImageToPalette(T, allocator, image, palette, indices, options.dither, null);
+        if (has_transparent) {
+            palette_buf[palette_size] = .{ .r = 0, .g = 0, .b = 0 };
+            transparent_index = @intCast(palette_size);
+            palette_size += 1;
+        }
+        palette = palette_buf[0..palette_size];
+        try mapImageToPalette(T, allocator, image, palette, indices, options.dither, if (has_transparent) transparent_index else null);
     }
 
     var min_code_size: u4 = 2;
@@ -848,6 +871,17 @@ pub fn encode(comptime T: type, allocator: Allocator, image: Image(T), options: 
     try out.append(allocator, 0); // pixel aspect ratio
 
     try writeColorTable(allocator, &out, palette, declared_entries);
+
+    if (has_transparent) {
+        // Graphic Control Extension naming the transparent index.
+        try out.append(allocator, block_extension_introducer);
+        try out.append(allocator, ext_label_graphic_control);
+        try out.append(allocator, 0x04);
+        try out.append(allocator, gce_flag_transparent);
+        try writeU16Le(allocator, &out, 0);
+        try out.append(allocator, transparent_index);
+        try out.append(allocator, 0);
+    }
 
     try out.append(allocator, block_image_descriptor);
     try writeU16Le(allocator, &out, 0);
@@ -1050,7 +1084,7 @@ fn emitAnimatedFrame(
         }
     } else {
         const reserve: u16 = if (has_transparent) 1 else 0;
-        const max_colors = @max(@as(u16, 2), @min(options.max_colors, 256) - reserve);
+        const max_colors = @max(@as(u16, 2), @min(options.max_colors, 256) -| reserve);
         var size = try quantize.medianCut(T, gpa, frame, &palette_buf, max_colors);
         if (size < 2) {
             palette_buf[1] = palette_buf[0];
@@ -1831,4 +1865,21 @@ test "getInfo — image descriptor with local color table" {
     try expectEqual(@as(u32, 1), info.frame_count);
     try expect(info.has_global_color_table);
     try expectEqual(@as(u16, 2), info.global_color_table_size);
+}
+
+test "GIF encode keeps the transparent pixels of an Rgba image" {
+    const gpa = std.testing.allocator;
+    var img: Image(Rgba) = try .init(gpa, 4, 4);
+    defer img.deinit(gpa);
+    for (img.data, 0..) |*p, i| {
+        p.* = if (i % 3 == 0) .{ .r = 0, .g = 0, .b = 0, .a = 0 } else .{ .r = @intCast(i * 16), .g = 30, .b = 200, .a = 255 };
+    }
+    const bytes = try encode(Rgba, gpa, img, .default);
+    defer gpa.free(bytes);
+    var decoded = try loadFromBytes(Rgba, gpa, bytes, .{});
+    defer decoded.deinit(gpa);
+    for (img.data, decoded.data) |want, got| {
+        try std.testing.expectEqual(want.a, got.a);
+        if (want.a == 255) try std.testing.expect(@abs(@as(i32, want.r) - got.r) <= 8);
+    }
 }

--- a/src/codecs/png.zig
+++ b/src/codecs/png.zig
@@ -39,6 +39,8 @@ pub const DecodeLimits = struct {
     /// Maximum number of bytes produced by zlib inflate (including filter bytes,
     /// across all Adam7 passes when applicable).
     max_decompressed_bytes: usize = max_decompressed_default,
+
+    pub const default: DecodeLimits = .{};
 };
 
 const ChunkOrderState = struct {
@@ -898,6 +900,7 @@ pub fn toNativeImage(allocator: Allocator, png_state: *PngState) !union(enum) {
                     return error.ImageTooLarge;
                 }
                 var output_data = try allocator.alloc(Rgba, @intCast(total_pixels));
+                errdefer allocator.free(output_data);
 
                 for (0..height) |y| {
                     const src_row_start = y * (scanline_bytes + 1) + 1;
@@ -918,6 +921,7 @@ pub fn toNativeImage(allocator: Allocator, png_state: *PngState) !union(enum) {
                     return error.ImageTooLarge;
                 }
                 var output_data = try allocator.alloc(u8, @intCast(total_pixels));
+                errdefer allocator.free(output_data);
 
                 for (0..height) |y| {
                     const src_row_start = y * (scanline_bytes + 1) + 1;
@@ -941,6 +945,7 @@ pub fn toNativeImage(allocator: Allocator, png_state: *PngState) !union(enum) {
                     return error.ImageTooLarge;
                 }
                 var output_data = try allocator.alloc(Rgba, @intCast(total_pixels));
+                errdefer allocator.free(output_data);
 
                 for (0..height) |y| {
                     const src_row_start = y * (scanline_bytes + 1) + 1;
@@ -961,6 +966,7 @@ pub fn toNativeImage(allocator: Allocator, png_state: *PngState) !union(enum) {
                     return error.ImageTooLarge;
                 }
                 var output_data = try allocator.alloc(Rgb, @intCast(total_pixels));
+                errdefer allocator.free(output_data);
 
                 if (png_state.header.bit_depth == 8) {
                     // Optimized path for 8-bit RGB
@@ -1003,6 +1009,7 @@ pub fn toNativeImage(allocator: Allocator, png_state: *PngState) !union(enum) {
                 return error.ImageTooLarge;
             }
             var output_data = try allocator.alloc(Rgba, @intCast(total_pixels));
+            errdefer allocator.free(output_data);
 
             if (png_state.header.bit_depth == 8) {
                 // Optimized path for 8-bit RGBA
@@ -1062,6 +1069,7 @@ pub fn toNativeImage(allocator: Allocator, png_state: *PngState) !union(enum) {
             if (transparency != null) {
                 // Has transparency - convert to RGBA
                 var output_data = try allocator.alloc(Rgba, @intCast(total_pixels));
+                errdefer allocator.free(output_data);
                 const transparency_data = transparency.?;
 
                 for (0..height) |y| {
@@ -1103,6 +1111,7 @@ pub fn toNativeImage(allocator: Allocator, png_state: *PngState) !union(enum) {
             } else {
                 // No transparency - convert to RGB
                 var output_data = try allocator.alloc(Rgb, @intCast(total_pixels));
+                errdefer allocator.free(output_data);
 
                 for (0..height) |y| {
                     const src_row_start = y * (scanline_bytes + 1) + 1;
@@ -1402,22 +1411,16 @@ pub fn encode(comptime T: type, allocator: Allocator, image: Image(T), options: 
 
     switch (T) {
         u8, Rgb, Rgba => {
-            // Direct support - use image as-is
-            const image_bytes = image.asBytes();
-            return encodeRaw(allocator, image_bytes, image.cols, image.rows, color_type, 8, options);
+            // Views are packed into a contiguous copy first.
+            if (image.isContiguous()) return encodeRaw(allocator, image.asBytes(), image.cols, image.rows, color_type, 8, options);
+            var contiguous = try image.dupe(allocator);
+            defer contiguous.deinit(allocator);
+            return encodeRaw(allocator, contiguous.asBytes(), image.cols, image.rows, color_type, 8, options);
         },
         else => {
-            // Convert unsupported type to RGB
-            var rgb_image: Image(Rgb) = try .init(allocator, image.rows, image.cols);
+            var rgb_image = try image.convert(allocator, Rgb);
             defer rgb_image.deinit(allocator);
-
-            // Convert each pixel to RGB
-            for (image.data, 0..) |pixel, i| {
-                rgb_image.data[i] = convertColor(Rgb, pixel);
-            }
-
-            const image_bytes = rgb_image.asBytes();
-            return encodeRaw(allocator, image_bytes, image.cols, image.rows, color_type, 8, options);
+            return encodeRaw(allocator, rgb_image.asBytes(), image.cols, image.rows, color_type, 8, options);
         },
     }
 }
@@ -1806,6 +1809,7 @@ fn deinterlaceAdam7(allocator: Allocator, comptime T: type, decompressed: []u8, 
     }
 
     var output_data = try allocator.alloc(T, @intCast(total_pixels));
+    errdefer allocator.free(output_data);
     var data_offset: usize = 0;
 
     // Process each of the 7 Adam7 passes
@@ -1851,20 +1855,28 @@ fn deinterlaceAdam7(allocator: Allocator, comptime T: type, decompressed: []u8, 
 /// Extract grayscale pixel from Adam7 pass data with optional transparency
 fn extractGrayscalePixel(comptime T: type, src_row: []const u8, pass_x: usize, header: Header, transparency: ?[]const u8) T {
     var pixel_alpha: u8 = 255;
+    // The sample as stored, for the tRNS comparison; `pixel_value` is its 8-bit rendering.
+    var raw_sample: u16 = 0;
     const pixel_value: u8 = switch (header.bit_depth) {
-        8 => if (header.color_type == .grayscale_alpha) blk: {
-            if (pass_x * 2 + 1 < src_row.len) {
-                pixel_alpha = src_row[pass_x * 2 + 1];
+        8 => blk: {
+            if (header.color_type == .grayscale_alpha) {
+                if (pass_x * 2 + 1 < src_row.len) {
+                    pixel_alpha = src_row[pass_x * 2 + 1];
+                }
+                raw_sample = src_row[pass_x * 2];
+            } else {
+                raw_sample = src_row[pass_x];
             }
-            break :blk src_row[pass_x * 2];
-        } else src_row[pass_x],
+            break :blk @intCast(raw_sample);
+        },
         16 => blk: {
             const offset = if (header.color_type == .grayscale_alpha) pass_x * 4 else pass_x * 2;
             if (offset + 1 >= src_row.len) break :blk 0;
             if (header.color_type == .grayscale_alpha and offset + 3 < src_row.len) {
                 pixel_alpha = @intCast(std.mem.readInt(u16, src_row[offset + 2 .. offset + 4][0..2], .big) >> 8);
             }
-            break :blk @intCast(std.mem.readInt(u16, src_row[offset .. offset + 2][0..2], .big) >> 8);
+            raw_sample = std.mem.readInt(u16, src_row[offset .. offset + 2][0..2], .big);
+            break :blk @intCast(raw_sample >> 8);
         },
         1, 2, 4 => blk: {
             const bits_per_pixel = header.bit_depth;
@@ -1875,23 +1887,18 @@ fn extractGrayscalePixel(comptime T: type, src_row: []const u8, pass_x: usize, h
             const pixel_idx = pass_x % pixels_per_byte;
             const bit_offset: u3 = @intCast((pixels_per_byte - 1 - pixel_idx) * bits_per_pixel);
             const pixel_val = (src_row[byte_idx] >> bit_offset) & mask;
+            raw_sample = pixel_val;
             const scale_factor = 255 / mask;
             break :blk pixel_val * scale_factor;
         },
         else => 0,
     };
 
-    // Check for transparency (only for grayscale without alpha)
+    // tRNS for grayscale holds one 16-bit sample value in the image's bit depth.
     if (header.color_type == .grayscale) {
         if (transparency) |trans_data| {
-            if (trans_data.len >= 2) {
-                const transparent_value = if (header.is16Bit())
-                    @as(u8, @intCast(std.mem.readInt(u16, trans_data[0..2], .big) >> 8))
-                else
-                    trans_data[1]; // For 8-bit and sub-byte, use lower byte
-                if (pixel_value == transparent_value) {
-                    pixel_alpha = 0;
-                }
+            if (trans_data.len >= 2 and raw_sample == std.mem.readInt(u16, trans_data[0..2], .big)) {
+                pixel_alpha = 0;
             }
         }
     }
@@ -3487,4 +3494,38 @@ test "PNG grayscale with transparency chunk (tRNS)" {
 
     const pixel1 = extractGrayscalePixel(Rgba, &gs_src, 1, header, trans_slice);
     try std.testing.expectEqual(Rgba{ .r = 255, .g = 255, .b = 255, .a = 255 }, pixel1);
+}
+
+test "PNG encode of a view packs only the visible pixels" {
+    const gpa = std.testing.allocator;
+    var img: Image(Rgb) = try .init(gpa, 8, 8);
+    defer img.deinit(gpa);
+    for (img.data, 0..) |*p, i| p.* = .{ .r = @intCast(i % 256), .g = @intCast((i * 7) % 256), .b = @intCast((i * 13) % 256) };
+    const view = img.view(.{ .l = 2, .t = 3, .r = 7, .b = 6 });
+    try std.testing.expect(!view.isContiguous());
+
+    const bytes = try encode(Rgb, gpa, view, .default);
+    defer gpa.free(bytes);
+    var decoded = try loadFromBytes(Rgb, gpa, bytes, .{});
+    defer decoded.deinit(gpa);
+    try std.testing.expectEqual(view.rows, decoded.rows);
+    try std.testing.expectEqual(view.cols, decoded.cols);
+    for (0..view.rows) |r| for (0..view.cols) |c| {
+        try std.testing.expectEqual(view.at(r, c).*, decoded.at(r, c).*);
+    };
+}
+
+test "PNG grayscale tRNS matches the raw sample at every bit depth" {
+    // 4-bit: samples 0x3 and 0xA; tRNS names sample 3.
+    const h4: Header = .{ .width = 2, .height = 1, .bit_depth = 4, .color_type = .grayscale };
+    const row4 = [_]u8{0x3A};
+    const trns3: []const u8 = &.{ 0, 3 };
+    try std.testing.expectEqual(@as(u8, 0), extractGrayscalePixel(Rgba, &row4, 0, h4, trns3).a);
+    try std.testing.expectEqual(@as(u8, 255), extractGrayscalePixel(Rgba, &row4, 1, h4, trns3).a);
+    // 16-bit: 0x1234 is transparent, 0x1200 (same high byte) is not.
+    const h16: Header = .{ .width = 2, .height = 1, .bit_depth = 16, .color_type = .grayscale };
+    const row16 = [_]u8{ 0x12, 0x34, 0x12, 0x00 };
+    const trns16: []const u8 = &.{ 0x12, 0x34 };
+    try std.testing.expectEqual(@as(u8, 0), extractGrayscalePixel(Rgba, &row16, 0, h16, trns16).a);
+    try std.testing.expectEqual(@as(u8, 255), extractGrayscalePixel(Rgba, &row16, 1, h16, trns16).a);
 }

--- a/src/features/KeyPoint.zig
+++ b/src/features/KeyPoint.zig
@@ -15,7 +15,7 @@ y: f32,
 /// Diameter of the meaningful keypoint neighborhood
 size: f32,
 
-/// Computed orientation of the keypoint in degrees [0, 360)
+/// Computed orientation of the keypoint in degrees (-180, 180]
 angle: f32,
 
 /// The response by which the keypoint was detected (corner strength)

--- a/src/features/Tracer.zig
+++ b/src/features/Tracer.zig
@@ -63,7 +63,10 @@ pub const Tracer = struct {
 
                     if (raw_path.items.len >= self.min_path_length) {
                         if (self.simplification_epsilon > 0) {
-                            const simplified = try self.simplifyPath(raw_path.items);
+                            const simplified = self.simplifyPath(raw_path.items) catch |err| {
+                                raw_path.deinit(self.allocator);
+                                return err;
+                            };
                             raw_path.deinit(self.allocator);
                             try paths.append(self.allocator, simplified);
                         } else {

--- a/src/features/orb.zig
+++ b/src/features/orb.zig
@@ -153,7 +153,7 @@ fn detectWithPyramid(self: Orb, allocator: Allocator, pyramid: ImagePyramid(u8))
     defer all_keypoints.deinit(allocator);
 
     // Detect features at each pyramid level
-    for (0..self.n_levels) |level| {
+    for (0..pyramid.n_levels) |level| {
         if (level < self.first_level) continue;
 
         const level_image = pyramid.levels[level];
@@ -225,7 +225,7 @@ fn computeWithPyramid(self: Orb, allocator: Allocator, pyramid: ImagePyramid(u8)
     var descriptors = try allocator.alloc(BinaryDescriptor, keypoints.len);
 
     for (keypoints, 0..) |kp, i| {
-        const level = @min(@as(usize, @intCast(@max(0, kp.octave))), self.n_levels - 1);
+        const level = @min(@as(usize, @intCast(@max(0, kp.octave))), pyramid.n_levels - 1);
         const level_image = pyramid.levels[level];
 
         // Scale keypoint to pyramid level
@@ -660,4 +660,20 @@ test "ORB adaptive FAST threshold stays within bounds" {
     try expectEqual(@as(u8, 20), orb.computeAdaptiveThreshold(0));
     try expectEqual(true, orb.computeAdaptiveThreshold(10) >= 5);
     try expectEqual(true, orb.computeAdaptiveThreshold(11) >= 5);
+}
+
+test "ORB on an image smaller than the requested pyramid" {
+    const allocator = std.testing.allocator;
+    // 25 px: the default 8-level pyramid at 1.2 truncates before its last level.
+    var image = try Image(u8).init(allocator, 25, 25);
+    defer image.deinit(allocator);
+    image.fill(100);
+    for (5..15) |r| for (5..15) |c| {
+        image.at(r, c).* = 250;
+    };
+    const orb = Orb{ .n_features = 20, .fast_threshold = 10 };
+    const result = try orb.detectAndCompute(allocator, image);
+    defer allocator.free(result.keypoints);
+    defer allocator.free(result.descriptors);
+    try expectEqual(result.keypoints.len, result.descriptors.len);
 }

--- a/src/font/bdf.zig
+++ b/src/font/bdf.zig
@@ -87,8 +87,8 @@ pub fn parse(gpa: Allocator, bytes: []const u8, filter: LoadFilter) !BitmapFont 
     errdefer gpa.free(glyphs);
     return .{
         .name = state.font.name,
-        .char_width = @intCast(@abs(state.font.bbox_width)),
-        .char_height = @intCast(@abs(state.font.bbox_height)),
+        .char_width = std.math.cast(u8, @abs(state.font.bbox_width)) orelse return BdfError.InvalidFormat,
+        .char_height = std.math.cast(u8, @abs(state.font.bbox_height)) orelse return BdfError.InvalidFormat,
         .data = bitmap_data,
         .glyphs = glyphs,
         .font_ascent = state.font.ascent,
@@ -219,7 +219,7 @@ fn parseGlyph(gpa: Allocator, lines: *std.mem.TokenIterator(u8, .any), state: *B
                 return false;
             }
             // BDF offsets count up from the baseline; ours count down from the line's top.
-            info.y_offset = state.font.ascent - (bottom + @as(i16, info.height));
+            info.y_offset = std.math.cast(i16, @as(i32, state.font.ascent) - bottom - info.height) orelse return BdfError.InvalidFormat;
 
             const bytes_per_row = info.bytesPerRow();
             try state.bitmap_data.ensureUnusedCapacity(gpa, info.bitmapSize());

--- a/src/font/pcf.zig
+++ b/src/font/pcf.zig
@@ -104,11 +104,11 @@ const Metric = struct {
     const extents = .{ "left_sided_bearing", "right_sided_bearing", "character_width", "ascent", "descent" };
 
     fn width(self: Metric) u16 {
-        return @intCast(@abs(self.right_sided_bearing - self.left_sided_bearing));
+        return @intCast(@abs(@as(i32, self.right_sided_bearing) - self.left_sided_bearing));
     }
 
     fn height(self: Metric) u16 {
-        return @intCast(@abs(self.ascent + self.descent));
+        return @intCast(@abs(@as(i32, self.ascent) + self.descent));
     }
 };
 
@@ -382,9 +382,11 @@ fn parseEncodings(allocator: std.mem.Allocator, data: []const u8, table: TableEn
     encoding.max_byte1 = try t.reader.takeVarInt(u16, t.byte_order, @sizeOf(u16));
     try t.reader.discardAll(@sizeOf(u16)); // default_char
 
-    // Calculate total encodings with overflow protection
-    const cols: u32 = encoding.max_char_or_byte2 - encoding.min_char_or_byte2 + 1;
-    const rows: u32 = encoding.max_byte1 - encoding.min_byte1 + 1;
+    if (encoding.max_char_or_byte2 < encoding.min_char_or_byte2 or encoding.max_byte1 < encoding.min_byte1) {
+        return PcfError.InvalidEncodingRange;
+    }
+    const cols: u32 = @as(u32, encoding.max_char_or_byte2) - encoding.min_char_or_byte2 + 1;
+    const rows: u32 = @as(u32, encoding.max_byte1) - encoding.min_byte1 + 1;
     const encodings_count = cols * rows;
 
     // Both halves are bytes, so codepoints fit u16 and ascend with the table index.
@@ -509,9 +511,10 @@ fn convertToBitmapFont(
         try glyph_list.append(gpa, .{ .codepoint = codepoint, .glyph_index = glyph_index, .metric = metrics[glyph_index] });
     }
 
-    // Pre-calculate total bitmap size needed
+    // Pre-calculate total bitmap size needed; glyph extents must fit the u8 metrics.
     var total_bitmap_size: u32 = 0;
     for (glyph_list.items) |glyph_info| {
+        if (glyph_info.metric.width() > 255 or glyph_info.metric.height() > 255) return PcfError.InvalidBitmapData;
         total_bitmap_size += GlyphData.bytesForWidth(glyph_info.metric.width()) * glyph_info.metric.height();
     }
 

--- a/src/image.zig
+++ b/src/image.zig
@@ -107,17 +107,8 @@ pub fn Image(comptime T: type) type {
         /// Integral image operations for fast box filtering and region sums.
         pub const Integral = @import("image/integral.zig").Integral(T);
 
-        /// Creates an empty image with zero dimensions, used as a placeholder for output parameters.
-        /// When passed to functions like `rotateFrom()`, `blurBox()`, etc., the function will
-        /// automatically allocate and size the image appropriately. This eliminates the need
-        /// to pre-allocate or guess output dimensions.
-        ///
-        /// Example usage:
-        /// ```zig
-        /// var rotated: Image(u8) = .empty;
-        /// try image.rotateFrom(allocator, center, angle, &rotated); // Auto-sizes to optimal dimensions
-        /// defer rotated.deinit(allocator);
-        /// ```
+        /// An image with zero dimensions and no allocation: the initial value of an image that
+        /// is filled in later (`var img: Image(u8) = .empty;`). Safe to `deinit`.
         pub const empty: Self = .{ .rows = 0, .cols = 0, .data = &[_]T{}, .stride = 0 };
 
         /// Constructs an image of rows and cols size allocating its own memory.
@@ -318,7 +309,7 @@ pub fn Image(comptime T: type) type {
         ///
         /// Example usage:
         /// ```zig
-        /// try image.rotate(allocator, image.getCenter(), angle, &rotated);
+        /// const center = image.getCenter();
         /// ```
         pub fn getCenter(self: Self) Point(2, f32) {
             return .init(.{
@@ -811,10 +802,8 @@ pub fn Image(comptime T: type) type {
         /// Example usage:
         /// ```zig
         /// var img = try Image(u8).load(io, allocator, "low_contrast.png");
-        /// var equalized = try img.equalize(allocator);
-        /// defer equalized.deinit(allocator);
+        /// img.equalize();
         /// ```
-        /// Equalizes the histogram to improve contrast. Modifies in-place.
         pub fn equalize(self: Self) void {
             return Enhancement(T).equalize(self);
         }
@@ -1130,7 +1119,7 @@ pub fn Image(comptime T: type) type {
         /// Computes the difference between `self` and `other` per pixel/channel.
         /// The result is stored in `out`, which must have the same dimensions.
         /// Applies scaling, thresholding, and visualization options in a single pass.
-        pub fn diff(self: Self, out: Self, other: Self, opts: DiffOptions) !DiffResult {
+        pub fn diff(self: Self, other: Self, out: Self, opts: DiffOptions) !DiffResult {
             return diff_mod.compute(T, self, out, other, opts);
         }
 
@@ -1263,4 +1252,6 @@ test {
     _ = @import("image/convolution.zig");
     _ = @import("image/order_statistic_blur.zig");
     _ = @import("image/tests/flood_fill.zig");
+    _ = @import("image/pyramid.zig");
+    _ = @import("image/metrics.zig");
 }

--- a/src/image/enhancement.zig
+++ b/src/image/enhancement.zig
@@ -116,7 +116,7 @@ pub fn Enhancement(comptime T: type) type {
                     } else {
                         for (0..256) |i| {
                             if (cdf[i] >= cdf_min) {
-                                const numerator = (cdf[i] - cdf_min) * 255;
+                                const numerator = @as(u64, cdf[i] - cdf_min) * 255;
                                 lut[i] = @intCast(numerator / denominator);
                             } else {
                                 lut[i] = 0;
@@ -209,7 +209,7 @@ pub fn Enhancement(comptime T: type) type {
                                 } else {
                                     for (0..256) |i| {
                                         if (cdf[i] >= cdf_min) {
-                                            const numerator = (cdf[i] - cdf_min) * 255;
+                                            const numerator = @as(u64, cdf[i] - cdf_min) * 255;
                                             lut[i] = @intCast(numerator / denominator);
                                         } else {
                                             lut[i] = 0;
@@ -244,10 +244,10 @@ pub fn Enhancement(comptime T: type) type {
                             }
                         }
                     } else {
-                        return error.UnsupportedType;
+                        @compileError("equalize: unsupported pixel type " ++ @typeName(T));
                     }
                 },
-                else => return error.UnsupportedType,
+                else => @compileError("equalize: unsupported pixel type " ++ @typeName(T)),
             }
         }
     };

--- a/src/image/hough.zig
+++ b/src/image/hough.zig
@@ -71,7 +71,8 @@ pub const HoughTransform = struct {
         self.allocator.free(self.y_cache);
     }
 
-    /// Performs the Hough Transform on a binary edge image.
+    /// Performs the Hough Transform on a binary edge image, adding votes to `accumulator`,
+    /// which the caller allocates and zeroes.
     pub fn compute(self: Self, edges: Image(u8), box: Rectangle(u32), accumulator: Image(u32)) void {
         assert(box.width() == self.size and box.height() == self.size);
         assert(accumulator.rows == self.size and accumulator.cols == self.size);

--- a/src/image/interpolation.zig
+++ b/src/image/interpolation.zig
@@ -8,7 +8,7 @@
 //!
 //! ### Basic interpolation:
 //! ```zig
-//! const pixel = image.interpolate(100.5, 50.3, .bilinear);
+//! const pixel = image.interpolate(100.5, 50.3, .bilinear, .mirror);
 //! ```
 //!
 //! ### Resize with different methods:
@@ -315,8 +315,7 @@ fn interpolateBilinear(comptime T: type, self: Image(T), x: f32, y: f32, border:
         }
     }.get;
 
-    // Original behavior: if any neighbor is out of bounds with .mirror, return null.
-    // For .zero, we continue with zeroes.
+    // With .mirror any out-of-bounds neighbor yields null; .zero continues with zeroes.
     if (border == .mirror) {
         if (r0_opt == null or r1_opt == null or c0_opt == null or c1_opt == null) return null;
     }

--- a/src/image/metrics.zig
+++ b/src/image/metrics.zig
@@ -45,6 +45,7 @@ pub fn psnr(comptime T: type, image_a: Image(T), image_b: Image(T)) !f64 {
         }
     }
 
+    if (component_count == 0) return error.ImageTooSmall;
     mse /= @as(f64, @floatFromInt(component_count));
     if (mse == 0.0) return std.math.inf(f64);
 

--- a/src/image/motion_blur.zig
+++ b/src/image/motion_blur.zig
@@ -258,6 +258,7 @@ pub fn MotionBlurOps(comptime T: type) type {
             strength: f32,
             blur_type: RadialType,
         ) !void {
+            if (image.rows == 0 or image.cols == 0) return;
             if (strength == 0) {
                 image.copy(out);
                 return;
@@ -266,6 +267,10 @@ pub fn MotionBlurOps(comptime T: type) type {
             // Convert normalized center to pixel coordinates
             const cx = center_x * @as(f32, @floatFromInt(image.cols - 1));
             const cy = center_y * @as(f32, @floatFromInt(image.rows - 1));
+            // Full strength is reached at the farthest corner, whatever the center.
+            const far_x = @max(cx, @as(f32, @floatFromInt(image.cols - 1)) - cx);
+            const far_y = @max(cy, @as(f32, @floatFromInt(image.rows - 1)) - cy);
+            const max_distance = @max(@sqrt(far_x * far_x + far_y * far_y), std.math.floatEps(f32));
 
             // Clamp strength to [0, 1]
             const clamped_strength = @max(0, @min(1, strength));
@@ -278,7 +283,6 @@ pub fn MotionBlurOps(comptime T: type) type {
             switch (@typeInfo(T)) {
                 .int, .float => {
                     // Process scalar types
-                    const max_distance = @sqrt(cx * cx + cy * cy);
                     for (0..image.rows) |r| {
                         for (0..image.cols) |c| {
                             const fx = @as(f32, @floatFromInt(c));
@@ -360,7 +364,6 @@ pub fn MotionBlurOps(comptime T: type) type {
                     // once per sample and accumulate all channels; the per-channel bilinear
                     // keeps the same two-stage form, so results are bit-identical.
                     const fields = comptime meta.structFields(T);
-                    const max_distance = @sqrt(cx * cx + cy * cy);
                     for (0..image.rows) |r| {
                         for (0..image.cols) |c| {
                             const fx = @as(f32, @floatFromInt(c));

--- a/src/image/pyramid.zig
+++ b/src/image/pyramid.zig
@@ -40,11 +40,10 @@ pub fn ImagePyramid(comptime T: type) type {
             assert(blur_sigma > 0);
 
             var levels = try allocator.alloc(Image(T), n_levels);
+            @memset(levels, .empty);
             errdefer {
-                for (levels, 0..) |*level, i| {
-                    if (i > 0 and level.rows > 0) {
-                        level.deinit(allocator);
-                    }
+                for (levels[1..]) |*level| {
+                    if (level.rows > 0) level.deinit(allocator);
                 }
                 allocator.free(levels);
             }

--- a/src/image/tests/transforms.zig
+++ b/src/image/tests/transforms.zig
@@ -454,3 +454,16 @@ test "flipTopBottom" {
     };
     try expectEqualDeep(expected, data);
 }
+
+test "insert with a rectangle outside the image or a NaN angle is a no-op" {
+    const allocator = std.testing.allocator;
+    var dest = try Image(u8).init(allocator, 10, 10);
+    defer dest.deinit(allocator);
+    dest.fill(0);
+    var source = try Image(u8).init(allocator, 4, 4);
+    defer source.deinit(allocator);
+    source.fill(255);
+    dest.insert(source, .{ .l = -20, .t = -20, .r = -10, .b = -10 }, 0.3, .bilinear, color.Blending.none);
+    dest.insert(source, .{ .l = 2, .t = 2, .r = 6, .b = 6 }, std.math.nan(f32), .bilinear, color.Blending.none);
+    for (dest.data) |px| try std.testing.expectEqual(@as(u8, 0), px);
+}

--- a/src/image/transforms.zig
+++ b/src/image/transforms.zig
@@ -79,9 +79,9 @@ pub fn Transform(comptime T: type) type {
             // Choose the smaller scale to maintain aspect ratio
             const aspect_scale = @min(rows_scale, cols_scale);
 
-            // Calculate dimensions of the scaled image (ensure at least 1 pixel)
-            const scaled_rows: u32 = @round(aspect_scale * @as(f32, @floatFromInt(self.rows)));
-            const scaled_cols: u32 = @round(aspect_scale * @as(f32, @floatFromInt(self.cols)));
+            // Dimensions of the scaled image, at least 1 pixel each way
+            const scaled_rows: u32 = @max(1, @as(u32, @round(aspect_scale * @as(f32, @floatFromInt(self.rows)))));
+            const scaled_cols: u32 = @max(1, @as(u32, @round(aspect_scale * @as(f32, @floatFromInt(self.cols)))));
 
             // Calculate offset to center the image
             const offset_row = (out.rows -| scaled_rows) / 2;
@@ -338,10 +338,18 @@ pub fn Transform(comptime T: type) type {
             const bound_hw = half_width * abs_cos + half_height * abs_sin;
             const bound_hh = half_width * abs_sin + half_height * abs_cos;
 
-            const min_r: u32 = if (cy - bound_hh < 0) 0 else @as(u32, @floor(cy - bound_hh));
-            const max_r: u32 = @min(self.rows, @as(u32, @ceil(cy + bound_hh)) + 1);
-            const min_c: u32 = if (cx - bound_hw < 0) 0 else @as(u32, @floor(cx - bound_hw));
-            const max_c: u32 = @min(self.cols, @as(u32, @ceil(cx + bound_hw)) + 1);
+            // A rectangle that misses the image (or carries NaN) touches no pixel.
+            const top = cy - bound_hh;
+            const bottom = cy + bound_hh;
+            const left = cx - bound_hw;
+            const right = cx + bound_hw;
+            const rows_f: f32 = @floatFromInt(self.rows);
+            const cols_f: f32 = @floatFromInt(self.cols);
+            if (!(bottom >= 0 and right >= 0 and top < rows_f and left < cols_f)) return;
+            const min_r: u32 = @floor(@max(0, top));
+            const max_r: u32 = @min(self.rows, @as(u32, @ceil(@min(bottom, rows_f))) + 1);
+            const min_c: u32 = @floor(@max(0, left));
+            const max_c: u32 = @min(self.cols, @as(u32, @ceil(@min(right, cols_f))) + 1);
 
             // Only iterate over potentially affected pixels
             for (min_r..max_r) |r| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -130,6 +130,7 @@ pub const Cli = struct {
                     if (err != error.BatchIncomplete) {
                         std.log.err("{s} command failed: {t}", .{ cmd_name, err });
                     }
+                    stdout.flush() catch {};
                     std.process.exit(1);
                 };
                 return;

--- a/src/meta.zig
+++ b/src/meta.zig
@@ -135,7 +135,7 @@ pub fn clamp(comptime T: type, value: anytype) T {
 }
 
 /// Check if a type is an RGB or RGBA type with u8 components.
-/// Returns true for structs with 3 or 4 u8 fields named (r,g,b[,a]) or (red,green,blue[,alpha]).
+/// Returns true for structs with 3 or 4 u8 fields named r, g, b[, a].
 ///
 /// Example usage:
 /// ```zig

--- a/src/terminal/detect.zig
+++ b/src/terminal/detect.zig
@@ -297,9 +297,9 @@ const State = struct {
 
                         if (total_read >= buffer.len) break :poll;
 
-                        // Stop at common response terminators
+                        // Stop at the final byte of DA (c), CPR (R), XTSMGRAPHICS (S) or a string terminator
                         const char: u8 = @intCast(ch);
-                        if ((char == 'c' or char == 'R' or char == '\\' or char == ';') and total_read > 3) {
+                        if ((char == 'c' or char == 'R' or char == 'S' or char == '\\') and total_read > 3) {
                             break :poll;
                         }
                     }


### PR DESCRIPTION
Stacked on `audit/jpeg`.

- Canvas: shapes entirely above the image no longer coerce a negative row to `usize`; non-finite coordinates draw nothing; far-off pixel lines are clipped before the pixel walk.
- ORB iterates the pyramid that was actually built; PNG/JPEG encode views correctly; PNG palette/Adam7 paths free on error; grayscale tRNS compares the raw sample.
- `insert` with an off-image or NaN rect is a no-op; pcf/bdf validate metrics before narrowing casts; `equalize` accumulates in u64; radial blur handles empty images and off-centre zoom.
- BMP v2/v3 header masks; GIF single-frame encode keeps Rgba transparency; `psnr` on an empty image errors.
- CLI commands exit non-zero on failure and flush stdout; Windows terminal reader stops at the reply terminator, not `;`; Tracer error-path leak.
- Option structs expose `.default`; pyramid/metrics tests are wired in; stale docs fixed.