### PR TITLE
refactor(image): allocator before out in out-param methods

### DIFF
--- a/bindings/python/src/image/binary.zig
+++ b/bindings/python/src/image/binary.zig
@@ -102,7 +102,7 @@ pub fn image_threshold_otsu(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv
         python.setMemoryError("threshold operation");
         return null;
     };
-    const threshold = handle.view.thresholdOtsu(out, allocator) catch {
+    const threshold = handle.view.thresholdOtsu(allocator, out) catch {
         python.setMemoryError("threshold operation");
         return null;
     };
@@ -175,7 +175,7 @@ pub fn image_threshold_adaptive_mean(self_obj: ?*c.PyObject, args: ?*c.PyObject,
         python.setMemoryError("adaptive threshold operation");
         return null;
     };
-    handle.view.thresholdAdaptiveMean(out, allocator, radius, @floatCast(c_value)) catch |err| {
+    handle.view.thresholdAdaptiveMean(allocator, out, radius, @floatCast(c_value)) catch |err| {
         switch (err) {
             error.InvalidRadius => python.setValueError("radius must be > 0", .{}),
             else => python.setMemoryError("threshold operation"),
@@ -217,10 +217,10 @@ fn morphologyCommon(
         return null;
     };
     const result = switch (op) {
-        .dilate => handle.view.dilateBinary(out, allocator, kernel, iterations),
-        .erode => handle.view.erodeBinary(out, allocator, kernel, iterations),
-        .open => handle.view.openBinary(out, allocator, kernel, iterations),
-        .close => handle.view.closeBinary(out, allocator, kernel, iterations),
+        .dilate => handle.view.dilateBinary(allocator, out, kernel, iterations),
+        .erode => handle.view.erodeBinary(allocator, out, kernel, iterations),
+        .open => handle.view.openBinary(allocator, out, kernel, iterations),
+        .close => handle.view.closeBinary(allocator, out, kernel, iterations),
     };
 
     result catch {

--- a/bindings/python/src/image/filtering.zig
+++ b/bindings/python/src/image/filtering.zig
@@ -106,7 +106,7 @@ pub fn image_box_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyOb
                 python.setMemoryError("image operation");
                 return null;
             };
-            img.boxBlur(out, allocator, @intCast(r)) catch {
+            img.boxBlur(allocator, out, @intCast(r)) catch {
                 python.setMemoryError("image operation");
                 return null;
             };
@@ -147,7 +147,7 @@ pub fn image_median_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.P
                 python.setMemoryError("image operation");
                 return null;
             };
-            img.medianBlur(out, allocator, @intCast(r)) catch |err| {
+            img.medianBlur(allocator, out, @intCast(r)) catch |err| {
                 switch (err) {
                     error.InvalidRadius => python.setValueError("radius must be > 0", .{}),
                     error.UnsupportedPixelType => python.setValueError("median blur requires u8, RGB, or RGBA images", .{}),
@@ -198,7 +198,7 @@ pub fn image_min_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyOb
                 python.setMemoryError("image operation");
                 return null;
             };
-            img.minBlur(out, allocator, @intCast(r), b) catch |err| {
+            img.minBlur(allocator, out, @intCast(r), b) catch |err| {
                 switch (err) {
                     error.InvalidRadius => python.setValueError("radius must be > 0", .{}),
                     error.UnsupportedPixelType => python.setValueError("min blur requires u8, RGB, or RGBA images", .{}),
@@ -249,7 +249,7 @@ pub fn image_max_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyOb
                 python.setMemoryError("image operation");
                 return null;
             };
-            img.maxBlur(out, allocator, @intCast(r), b) catch |err| {
+            img.maxBlur(allocator, out, @intCast(r), b) catch |err| {
                 switch (err) {
                     error.InvalidRadius => python.setValueError("radius must be > 0", .{}),
                     error.UnsupportedPixelType => python.setValueError("max blur requires u8, RGB, or RGBA images", .{}),
@@ -300,7 +300,7 @@ pub fn image_midpoint_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c
                 python.setMemoryError("image operation");
                 return null;
             };
-            img.midpointBlur(out, allocator, @intCast(r), b) catch |err| {
+            img.midpointBlur(allocator, out, @intCast(r), b) catch |err| {
                 switch (err) {
                     error.InvalidRadius => python.setValueError("radius must be > 0", .{}),
                     error.UnsupportedPixelType => python.setValueError("midpoint blur requires u8, RGB, or RGBA images", .{}),
@@ -361,7 +361,7 @@ pub fn image_percentile_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?
                 python.setMemoryError("image operation");
                 return null;
             };
-            img.percentileBlur(out, allocator, @intCast(r), p, b) catch |err| {
+            img.percentileBlur(allocator, out, @intCast(r), p, b) catch |err| {
                 switch (err) {
                     error.InvalidRadius => python.setValueError("radius must be > 0", .{}),
                     error.InvalidPercentile => python.setValueError("percentile must be between 0 and 1", .{}),
@@ -420,7 +420,7 @@ pub fn image_alpha_trimmed_mean_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject,
                 python.setMemoryError("image operation");
                 return null;
             };
-            img.alphaTrimmedMeanBlur(out, allocator, @intCast(r), tf, b) catch |err| {
+            img.alphaTrimmedMeanBlur(allocator, out, @intCast(r), tf, b) catch |err| {
                 switch (err) {
                     error.InvalidRadius => python.setValueError("radius must be > 0", .{}),
                     error.InvalidTrim => python.setValueError("trim_fraction must be in [0, 0.5)", .{}),
@@ -469,7 +469,7 @@ pub fn image_gaussian_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c
                 python.setMemoryError("image operation");
                 return null;
             };
-            img.gaussianBlur(out, allocator, @floatCast(s)) catch |err| {
+            img.gaussianBlur(allocator, out, @floatCast(s)) catch |err| {
                 if (err == error.InvalidSigma) {
                     python.setValueError("Invalid sigma value", .{});
                 } else {
@@ -548,7 +548,7 @@ pub fn image_sharpen(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObj
                 python.setMemoryError("image operation");
                 return null;
             };
-            img.sharpen(out, allocator, @intCast(r)) catch {
+            img.sharpen(allocator, out, @intCast(r)) catch {
                 python.setMemoryError("image operation");
                 return null;
             };
@@ -756,7 +756,7 @@ pub fn image_motion_blur(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.P
                 },
             };
 
-            img.motionBlur(out, allocator, blur_config) catch {
+            img.motionBlur(allocator, out, blur_config) catch {
                 python.setMemoryError("image operation");
                 return null;
             };
@@ -790,7 +790,7 @@ pub fn image_sobel(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.
                 python.setMemoryError("image operation");
                 return null;
             };
-            img.sobel(out, allocator) catch {
+            img.sobel(allocator, out) catch {
                 python.setMemoryError("image operation");
                 return null;
             };
@@ -904,7 +904,7 @@ pub fn image_shen_castan(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.P
                 python.setMemoryError("image operation");
                 return null;
             };
-            img.shenCastan(out, allocator, o) catch |err| {
+            img.shenCastan(allocator, out, o) catch |err| {
                 if (err == error.InvalidBParameter) {
                     c.PyErr_SetString(c.PyExc_ValueError, "smooth parameter must be between 0 and 1");
                 } else if (err == error.WindowSizeMustBeOdd) {
@@ -1001,7 +1001,7 @@ pub fn image_canny(self_obj: ?*c.PyObject, args: ?*c.PyObject, kwds: ?*c.PyObjec
                 python.setMemoryError("image operation");
                 return null;
             };
-            img.canny(out, allocator, s, l, h) catch |err| {
+            img.canny(allocator, out, s, l, h) catch |err| {
                 if (err == error.InvalidParameter) {
                     python.setValueError("parameters must be finite numbers", .{});
                 } else if (err == error.InvalidSigma) {

--- a/bindings/python/src/image/transforms.zig
+++ b/bindings/python/src/image/transforms.zig
@@ -53,7 +53,7 @@ fn image_reshape(self: *ImageObject, rows: u32, cols: u32, method: Interpolation
     return self.py_image.?.dispatch(.{ rows, cols, method }, struct {
         fn apply(img: anytype, r: u32, col: u32, m: Interpolation) !*ImageObject {
             const out = @TypeOf(img.*).init(allocator, r, col) catch return error.OutOfMemory;
-            img.resize(out, allocator, m);
+            img.resize(allocator, out, m);
             return moveImageToPython(out) orelse error.OutOfMemory;
         }
     }.apply);
@@ -64,7 +64,7 @@ fn image_letterbox_shape(self: *ImageObject, rows: u32, cols: u32, method: Inter
     return self.py_image.?.dispatch(.{ rows, cols, method }, struct {
         fn apply(img: anytype, r: u32, col: u32, m: Interpolation) !*ImageObject {
             const out = @TypeOf(img.*).init(allocator, r, col) catch return error.OutOfMemory;
-            _ = img.letterbox(out, allocator, m);
+            _ = img.letterbox(allocator, out, m);
             return moveImageToPython(out) orelse error.OutOfMemory;
         }
     }.apply);

--- a/examples/src/blur_box_vs_gaussian.zig
+++ b/examples/src/blur_box_vs_gaussian.zig
@@ -92,7 +92,7 @@ pub fn main(init: std.process.Init) !void {
     defer gaussian.deinit(init.gpa);
 
     const start_gaussian = std.Io.Clock.awake.now(init.io);
-    try original.gaussianBlur(gaussian, init.gpa, sigma);
+    try original.gaussianBlur(init.gpa, gaussian, sigma);
     const end_gaussian = std.Io.Clock.awake.now(init.io);
     const gaussian_ns = start_gaussian.durationTo(end_gaussian).toNanoseconds();
     try gaussian.save(init.io, init.gpa, "blur_gaussian.png");
@@ -133,7 +133,7 @@ pub fn main(init: std.process.Init) !void {
             const radius: u32 = @intCast((width - 1) / 2);
             const dst = scratch[scratch_index];
             scratch_index = (scratch_index + 1) % scratch.len;
-            try source.boxBlur(dst.*, init.gpa, radius);
+            try source.boxBlur(init.gpa, dst.*, radius);
             source = dst;
             last_result = dst;
         }

--- a/examples/src/convolution_bench.zig
+++ b/examples/src/convolution_bench.zig
@@ -81,7 +81,7 @@ fn benchGaussian(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random: s
         gpa: std.mem.Allocator,
         sigma: f32,
         fn run(self: @This()) !void {
-            try self.src.gaussianBlur(self.dst, self.gpa, self.sigma);
+            try self.src.gaussianBlur(self.gpa, self.dst, self.sigma);
         }
     };
     try benchOp(io, name, rows, cols, Ctx{ .src = src, .dst = dst, .gpa = gpa, .sigma = sigma });
@@ -103,7 +103,7 @@ fn benchConvolve2D(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random:
         gpa: std.mem.Allocator,
         border: BorderMode,
         fn run(self: @This()) !void {
-            try self.src.convolve(self.dst, self.gpa, kernel, self.border);
+            try self.src.convolve(self.gpa, self.dst, kernel, self.border);
         }
     };
     try benchOp(io, name, rows, cols, Ctx{ .src = src, .dst = dst, .gpa = gpa, .border = border });
@@ -122,7 +122,7 @@ fn benchSobel(io: std.Io, gpa: std.mem.Allocator, random: std.Random, filter: ?[
         dst: Image(u8),
         gpa: std.mem.Allocator,
         fn run(self: @This()) !void {
-            try self.src.sobel(self.dst, self.gpa);
+            try self.src.sobel(self.gpa, self.dst);
         }
     };
     try benchOp(io, "sobel f32", rows, cols, Ctx{ .src = src, .dst = dst, .gpa = gpa });
@@ -144,7 +144,7 @@ fn benchMotionBlur(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random:
         gpa: std.mem.Allocator,
         distance: usize,
         fn run(self: @This()) !void {
-            try self.src.motionBlur(self.dst, self.gpa, .{ .linear = .{ .angle = 0, .distance = self.distance } });
+            try self.src.motionBlur(self.gpa, self.dst, .{ .linear = .{ .angle = 0, .distance = self.distance } });
         }
     };
     try benchOp(io, name, rows, cols, Ctx{ .src = src, .dst = dst, .gpa = gpa, .distance = distance });
@@ -165,7 +165,7 @@ fn benchSeparable(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random: 
         dst: Image(T),
         gpa: std.mem.Allocator,
         fn run(self: @This()) !void {
-            try self.src.convolveSeparable(self.dst, self.gpa, &gaussian_9, &gaussian_9, .mirror);
+            try self.src.convolveSeparable(self.gpa, self.dst, &gaussian_9, &gaussian_9, .mirror);
         }
     };
     try benchOp(io, name, rows, cols, Ctx{ .src = src, .dst = dst, .gpa = gpa });
@@ -187,7 +187,7 @@ fn benchMedian(comptime T: type, io: std.Io, gpa: std.mem.Allocator, random: std
         gpa: std.mem.Allocator,
         radius: usize,
         fn run(self: @This()) !void {
-            try self.src.medianBlur(self.dst, self.gpa, self.radius);
+            try self.src.medianBlur(self.gpa, self.dst, self.radius);
         }
     };
     try benchOp(io, name, rows, cols, Ctx{ .src = src, .dst = dst, .gpa = gpa, .radius = radius });

--- a/examples/src/edge_detection.zig
+++ b/examples/src/edge_detection.zig
@@ -25,17 +25,17 @@ pub fn main(init: std.process.Init) !void {
     const font = zignal.font.font8x8.basic;
 
     const sobel = edges.view(.{ .t = 0, .l = 0, .r = scaled.cols, .b = scaled.rows });
-    try scaled.sobel(sobel, init.gpa);
+    try scaled.sobel(init.gpa, sobel);
     canvas = .init(init.gpa, sobel);
     try canvas.drawText("Sobel", p(.{ 0, 0 }), @as(u8, 255), .{ .bitmap = font }, 24, .fast);
 
     const shenCastan = edges.view(.{ .t = 0, .l = scaled.cols, .r = 2 * scaled.cols, .b = scaled.rows });
-    try scaled.shenCastan(shenCastan, init.gpa, .heavy_smooth);
+    try scaled.shenCastan(init.gpa, shenCastan, .heavy_smooth);
     canvas = .init(init.gpa, shenCastan);
     try canvas.drawText("Shen Castan", p(.{ 0, 0 }), @as(u8, 255), .{ .bitmap = font }, 24, .fast);
 
     const canny = edges.view(.{ .t = 0, .l = 2 * scaled.cols, .r = 3 * scaled.cols, .b = scaled.rows });
-    try scaled.canny(canny, init.gpa, 1.4, 75, 150);
+    try scaled.canny(init.gpa, canny, 1.4, 75, 150);
     canvas = .init(init.gpa, canny);
     try canvas.drawText("Canny", p(.{ 0, 0 }), @as(u8, 255), .{ .bitmap = font }, 24, .fast);
 

--- a/examples/src/face_alignment.zig
+++ b/examples/src/face_alignment.zig
@@ -92,9 +92,9 @@ pub fn extractAlignedFace(
 
     // Perform blurring or sharpening to the aligned face.
     if (blurring > 0) {
-        try out.boxBlur(out.*, allocator, @intCast(blurring));
+        try out.boxBlur(allocator, out.*, @intCast(blurring));
     } else if (blurring < 0) {
-        try out.sharpen(out.*, allocator, @intCast(-blurring));
+        try out.sharpen(allocator, out.*, @intCast(-blurring));
     }
 }
 

--- a/examples/src/image_demo.zig
+++ b/examples/src/image_demo.zig
@@ -14,27 +14,27 @@ pub fn main(init: std.process.Init) !void {
     var edges: Image(u8) = try .init(init.gpa, image.rows, image.cols);
     defer edges.deinit(init.gpa);
 
-    try image.sobel(edges, init.gpa);
+    try image.sobel(init.gpa, edges);
     try edges.save(init.io, init.gpa, "image-demo-sobel.png");
 
     var blurred: Image(Rgba) = try .init(init.gpa, image.rows, image.cols);
     defer blurred.deinit(init.gpa);
-    try image.gaussianBlur(blurred, init.gpa, 5.0);
+    try image.gaussianBlur(init.gpa, blurred, 5.0);
     try blurred.save(init.io, init.gpa, "image-demo-gaussian.png");
 
     var resized: Image(Rgba) = try .init(init.gpa, image.rows / 2, image.cols / 2);
     defer resized.deinit(init.gpa);
-    image.resize(resized, init.gpa, .nearest);
+    image.resize(init.gpa, resized, .nearest);
     try resized.save(init.io, init.gpa, "image-demo-resized-nearest.png");
-    image.resize(resized, init.gpa, .bilinear);
+    image.resize(init.gpa, resized, .bilinear);
     try resized.save(init.io, init.gpa, "image-demo-resized-bilinear.png");
-    image.resize(resized, init.gpa, .bicubic);
+    image.resize(init.gpa, resized, .bicubic);
     try resized.save(init.io, init.gpa, "image-demo-resized-bicubic.png");
-    image.resize(resized, init.gpa, .catmull_rom);
+    image.resize(init.gpa, resized, .catmull_rom);
     try resized.save(init.io, init.gpa, "image-demo-resized-catmull-rom.png");
-    image.resize(resized, init.gpa, .{ .mitchell = .default });
+    image.resize(init.gpa, resized, .{ .mitchell = .default });
     try resized.save(init.io, init.gpa, "image-demo-resized-mitchell.png");
-    image.resize(resized, init.gpa, .lanczos);
+    image.resize(init.gpa, resized, .lanczos);
     try resized.save(init.io, init.gpa, "image-demo-resized-lanczos.png");
     std.debug.print("{f}\n", .{image});
     std.debug.print("{f}\n", .{image.display(init.io, .{ .auto = .{} })});

--- a/examples/src/motion_blur_demo.zig
+++ b/examples/src/motion_blur_demo.zig
@@ -18,23 +18,23 @@ pub fn main(init: std.process.Init) !void {
 
     // Apply different motion blur effects using the unified API
     std.debug.print("Applying horizontal motion blur...\n", .{});
-    try image.motionBlur(blurred, init.gpa, .{ .linear = .{ .angle = 0, .distance = 30 } });
+    try image.motionBlur(init.gpa, blurred, .{ .linear = .{ .angle = 0, .distance = 30 } });
     try blurred.save(init.io, init.gpa, "motion-blur-horizontal.png");
 
     std.debug.print("Applying vertical motion blur...\n", .{});
-    try image.motionBlur(blurred, init.gpa, .{ .linear = .{ .angle = std.math.pi / 2.0, .distance = 30 } });
+    try image.motionBlur(init.gpa, blurred, .{ .linear = .{ .angle = std.math.pi / 2.0, .distance = 30 } });
     try blurred.save(init.io, init.gpa, "motion-blur-vertical.png");
 
     std.debug.print("Applying diagonal motion blur...\n", .{});
-    try image.motionBlur(blurred, init.gpa, .{ .linear = .{ .angle = std.math.pi / 4.0, .distance = 25 } });
+    try image.motionBlur(init.gpa, blurred, .{ .linear = .{ .angle = std.math.pi / 4.0, .distance = 25 } });
     try blurred.save(init.io, init.gpa, "motion-blur-diagonal.png");
 
     std.debug.print("Applying zoom blur...\n", .{});
-    try image.motionBlur(blurred, init.gpa, .{ .radial_zoom = .{ .center_x = 0.5, .center_y = 0.5, .strength = 0.7 } });
+    try image.motionBlur(init.gpa, blurred, .{ .radial_zoom = .{ .center_x = 0.5, .center_y = 0.5, .strength = 0.7 } });
     try blurred.save(init.io, init.gpa, "motion-blur-zoom.png");
 
     std.debug.print("Applying spin blur...\n", .{});
-    try image.motionBlur(blurred, init.gpa, .{ .radial_spin = .{ .center_x = 0.5, .center_y = 0.5, .strength = 0.5 } });
+    try image.motionBlur(init.gpa, blurred, .{ .radial_spin = .{ .center_x = 0.5, .center_y = 0.5, .strength = 0.5 } });
     try blurred.save(init.io, init.gpa, "motion-blur-spin.png");
 
     std.debug.print("Motion blur examples saved successfully!\n", .{});

--- a/examples/src/seam_carving.zig
+++ b/examples/src/seam_carving.zig
@@ -131,7 +131,7 @@ pub export fn seam_carve(
 
     var edges = Image(u8).init(allocator, rows, cols) catch @panic("OOM");
     defer edges.deinit(allocator);
-    image.sobel(edges, allocator) catch @panic("OOM");
+    image.sobel(allocator, edges) catch @panic("OOM");
 
     var energy_map = Image(u32).init(allocator, image.rows, image.cols) catch @panic("OOM");
     defer energy_map.deinit(allocator);

--- a/examples/src/trace_edges.zig
+++ b/examples/src/trace_edges.zig
@@ -23,9 +23,9 @@ pub fn main(init: std.process.Init) !void {
     var edges = try Image(u8).init(init.gpa, image.rows, image.cols);
     defer edges.deinit(init.gpa);
 
-    try gray.canny(edges, init.gpa, 2.0, 25, 75);
+    try gray.canny(init.gpa, edges, 2.0, 25, 75);
     // Custom "Human-Like" Shen-Castan parameters
-    // try gray.shenCastan(edges,init.gpa, .{
+    // try gray.shenCastan(init.gpa,edges, .{
     //     .smooth = 0.5, // Moderate smoothing (balance detail/structure)
     //     .window_size = 13, // Medium window
     //     .high_ratio = 0.92, // More sensitive start threshold

--- a/src/cli/blur.zig
+++ b/src/cli/blur.zig
@@ -108,7 +108,7 @@ pub fn apply(io: Io, gpa: Allocator, img: zignal.Image(zignal.Rgba(u8)), options
     switch (blur_type) {
         .box => {
             const radius = options.radius orelse 1;
-            try img.boxBlur(out, gpa, radius);
+            try img.boxBlur(gpa, out, radius);
         },
         .gaussian => {
             const sigma = options.sigma orelse 1.0;
@@ -116,7 +116,7 @@ pub fn apply(io: Io, gpa: Allocator, img: zignal.Image(zignal.Rgba(u8)), options
                 std.log.err("sigma must be a non-negative finite number.", .{});
                 return error.InvalidArguments;
             }
-            try img.gaussianBlur(out, gpa, sigma);
+            try img.gaussianBlur(gpa, out, sigma);
         },
         .median => {
             const radius = options.radius orelse 1;
@@ -124,7 +124,7 @@ pub fn apply(io: Io, gpa: Allocator, img: zignal.Image(zignal.Rgba(u8)), options
                 std.log.err("median blur radius {d} exceeds maximum limit of 256.", .{radius});
                 return error.InvalidArguments;
             }
-            try img.medianBlur(out, gpa, radius);
+            try img.medianBlur(gpa, out, radius);
         },
         .motion_linear => {
             const angle_deg = options.angle orelse 0.0;
@@ -147,7 +147,7 @@ pub fn apply(io: Io, gpa: Allocator, img: zignal.Image(zignal.Rgba(u8)), options
             }
 
             const angle_rad = std.math.degreesToRadians(angle_deg);
-            try img.motionBlur(out, gpa, .{ .linear = .{ .angle = angle_rad, .distance = @trunc(dist) } });
+            try img.motionBlur(gpa, out, .{ .linear = .{ .angle = angle_rad, .distance = @trunc(dist) } });
         },
         .motion_zoom, .motion_spin => {
             const cx = options.center_x orelse 0.5;
@@ -173,7 +173,7 @@ pub fn apply(io: Io, gpa: Allocator, img: zignal.Image(zignal.Rgba(u8)), options
             else
                 .{ .radial_spin = .{ .center_x = cx, .center_y = cy, .strength = strength } };
 
-            try img.motionBlur(out, gpa, motion);
+            try img.motionBlur(gpa, out, motion);
         },
     }
 

--- a/src/cli/diff.zig
+++ b/src/cli/diff.zig
@@ -94,7 +94,7 @@ pub fn run(io: Io, writer: *Io.Writer, gpa: Allocator, iterator: *std.process.Ar
     };
 
     const timer = common.Timer.begin(io);
-    const result = try img1.diff(diff_img, img2, diff_opts);
+    const result = try img1.diff(img2, diff_img, diff_opts);
     timer.logElapsed("diff");
 
     // `result.stats` describes the *visualized* diff image (after threshold/scale/binary),

--- a/src/cli/edges.zig
+++ b/src/cli/edges.zig
@@ -94,14 +94,14 @@ pub fn applyGray(io: Io, gpa: Allocator, img: zignal.Image(u8), out: zignal.Imag
 
     switch (algo) {
         .sobel => {
-            try img.sobel(out, gpa);
+            try img.sobel(gpa, out);
         },
         .canny => {
             const sigma = options.sigma orelse 1.0;
             const low = options.low orelse 50.0;
             const high = options.high orelse 100.0;
             std.log.debug("canny params: sigma={d:.2}, low={d:.2}, high={d:.2}", .{ sigma, low, high });
-            try img.canny(out, gpa, sigma, low, high);
+            try img.canny(gpa, out, sigma, low, high);
         },
         .shen_castan => {
             const opts = zignal.ShenCastan{
@@ -114,7 +114,7 @@ pub fn applyGray(io: Io, gpa: Allocator, img: zignal.Image(u8), out: zignal.Imag
             std.log.debug("shen_castan params: smooth={d:.2}, window={d}, high_ratio={d:.2}, low_rel={d:.2}, nms={}", .{
                 opts.smooth, opts.window_size, opts.high_ratio, opts.low_rel, opts.use_nms,
             });
-            try img.shenCastan(out, gpa, opts);
+            try img.shenCastan(gpa, out, opts);
         },
     }
 

--- a/src/cli/resize.zig
+++ b/src/cli/resize.zig
@@ -93,7 +93,7 @@ pub fn apply(io: Io, gpa: Allocator, img: zignal.Image(zignal.Rgba(u8)), options
     errdefer out.deinit(gpa);
 
     const timer = common.Timer.begin(io);
-    img.resize(out, gpa, filter);
+    img.resize(gpa, out, filter);
     timer.logElapsed("resize");
 
     return out;

--- a/src/image.zig
+++ b/src/image.zig
@@ -130,7 +130,7 @@ pub fn Image(comptime T: type) type {
         /// ```zig
         /// var blurred = try Image(u8).initLike(allocator, original);
         /// defer blurred.deinit(allocator);
-        /// try original.gaussianBlur(1.4, blurred);
+        /// try original.gaussianBlur(allocator, blurred, 1.4);
         /// ```
         pub fn initLike(allocator: Allocator, reference: anytype) !Image(T) {
             const RefType = @TypeOf(reference);
@@ -512,7 +512,7 @@ pub fn Image(comptime T: type) type {
         /// Resizes an image to fit in out, using the specified interpolation method.
         /// The output image must have the desired dimensions pre-allocated.
         /// Note: allocator is used for temporary buffers during RGB/RGBA channel processing.
-        pub fn resize(self: Self, out: Self, allocator: Allocator, method: Interpolation) void {
+        pub fn resize(self: Self, allocator: Allocator, out: Self, method: Interpolation) void {
             interpolation.resize(T, self, out, allocator, method);
         }
 
@@ -528,14 +528,14 @@ pub fn Image(comptime T: type) type {
             if (new_rows == 0 or new_cols == 0) return error.InvalidDimensions;
 
             const scaled: Self = try .init(allocator, new_rows, new_cols);
-            self.resize(scaled, allocator, method);
+            self.resize(allocator, scaled, method);
             return scaled;
         }
 
         /// Resizes an image to fit within the output dimensions while preserving aspect ratio.
         /// The image is centered with black/zero padding around it (letterboxing).
         /// Returns a rectangle describing the area containing the actual image content.
-        pub fn letterbox(self: Self, out: Self, allocator: Allocator, method: Interpolation) Rectangle(u32) {
+        pub fn letterbox(self: Self, allocator: Allocator, out: Self, method: Interpolation) Rectangle(u32) {
             return Transform(T).letterbox(self, out, allocator, method);
         }
 
@@ -624,7 +624,7 @@ pub fn Image(comptime T: type) type {
         /// Computes a blurred version of `self` using a box blur. The `radius` parameter
         /// determines the size of the box window. The output image must be pre-allocated
         /// with the same dimensions as the input.
-        pub fn boxBlur(self: Self, out: Self, allocator: Allocator, radius: u32) !void {
+        pub fn boxBlur(self: Self, allocator: Allocator, out: Self, radius: u32) !void {
             if (!self.hasSameShape(out)) {
                 return error.DimensionMismatch;
             }
@@ -639,7 +639,7 @@ pub fn Image(comptime T: type) type {
         /// Applies a median blur using a square window with the given radius.
         /// Radius specifies half the window size; window size = `radius * 2 + 1`.
         /// The output image must be pre-allocated with the same dimensions as the input.
-        pub fn medianBlur(self: Self, out: Self, allocator: Allocator, radius: usize) !void {
+        pub fn medianBlur(self: Self, allocator: Allocator, out: Self, radius: usize) !void {
             if (!self.hasSameShape(out)) {
                 return error.DimensionMismatch;
             }
@@ -656,12 +656,12 @@ pub fn Image(comptime T: type) type {
         /// ```zig
         /// var robust = try Image(u8).initLike(allocator, image);
         /// defer robust.deinit(allocator);
-        /// try image.percentileBlur(robust, allocator, 2, 0.1, .mirror);
+        /// try image.percentileBlur( allocator,robust, 2, 0.1, .mirror);
         /// ```
         pub fn percentileBlur(
             self: Self,
-            out: Self,
             allocator: Allocator,
+            out: Self,
             radius: usize,
             percentile: f64,
             border: BorderMode,
@@ -680,12 +680,12 @@ pub fn Image(comptime T: type) type {
         /// ```zig
         /// var denoised = try Image(u8).initLike(allocator, image);
         /// defer denoised.deinit(allocator);
-        /// try image.minBlur(denoised, allocator, 1, .mirror);
+        /// try image.minBlur( allocator,denoised, 1, .mirror);
         /// ```
         pub fn minBlur(
             self: Self,
-            out: Self,
             allocator: Allocator,
+            out: Self,
             radius: usize,
             border: BorderMode,
         ) !void {
@@ -703,12 +703,12 @@ pub fn Image(comptime T: type) type {
         /// ```zig
         /// var mask = try Image(u8).initLike(allocator, image);
         /// defer mask.deinit(allocator);
-        /// try image.maxBlur(mask, allocator, 2, .mirror);
+        /// try image.maxBlur( allocator,mask, 2, .mirror);
         /// ```
         pub fn maxBlur(
             self: Self,
-            out: Self,
             allocator: Allocator,
+            out: Self,
             radius: usize,
             border: BorderMode,
         ) !void {
@@ -726,12 +726,12 @@ pub fn Image(comptime T: type) type {
         /// ```zig
         /// var softened = try Image(u8).initLike(allocator, image);
         /// defer softened.deinit(allocator);
-        /// try image.midpointBlur(softened, allocator, 1, .mirror);
+        /// try image.midpointBlur( allocator,softened, 1, .mirror);
         /// ```
         pub fn midpointBlur(
             self: Self,
-            out: Self,
             allocator: Allocator,
+            out: Self,
             radius: usize,
             border: BorderMode,
         ) !void {
@@ -751,12 +751,12 @@ pub fn Image(comptime T: type) type {
         /// ```zig
         /// var robust_mean = try Image(Rgba).initLike(allocator, color_image);
         /// defer robust_mean.deinit(allocator);
-        /// try color_image.alphaTrimmedMeanBlur(robust_mean, allocator, 2, 0.1, .mirror);
+        /// try color_image.alphaTrimmedMeanBlur( allocator,robust_mean, 2, 0.1, .mirror);
         /// ```
         pub fn alphaTrimmedMeanBlur(
             self: Self,
-            out: Self,
             allocator: Allocator,
+            out: Self,
             radius: usize,
             trim_fraction: f64,
             border: BorderMode,
@@ -771,7 +771,7 @@ pub fn Image(comptime T: type) type {
         /// `sharpened = 2 * original - blurred`, where `blurred` is a box-blurred version
         /// of the original image. The `radius` parameter controls the size of the blur.
         /// The output image must be pre-allocated with the same dimensions as the input.
-        pub fn sharpen(self: Self, out: Self, allocator: Allocator, radius: usize) !void {
+        pub fn sharpen(self: Self, allocator: Allocator, out: Self, radius: usize) !void {
             if (!self.hasSameShape(out)) {
                 return error.DimensionMismatch;
             }
@@ -825,7 +825,7 @@ pub fn Image(comptime T: type) type {
         /// Computes Otsu's threshold and produces a binary image.
         /// Returns the threshold value that maximizes between-class variance.
         /// The output image must be pre-allocated with the same dimensions as the input.
-        pub fn thresholdOtsu(self: Self, out: Image(u8), allocator: Allocator) !u8 {
+        pub fn thresholdOtsu(self: Self, allocator: Allocator, out: Image(u8)) !u8 {
             if (comptime T != u8) {
                 @compileError("thresholdOtsu is only available for Image(u8)");
             }
@@ -838,7 +838,7 @@ pub fn Image(comptime T: type) type {
         /// Applies adaptive mean thresholding using a square window defined by `radius`.
         /// Each pixel is compared against the mean of its local neighborhood minus `c`.
         /// The output image must be pre-allocated with the same dimensions as the input.
-        pub fn thresholdAdaptiveMean(self: Self, out: Image(u8), allocator: Allocator, radius: usize, c: f32) !void {
+        pub fn thresholdAdaptiveMean(self: Self, allocator: Allocator, out: Image(u8), radius: usize, c: f32) !void {
             if (comptime T != u8) {
                 @compileError("thresholdAdaptiveMean is only available for Image(u8)");
             }
@@ -850,7 +850,7 @@ pub fn Image(comptime T: type) type {
 
         /// Performs binary dilation using the provided structuring element.
         /// The output image must be pre-allocated with the same dimensions as the input.
-        pub fn dilateBinary(self: Self, out: Image(u8), allocator: Allocator, kernel: BinaryKernel, iterations: usize) !void {
+        pub fn dilateBinary(self: Self, allocator: Allocator, out: Image(u8), kernel: BinaryKernel, iterations: usize) !void {
             if (comptime T != u8) {
                 @compileError("dilateBinary is only available for Image(u8)");
             }
@@ -862,7 +862,7 @@ pub fn Image(comptime T: type) type {
 
         /// Performs binary erosion using the provided structuring element.
         /// The output image must be pre-allocated with the same dimensions as the input.
-        pub fn erodeBinary(self: Self, out: Image(u8), allocator: Allocator, kernel: BinaryKernel, iterations: usize) !void {
+        pub fn erodeBinary(self: Self, allocator: Allocator, out: Image(u8), kernel: BinaryKernel, iterations: usize) !void {
             if (comptime T != u8) {
                 @compileError("erodeBinary is only available for Image(u8)");
             }
@@ -874,7 +874,7 @@ pub fn Image(comptime T: type) type {
 
         /// Performs a binary opening (erosion followed by dilation).
         /// The output image must be pre-allocated with the same dimensions as the input.
-        pub fn openBinary(self: Self, out: Image(u8), allocator: Allocator, kernel: BinaryKernel, iterations: usize) !void {
+        pub fn openBinary(self: Self, allocator: Allocator, out: Image(u8), kernel: BinaryKernel, iterations: usize) !void {
             if (comptime T != u8) {
                 @compileError("openBinary is only available for Image(u8)");
             }
@@ -886,7 +886,7 @@ pub fn Image(comptime T: type) type {
 
         /// Performs a binary closing (dilation followed by erosion).
         /// The output image must be pre-allocated with the same dimensions as the input.
-        pub fn closeBinary(self: Self, out: Image(u8), allocator: Allocator, kernel: BinaryKernel, iterations: usize) !void {
+        pub fn closeBinary(self: Self, allocator: Allocator, out: Image(u8), kernel: BinaryKernel, iterations: usize) !void {
             if (comptime T != u8) {
                 @compileError("closeBinary is only available for Image(u8)");
             }
@@ -899,9 +899,9 @@ pub fn Image(comptime T: type) type {
         /// Applies a 2D convolution with the given kernel to the image.
         pub fn convolve(
             self: Self,
+            allocator: Allocator,
             /// The output image (must be pre-allocated with same dimensions).
             out: Self,
-            allocator: Allocator,
             /// A 2D array representing the convolution kernel.
             kernel: anytype,
             /// How to handle pixels at the image borders.
@@ -917,9 +917,9 @@ pub fn Image(comptime T: type) type {
         /// This is much more efficient for separable filters like Gaussian blur.
         pub fn convolveSeparable(
             self: Self,
+            allocator: Allocator,
             /// The output image (must be pre-allocated with same dimensions).
             out: Self,
-            allocator: Allocator,
             /// Horizontal (column) kernel.
             kernel_x: []const f32,
             /// Vertical (row) kernel.
@@ -936,9 +936,9 @@ pub fn Image(comptime T: type) type {
         /// Applies Gaussian blur to the image using separable convolution.
         pub fn gaussianBlur(
             self: Self,
+            allocator: Allocator,
             /// The output blurred image (must be pre-allocated with same dimensions).
             out: Self,
-            allocator: Allocator,
             /// Standard deviation of the Gaussian kernel.
             sigma: f32,
         ) !void {
@@ -981,9 +981,9 @@ pub fn Image(comptime T: type) type {
         /// The output image must be pre-allocated with the same dimensions as the input.
         pub fn sobel(
             self: Self,
+            allocator: Allocator,
             /// Output image that will be filled with the Sobel magnitude image.
             out: Image(u8),
-            allocator: Allocator,
         ) !void {
             if (self.rows != out.rows or self.cols != out.cols) {
                 return error.DimensionMismatch;
@@ -997,9 +997,9 @@ pub fn Image(comptime T: type) type {
         /// The output image must be pre-allocated with the same dimensions as the input.
         pub fn shenCastan(
             self: Self,
+            allocator: Allocator,
             /// Output edge map as binary image (0 or 255).
             out: Image(u8),
-            allocator: Allocator,
             /// Shen-Castan options (smoothing, thresholds, thinning, hysteresis).
             opts: ShenCastan,
         ) !void {
@@ -1025,13 +1025,13 @@ pub fn Image(comptime T: type) type {
         /// ```zig
         /// var edges = try Image(u8).initLike(allocator, image);
         /// defer edges.deinit(allocator);
-        /// try image.canny(edges, allocator, 1.4, 50, 150);
+        /// try image.canny( allocator,edges, 1.4, 50, 150);
         /// ```
         pub fn canny(
             self: Self,
+            allocator: Allocator,
             /// Output edge map as binary image (0 or 255).
             out: Image(u8),
-            allocator: Allocator,
             /// Standard deviation for Gaussian blur (typical: 1.0-2.0).
             sigma: f32,
             /// Lower threshold for hysteresis (0-255).
@@ -1055,13 +1055,13 @@ pub fn Image(comptime T: type) type {
         /// defer out.deinit(allocator);
         ///
         /// // Linear motion blur
-        /// try image.motionBlur(out, allocator, .{ .linear = .{ .angle = 0, .distance = 30 }});
+        /// try image.motionBlur( allocator,out, .{ .linear = .{ .angle = 0, .distance = 30 }});
         /// ```
         pub fn motionBlur(
             self: Self,
+            allocator: Allocator,
             /// Output image containing the motion blurred result.
             out: Self,
-            allocator: Allocator,
             /// Type and parameters of motion blur to apply.
             motion: MotionBlur,
         ) !void {

--- a/src/image/interpolation.zig
+++ b/src/image/interpolation.zig
@@ -13,9 +13,9 @@
 //!
 //! ### Resize with different methods:
 //! ```zig
-//! var small = Image(Rgba).init(256, 256, small_data);
-//! var large = Image(Rgba).init(512, 512, large_data);
-//! small.resize(large, allocator, .lanczos); // High quality upscaling
+//! var small = try Image(Rgba).load(io, allocator, "small.png");
+//! var large = try Image(Rgba).init(allocator, 512, 512);
+//! small.resize(allocator, large, .lanczos); // High quality upscaling
 //! ```
 //!
 //! ## Performance Guide

--- a/src/image/motion_blur.zig
+++ b/src/image/motion_blur.zig
@@ -128,7 +128,7 @@ pub fn MotionBlurOps(comptime T: type) type {
                 const identity = [_]f32{1.0};
 
                 // Apply separable convolution (horizontal blur only)
-                try image.convolveSeparable(out, allocator, kernel, &identity, .replicate);
+                try image.convolveSeparable(allocator, out, kernel, &identity, .replicate);
             } else if (is_vertical) {
                 // Use separable convolution for vertical motion blur
                 const kernel_size = distance;
@@ -145,7 +145,7 @@ pub fn MotionBlurOps(comptime T: type) type {
                 const identity = [_]f32{1.0};
 
                 // Apply separable convolution (vertical blur only)
-                try image.convolveSeparable(out, allocator, &identity, kernel, .replicate);
+                try image.convolveSeparable(allocator, out, &identity, kernel, .replicate);
             } else {
                 // General diagonal motion blur
                 switch (@typeInfo(T)) {

--- a/src/image/pyramid.zig
+++ b/src/image/pyramid.zig
@@ -80,7 +80,7 @@ pub fn ImagePyramid(comptime T: type) type {
                 // Apply Gaussian blur if sigma > 0.5
                 if (sigma > 0.5) {
                     blurred = try .initLike(allocator, source);
-                    try source.gaussianBlur(blurred, allocator, sigma);
+                    try source.gaussianBlur(allocator, blurred, sigma);
                 }
 
                 // Allocate and resize to create the new level
@@ -88,7 +88,7 @@ pub fn ImagePyramid(comptime T: type) type {
 
                 // Use bilinear interpolation for downsampling from original or blurred
                 const source_to_use = if (blurred.rows > 0) blurred else source;
-                source_to_use.resize(levels[i], allocator, .bilinear);
+                source_to_use.resize(allocator, levels[i], .bilinear);
             }
 
             return .{

--- a/src/image/tests/binary.zig
+++ b/src/image/tests/binary.zig
@@ -11,7 +11,7 @@ test "threshold otsu binarizes bimodal image" {
     var out: Image(u8) = try .initLike(testing.allocator, image);
     defer out.deinit(testing.allocator);
 
-    const threshold = try image.thresholdOtsu(out, testing.allocator);
+    const threshold = try image.thresholdOtsu(testing.allocator, out);
 
     try testing.expect(threshold >= 5 and threshold <= 50);
 
@@ -34,7 +34,7 @@ test "adaptive mean threshold isolates bright center" {
     var out: Image(u8) = try .initLike(testing.allocator, image);
     defer out.deinit(testing.allocator);
 
-    try image.thresholdAdaptiveMean(out, testing.allocator, 1, 10.0);
+    try image.thresholdAdaptiveMean(testing.allocator, out, 1, 10.0);
 
     for (0..3) |r| {
         for (0..3) |c| {
@@ -54,7 +54,7 @@ test "adaptive mean threshold rejects zero radius" {
     var out: Image(u8) = try .initLike(testing.allocator, image);
     defer out.deinit(testing.allocator);
 
-    try testing.expectError(error.InvalidRadius, image.thresholdAdaptiveMean(out, testing.allocator, 0, 0.0));
+    try testing.expectError(error.InvalidRadius, image.thresholdAdaptiveMean(testing.allocator, out, 0, 0.0));
 }
 
 test "binary dilation expands single pixel" {
@@ -76,7 +76,7 @@ test "binary dilation expands single pixel" {
         1, 1, 1,
     });
 
-    try image.dilateBinary(out, testing.allocator, kernel, 1);
+    try image.dilateBinary(testing.allocator, out, kernel, 1);
 
     for (0..5) |r| {
         for (0..5) |c| {
@@ -104,7 +104,7 @@ test "binary open removes isolated noise" {
         1, 1, 1,
     });
 
-    try image.openBinary(image, testing.allocator, kernel, 1);
+    try image.openBinary(testing.allocator, image, kernel, 1);
 
     for (0..5) |r| {
         for (0..5) |c| {
@@ -130,7 +130,7 @@ test "binary close fills holes" {
         1, 1, 1,
     });
 
-    try image.closeBinary(image, testing.allocator, kernel, 1);
+    try image.closeBinary(testing.allocator, image, kernel, 1);
 
     for (0..5) |r| {
         for (0..5) |c| {
@@ -159,7 +159,7 @@ test "binary erosion shrinks block across iterations" {
         1, 1, 1,
     });
 
-    try image.erodeBinary(out, testing.allocator, kernel, 2);
+    try image.erodeBinary(testing.allocator, out, kernel, 2);
 
     for (0..5) |r| {
         for (0..5) |c| {

--- a/src/image/tests/filters.zig
+++ b/src/image/tests/filters.zig
@@ -64,7 +64,7 @@ test "boxBlur radius 0 with views" {
     // Apply boxBlur with radius 0 to view
     var blurred = try Image(u8).initLike(std.testing.allocator, view);
     defer blurred.deinit(std.testing.allocator);
-    try view.boxBlur(blurred, std.testing.allocator, 0);
+    try view.boxBlur(std.testing.allocator, blurred, 0);
 
     // Should be identical to view
     for (0..view.rows) |r| {
@@ -94,7 +94,7 @@ test "boxBlur basic functionality" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.boxBlur(blurred, std.testing.allocator, 1);
+    try image.boxBlur(std.testing.allocator, blurred, 1);
 
     // Uniform image should remain uniform after blur
     for (blurred.data) |pixel| {
@@ -115,7 +115,7 @@ test "boxBlur zero radius" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.boxBlur(blurred, std.testing.allocator, 0);
+    try image.boxBlur(std.testing.allocator, blurred, 0);
 
     // Zero radius should produce identical image
     for (0..image.rows) |r| {
@@ -136,7 +136,7 @@ test "boxBlur border effects" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.boxBlur(blurred, std.testing.allocator, 1);
+    try image.boxBlur(std.testing.allocator, blurred, 1);
 
     // The center should be blurred down, corners should have some blur effect
     try expectEqual(@as(usize, 5), blurred.rows);
@@ -170,7 +170,7 @@ test "boxBlur struct type" {
 
     var blurred = try Image(Rgba).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.boxBlur(blurred, std.testing.allocator, 1);
+    try image.boxBlur(std.testing.allocator, blurred, 1);
 
     try expectEqual(@as(usize, 3), blurred.rows);
     try expectEqual(@as(usize, 3), blurred.cols);
@@ -197,7 +197,7 @@ test "boxBlur border area calculations" {
 
     var uniform_blurred = try Image(u8).initLike(std.testing.allocator, uniform_image);
     defer uniform_blurred.deinit(std.testing.allocator);
-    try uniform_image.boxBlur(uniform_blurred, std.testing.allocator, radius);
+    try uniform_image.boxBlur(std.testing.allocator, uniform_blurred, radius);
 
     // All pixels should remain 200 since it's uniform
     for (0..test_size) |r| {
@@ -218,7 +218,7 @@ test "boxBlur border area calculations" {
 
     var gradient_blurred = try Image(u8).initLike(std.testing.allocator, gradient_image);
     defer gradient_blurred.deinit(std.testing.allocator);
-    try gradient_image.boxBlur(gradient_blurred, std.testing.allocator, radius);
+    try gradient_image.boxBlur(std.testing.allocator, gradient_blurred, radius);
 
     // Check that we got reasonable blur results (no crashes, no extreme values)
     for (0..test_size) |r| {
@@ -254,7 +254,7 @@ test "boxBlur struct type comprehensive" {
 
             var blurred = try Image(Rgba).initLike(std.testing.allocator, image);
             defer blurred.deinit(std.testing.allocator);
-            try image.boxBlur(blurred, std.testing.allocator, radius);
+            try image.boxBlur(std.testing.allocator, blurred, radius);
 
             // Check that alpha remains unchanged
             for (0..test_size) |r| {
@@ -287,7 +287,7 @@ test "sharpen basic functionality" {
 
     var sharpened = try Image(u8).initLike(std.testing.allocator, image);
     defer sharpened.deinit(std.testing.allocator);
-    try image.sharpen(sharpened, std.testing.allocator, 1);
+    try image.sharpen(std.testing.allocator, sharpened, 1);
 
     try expectEqual(@as(usize, 5), sharpened.rows);
     try expectEqual(@as(usize, 5), sharpened.cols);
@@ -314,7 +314,7 @@ test "sharpen zero radius" {
 
     var sharpened = try Image(u8).initLike(std.testing.allocator, image);
     defer sharpened.deinit(std.testing.allocator);
-    try image.sharpen(sharpened, std.testing.allocator, 0);
+    try image.sharpen(std.testing.allocator, sharpened, 0);
 
     // Zero radius should produce identical image
     for (0..image.rows) |r| {
@@ -333,7 +333,7 @@ test "sharpen uniform image" {
 
     var sharpened = try Image(u8).initLike(std.testing.allocator, image);
     defer sharpened.deinit(std.testing.allocator);
-    try image.sharpen(sharpened, std.testing.allocator, 1);
+    try image.sharpen(std.testing.allocator, sharpened, 1);
 
     // Uniform image should remain uniform after sharpening
     // (2 * original - blurred = 2 * 100 - 100 = 100)
@@ -352,7 +352,7 @@ test "sharpen struct type" {
 
     var sharpened = try Image(Rgba).initLike(std.testing.allocator, image);
     defer sharpened.deinit(std.testing.allocator);
-    try image.sharpen(sharpened, std.testing.allocator, 1);
+    try image.sharpen(std.testing.allocator, sharpened, 1);
 
     try expectEqual(@as(usize, 3), sharpened.rows);
     try expectEqual(@as(usize, 3), sharpened.cols);
@@ -387,7 +387,7 @@ test "convolve identity kernel" {
 
     var result = try Image(u8).initLike(std.testing.allocator, image);
     defer result.deinit(std.testing.allocator);
-    try image.convolve(result, std.testing.allocator, identity, .zero);
+    try image.convolve(std.testing.allocator, result, identity, .zero);
 
     // Should be identical to original
     for (0..image.rows) |r| {
@@ -417,7 +417,7 @@ test "convolve blur kernel" {
 
     var result = try Image(u8).initLike(std.testing.allocator, image);
     defer result.deinit(std.testing.allocator);
-    try image.convolve(result, std.testing.allocator, blur, .replicate);
+    try image.convolve(std.testing.allocator, result, blur, .replicate);
 
     // Edge should be softened (values between 0 and 255)
     const edge_val = result.at(2, 2).*;
@@ -442,17 +442,17 @@ test "convolve border modes" {
     // Test zero border mode
     var result_zero = try Image(u8).initLike(std.testing.allocator, image);
     defer result_zero.deinit(std.testing.allocator);
-    try image.convolve(result_zero, std.testing.allocator, kernel, .zero);
+    try image.convolve(std.testing.allocator, result_zero, kernel, .zero);
 
     // Test replicate border mode
     var result_replicate = try Image(u8).initLike(std.testing.allocator, image);
     defer result_replicate.deinit(std.testing.allocator);
-    try image.convolve(result_replicate, std.testing.allocator, kernel, .replicate);
+    try image.convolve(std.testing.allocator, result_replicate, kernel, .replicate);
 
     // Test mirror border mode
     var result_mirror = try Image(u8).initLike(std.testing.allocator, image);
     defer result_mirror.deinit(std.testing.allocator);
-    try image.convolve(result_mirror, std.testing.allocator, kernel, .mirror);
+    try image.convolve(std.testing.allocator, result_mirror, kernel, .mirror);
 
     // Border modes should produce different results
     const corner_replicate = result_replicate.at(0, 0).*;
@@ -479,7 +479,7 @@ test "convolveSeparable Gaussian approximation" {
 
     var result = try Image(f32).initLike(std.testing.allocator, image);
     defer result.deinit(std.testing.allocator);
-    try image.convolveSeparable(result, std.testing.allocator, &gaussian_1d, &gaussian_1d, .zero);
+    try image.convolveSeparable(std.testing.allocator, result, &gaussian_1d, &gaussian_1d, .zero);
 
     // Check that center has been spread out
     const center = result.at(3, 3).*;
@@ -504,7 +504,7 @@ test "gaussianBlur basic" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.gaussianBlur(blurred, std.testing.allocator, 1.0);
+    try image.gaussianBlur(std.testing.allocator, blurred, 1.0);
 
     // Check that blur has smoothed the edges
     const edge_sharp = image.at(2, 5).*; // Just outside the square
@@ -529,11 +529,11 @@ test "gaussianBlur sigma variations" {
     // Test with different sigmas
     var blur_small = try Image(f32).initLike(std.testing.allocator, image);
     defer blur_small.deinit(std.testing.allocator);
-    try image.gaussianBlur(blur_small, std.testing.allocator, 0.5);
+    try image.gaussianBlur(std.testing.allocator, blur_small, 0.5);
 
     var blur_large = try Image(f32).initLike(std.testing.allocator, image);
     defer blur_large.deinit(std.testing.allocator);
-    try image.gaussianBlur(blur_large, std.testing.allocator, 2.0);
+    try image.gaussianBlur(std.testing.allocator, blur_large, 2.0);
 
     // Larger sigma should spread more
     const center_small = blur_small.at(7, 7).*;
@@ -558,7 +558,7 @@ test "sobel with new convolution" {
 
     var edges = try Image(u8).initLike(std.testing.allocator, image);
     defer edges.deinit(std.testing.allocator);
-    try image.sobel(edges, std.testing.allocator);
+    try image.sobel(std.testing.allocator, edges);
 
     // Should detect strong edge at column 2
     const edge_strength = edges.at(2, 2).*;
@@ -586,7 +586,7 @@ test "repro: uniform channel bug in struct convolution with .zero borders" {
         .{ 1.0 / 9.0, 1.0 / 9.0, 1.0 / 9.0 },
     };
 
-    try image.convolve(out, allocator, blur_kernel, .zero);
+    try image.convolve(allocator, out, blur_kernel, .zero);
 
     // At (0,0), only 4 of 9 taps are inside the image.
     // Sum should be 255 * (4/9) = 113.33 -> 113.
@@ -621,7 +621,7 @@ test "repro: stride bug in f32 separable convolution" {
     defer out.deinit(allocator);
 
     const k1 = [_]f32{1.0};
-    try view.convolveSeparable(out, allocator, &k1, &k1, .zero);
+    try view.convolveSeparable(allocator, out, &k1, &k1, .zero);
 
     // out should match view exactly if identity.
     for (0..3) |r| {
@@ -652,7 +652,7 @@ test "convolve3x3 optimization" {
 
     var result = try Image(u8).initLike(std.testing.allocator, image);
     defer result.deinit(std.testing.allocator);
-    try image.convolve(result, std.testing.allocator, edge, .zero);
+    try image.convolve(std.testing.allocator, result, edge, .zero);
 
     // Just verify it runs without error and produces reasonable output
     try expectEqual(result.rows, image.rows);
@@ -684,7 +684,7 @@ test "convolve preserves color channels" {
 
     var result = try Image(Rgb).initLike(std.testing.allocator, image);
     defer result.deinit(std.testing.allocator);
-    try image.convolve(result, std.testing.allocator, identity, .zero);
+    try image.convolve(std.testing.allocator, result, identity, .zero);
 
     // Verify identity kernel preserves all color channels exactly
     for (1..image.rows - 1) |r| {
@@ -725,7 +725,7 @@ test "convolve into view (stride-safe)" {
         .{ 0, 0, 0 },
     };
 
-    try src_view.convolve(dst_view, std.testing.allocator, identity, .zero);
+    try src_view.convolve(std.testing.allocator, dst_view, identity, .zero);
 
     // Verify dst view matches src view
     for (0..src_view.rows) |r| {
@@ -764,7 +764,7 @@ test "convolveSeparable into view (stride-safe)" {
 
     // Separable identity: [1] horizontally and vertically
     const k1 = [_]f32{1.0};
-    try src_view.convolveSeparable(dst_view, std.testing.allocator, &k1, &k1, .zero);
+    try src_view.convolveSeparable(std.testing.allocator, dst_view, &k1, &k1, .zero);
 
     // Verify dst view matches src view
     for (0..src_view.rows) |r| {
@@ -797,7 +797,7 @@ test "gaussianBlur preserves color" {
 
     var blurred = try Image(Rgb).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.gaussianBlur(blurred, std.testing.allocator, 1.0);
+    try image.gaussianBlur(std.testing.allocator, blurred, 1.0);
 
     // Center should still be red (though not pure 255)
     const center = blurred.at(3, 3).*;
@@ -823,7 +823,7 @@ test "medianBlur removes impulse noise" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.medianBlur(blurred, std.testing.allocator, 1);
+    try image.medianBlur(std.testing.allocator, blurred, 1);
 
     try expectEqual(@as(u8, 0), blurred.at(2, 2).*);
     try expectEqual(@as(u8, 0), blurred.at(2, 1).*);
@@ -844,7 +844,7 @@ test "percentileBlur max filter" {
 
     var out = try Image(u8).initLike(std.testing.allocator, image);
     defer out.deinit(std.testing.allocator);
-    try image.percentileBlur(out, std.testing.allocator, 1, 1.0, BorderMode.zero);
+    try image.percentileBlur(std.testing.allocator, out, 1, 1.0, BorderMode.zero);
 
     try expectEqual(@as(u8, 8), out.at(1, 1).*);
     try expectEqual(@as(u8, 4), out.at(0, 0).*);
@@ -860,7 +860,7 @@ test "medianBlur preserves dominant RGB color" {
 
     var blurred = try Image(Rgb).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.medianBlur(blurred, std.testing.allocator, 1);
+    try image.medianBlur(std.testing.allocator, blurred, 1);
 
     try expectEqualDeep(base, blurred.at(1, 1).*);
     try expectEqualDeep(base, blurred.at(0, 0).*);
@@ -883,8 +883,8 @@ test "minBlur matches percentile zero" {
     var percentile = try Image(u8).initLike(std.testing.allocator, image);
     defer percentile.deinit(std.testing.allocator);
 
-    try image.minBlur(min_blur, std.testing.allocator, 1, BorderMode.replicate);
-    try image.percentileBlur(percentile, std.testing.allocator, 1, 0.0, BorderMode.replicate);
+    try image.minBlur(std.testing.allocator, min_blur, 1, BorderMode.replicate);
+    try image.percentileBlur(std.testing.allocator, percentile, 1, 0.0, BorderMode.replicate);
 
     for (0..image.rows) |r| {
         for (0..image.cols) |c| {
@@ -908,8 +908,8 @@ test "maxBlur matches percentile one" {
     var percentile = try Image(u8).initLike(std.testing.allocator, image);
     defer percentile.deinit(std.testing.allocator);
 
-    try image.maxBlur(max_blur, std.testing.allocator, 1, BorderMode.replicate);
-    try image.percentileBlur(percentile, std.testing.allocator, 1, 1.0, BorderMode.replicate);
+    try image.maxBlur(std.testing.allocator, max_blur, 1, BorderMode.replicate);
+    try image.percentileBlur(std.testing.allocator, percentile, 1, 1.0, BorderMode.replicate);
 
     for (0..image.rows) |r| {
         for (0..image.cols) |c| {
@@ -932,7 +932,7 @@ test "midpointBlur averages extremes" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.midpointBlur(blurred, std.testing.allocator, 1, BorderMode.replicate);
+    try image.midpointBlur(std.testing.allocator, blurred, 1, BorderMode.replicate);
 
     try expectEqual(@as(u8, 4), blurred.at(1, 1).*);
 }
@@ -951,7 +951,7 @@ test "alphaTrimmedMeanBlur drops extremes" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.alphaTrimmedMeanBlur(blurred, std.testing.allocator, 1, 0.12, BorderMode.replicate);
+    try image.alphaTrimmedMeanBlur(std.testing.allocator, blurred, 1, 0.12, BorderMode.replicate);
 
     try expectEqual(@as(u8, 4), blurred.at(1, 1).*);
 }
@@ -963,7 +963,7 @@ test "alphaTrimmedMeanBlur invalid trim" {
     var out = try Image(u8).initLike(std.testing.allocator, image);
     defer out.deinit(std.testing.allocator);
 
-    try expectError(error.InvalidTrim, image.alphaTrimmedMeanBlur(out, std.testing.allocator, 1, 0.6, BorderMode.replicate));
+    try expectError(error.InvalidTrim, image.alphaTrimmedMeanBlur(std.testing.allocator, out, 1, 0.6, BorderMode.replicate));
 }
 
 test "linearMotionBlur horizontal" {
@@ -979,7 +979,7 @@ test "linearMotionBlur horizontal" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.motionBlur(blurred, std.testing.allocator, .{ .linear = .{ .angle = 0, .distance = 3 } });
+    try image.motionBlur(std.testing.allocator, blurred, .{ .linear = .{ .angle = 0, .distance = 3 } });
 
     // Edge should be blurred horizontally
     const edge_val = blurred.at(2, 3).*;
@@ -1005,7 +1005,7 @@ test "linearMotionBlur vertical" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.motionBlur(blurred, std.testing.allocator, .{ .linear = .{ .angle = std.math.pi / 2.0, .distance = 3 } });
+    try image.motionBlur(std.testing.allocator, blurred, .{ .linear = .{ .angle = std.math.pi / 2.0, .distance = 3 } });
 
     // Edge should be blurred vertically
     const edge_val = blurred.at(3, 2).*;
@@ -1028,7 +1028,7 @@ test "linearMotionBlur diagonal" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.motionBlur(blurred, std.testing.allocator, .{ .linear = .{ .angle = std.math.pi / 4.0, .distance = 3 } });
+    try image.motionBlur(std.testing.allocator, blurred, .{ .linear = .{ .angle = std.math.pi / 4.0, .distance = 3 } });
 
     // Should create diagonal streak
     // Points along the diagonal should have non-zero values
@@ -1050,7 +1050,7 @@ test "linearMotionBlur zero distance" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.motionBlur(blurred, std.testing.allocator, .{ .linear = .{ .angle = 0, .distance = 0 } });
+    try image.motionBlur(std.testing.allocator, blurred, .{ .linear = .{ .angle = 0, .distance = 0 } });
 
     // Should be identical to original
     for (0..image.rows) |r| {
@@ -1070,7 +1070,7 @@ test "linearMotionBlur RGB" {
 
     var blurred = try Image(Rgb).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.motionBlur(blurred, std.testing.allocator, .{ .linear = .{ .angle = 0, .distance = 3 } });
+    try image.motionBlur(std.testing.allocator, blurred, .{ .linear = .{ .angle = 0, .distance = 3 } });
 
     // Color should be preserved but spread
     const center = blurred.at(2, 2).*;
@@ -1098,7 +1098,7 @@ test "radialMotionBlur zoom" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.motionBlur(blurred, std.testing.allocator, .{ .radial_zoom = .{ .center_x = 0.5, .center_y = 0.5, .strength = 0.5 } });
+    try image.motionBlur(std.testing.allocator, blurred, .{ .radial_zoom = .{ .center_x = 0.5, .center_y = 0.5, .strength = 0.5 } });
 
     // Ring should be blurred radially
     // Center should be relatively unchanged
@@ -1119,7 +1119,7 @@ test "radialMotionBlur spin" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.motionBlur(blurred, std.testing.allocator, .{ .radial_spin = .{ .center_x = 0.5, .center_y = 0.5, .strength = 0.5 } });
+    try image.motionBlur(std.testing.allocator, blurred, .{ .radial_spin = .{ .center_x = 0.5, .center_y = 0.5, .strength = 0.5 } });
 
     // Should create arc/spin pattern
     // Adjacent pixels in tangential direction should have values
@@ -1146,7 +1146,7 @@ test "radialMotionBlur zero strength" {
 
     var blurred = try Image(u8).initLike(std.testing.allocator, image);
     defer blurred.deinit(std.testing.allocator);
-    try image.motionBlur(blurred, std.testing.allocator, .{ .radial_zoom = .{ .center_x = 0.5, .center_y = 0.5, .strength = 0 } });
+    try image.motionBlur(std.testing.allocator, blurred, .{ .radial_zoom = .{ .center_x = 0.5, .center_y = 0.5, .strength = 0 } });
 
     // Should be identical to original
     for (0..image.rows) |r| {
@@ -1169,7 +1169,7 @@ test "gaussianBlur with sigma=0" {
 
     var result = try Image(f32).initLike(std.testing.allocator, image);
     defer result.deinit(std.testing.allocator);
-    try image.gaussianBlur(result, std.testing.allocator, 0);
+    try image.gaussianBlur(std.testing.allocator, result, 0);
 
     // With sigma=0, result should be identical to input
     for (0..image.rows) |r| {
@@ -1193,7 +1193,7 @@ test "canny edge detection basic" {
 
     var edges = try Image(u8).initLike(std.testing.allocator, image);
     defer edges.deinit(std.testing.allocator);
-    try image.canny(edges, std.testing.allocator, 1.0, 50, 100);
+    try image.canny(std.testing.allocator, edges, 1.0, 50, 100);
 
     try expectEqual(image.rows, edges.rows);
     try expectEqual(image.cols, edges.cols);
@@ -1225,15 +1225,15 @@ test "canny edge detection parameter validation" {
     defer edges.deinit(std.testing.allocator);
 
     // Test sigma=0 is valid (no blur)
-    try image.canny(edges, std.testing.allocator, 0, 50, 100);
+    try image.canny(std.testing.allocator, edges, 0, 50, 100);
 
     // Test invalid sigma
-    try expectError(error.InvalidSigma, image.canny(edges, std.testing.allocator, -1, 50, 100));
+    try expectError(error.InvalidSigma, image.canny(std.testing.allocator, edges, -1, 50, 100));
 
     // Test invalid thresholds
-    try expectError(error.InvalidThreshold, image.canny(edges, std.testing.allocator, 1.0, -1, 100));
-    try expectError(error.InvalidThreshold, image.canny(edges, std.testing.allocator, 1.0, 50, -1));
-    try expectError(error.InvalidThreshold, image.canny(edges, std.testing.allocator, 1.0, 100, 50));
+    try expectError(error.InvalidThreshold, image.canny(std.testing.allocator, edges, 1.0, -1, 100));
+    try expectError(error.InvalidThreshold, image.canny(std.testing.allocator, edges, 1.0, 50, -1));
+    try expectError(error.InvalidThreshold, image.canny(std.testing.allocator, edges, 1.0, 100, 50));
 }
 
 test "canny rejects non-finite parameters" {
@@ -1250,17 +1250,17 @@ test "canny rejects non-finite parameters" {
     defer edges.deinit(std.testing.allocator);
 
     // Test NaN
-    try expectError(error.InvalidParameter, image.canny(edges, std.testing.allocator, std.math.nan(f32), 50, 100));
-    try expectError(error.InvalidParameter, image.canny(edges, std.testing.allocator, 1.0, std.math.nan(f32), 100));
-    try expectError(error.InvalidParameter, image.canny(edges, std.testing.allocator, 1.0, 50, std.math.nan(f32)));
+    try expectError(error.InvalidParameter, image.canny(std.testing.allocator, edges, std.math.nan(f32), 50, 100));
+    try expectError(error.InvalidParameter, image.canny(std.testing.allocator, edges, 1.0, std.math.nan(f32), 100));
+    try expectError(error.InvalidParameter, image.canny(std.testing.allocator, edges, 1.0, 50, std.math.nan(f32)));
 
     // Test infinity
-    try expectError(error.InvalidParameter, image.canny(edges, std.testing.allocator, std.math.inf(f32), 50, 100));
-    try expectError(error.InvalidParameter, image.canny(edges, std.testing.allocator, 1.0, std.math.inf(f32), 100));
-    try expectError(error.InvalidParameter, image.canny(edges, std.testing.allocator, 1.0, 50, std.math.inf(f32)));
+    try expectError(error.InvalidParameter, image.canny(std.testing.allocator, edges, std.math.inf(f32), 50, 100));
+    try expectError(error.InvalidParameter, image.canny(std.testing.allocator, edges, 1.0, std.math.inf(f32), 100));
+    try expectError(error.InvalidParameter, image.canny(std.testing.allocator, edges, 1.0, 50, std.math.inf(f32)));
 
     // Test negative infinity
-    try expectError(error.InvalidParameter, image.canny(edges, std.testing.allocator, -std.math.inf(f32), 50, 100));
+    try expectError(error.InvalidParameter, image.canny(std.testing.allocator, edges, -std.math.inf(f32), 50, 100));
 }
 
 test "canny edge detection on RGB" {
@@ -1281,7 +1281,7 @@ test "canny edge detection on RGB" {
 
     var edges = try Image(u8).initLike(std.testing.allocator, image);
     defer edges.deinit(std.testing.allocator);
-    try image.canny(edges, std.testing.allocator, 1.0, 30, 90);
+    try image.canny(std.testing.allocator, edges, 1.0, 30, 90);
 
     try expectEqual(image.rows, edges.rows);
     try expectEqual(image.cols, edges.cols);
@@ -1318,7 +1318,7 @@ test "convolve regression issue #255 (missing pixels)" {
         .{ 1, 1, 1 },
     };
 
-    try image.convolve(result, std.testing.allocator, kernel, .zero);
+    try image.convolve(std.testing.allocator, result, kernel, .zero);
 
     // For interior pixels with all 1s and zero padding, 3x3 kernel with 0 at center
     // should result in 8 if all neighbors are 1.
@@ -1374,8 +1374,8 @@ test "convolvePair matches two independent convolves" {
             defer solo_b.deinit(allocator);
 
             convolution.convolvePair(T, src, pair_a, pair_b, kernel_a, kernel_b, mode);
-            try src.convolve(solo_a, allocator, kernel_a, mode);
-            try src.convolve(solo_b, allocator, kernel_b, mode);
+            try src.convolve(allocator, solo_a, kernel_a, mode);
+            try src.convolve(allocator, solo_b, kernel_b, mode);
 
             try std.testing.expectEqualSlices(T, solo_a.data, pair_a.data);
             try std.testing.expectEqualSlices(T, solo_b.data, pair_b.data);
@@ -1404,14 +1404,14 @@ test "boxBlur/sharpen interleaved u8 path matches plane-split path" {
     for ([_]u32{ 1, 3, 7 }) |radius| {
         inline for ([_]enum { blur, sharpen }{ .blur, .sharpen }) |mode| {
             switch (mode) {
-                .blur => try image.boxBlur(filtered, allocator, radius),
-                .sharpen => try image.sharpen(filtered, allocator, radius),
+                .blur => try image.boxBlur(allocator, filtered, radius),
+                .sharpen => try image.sharpen(allocator, filtered, radius),
             }
             inline for ([_][]const u8{ "r", "g", "b" }) |name| {
                 for (chan.data, image.data) |*dst, px| dst.* = @field(px, name);
                 switch (mode) {
-                    .blur => try chan.boxBlur(chan_filtered, allocator, radius),
-                    .sharpen => try chan.sharpen(chan_filtered, allocator, radius),
+                    .blur => try chan.boxBlur(allocator, chan_filtered, radius),
+                    .sharpen => try chan.sharpen(allocator, chan_filtered, radius),
                 }
                 for (chan_filtered.data, filtered.data) |expected, px| {
                     try expectEqual(expected, @field(px, name));

--- a/src/image/tests/interpolation.zig
+++ b/src/image/tests/interpolation.zig
@@ -285,7 +285,7 @@ test "resize preserves value range" {
     defer dst.deinit(allocator);
 
     // Test resize with bilinear interpolation
-    src.resize(dst, allocator, .bilinear);
+    src.resize(allocator, dst, .bilinear);
 
     // Check that all interpolated values are within the original range
     var min_val: u8 = 255;

--- a/src/image/tests/resize.zig
+++ b/src/image/tests/resize.zig
@@ -29,7 +29,7 @@ test "letterbox maintains aspect ratio with padding" {
         var output: Image(u8) = try .init(allocator, 6, 6);
         defer output.deinit(allocator);
 
-        const rect = src.letterbox(output, allocator, .bilinear);
+        const rect = src.letterbox(allocator, output, .bilinear);
 
         try expectEqual(@as(usize, 6), rect.width());
         try expectEqual(@as(usize, 3), rect.height());
@@ -71,7 +71,7 @@ test "letterbox maintains aspect ratio with padding" {
         var output: Image(Rgb) = try .init(allocator, 4, 12);
         defer output.deinit(allocator);
 
-        const rect = src.letterbox(output, allocator, .nearest);
+        const rect = src.letterbox(allocator, output, .nearest);
 
         try expectEqual(@as(usize, 1), rect.width());
         try expectEqual(@as(usize, 4), rect.height());
@@ -102,12 +102,12 @@ test "letterbox edge cases" {
         defer src.deinit(allocator);
 
         const output: Image(u8) = .initFromSlice(0, 10, &[_]u8{});
-        const rect1 = src.letterbox(output, allocator, .nearest);
+        const rect1 = src.letterbox(allocator, output, .nearest);
         try expectEqual(@as(usize, 0), rect1.width());
         try expectEqual(@as(usize, 0), rect1.height());
 
         const output2: Image(u8) = .initFromSlice(10, 0, &[_]u8{});
-        const rect2 = src.letterbox(output2, allocator, .nearest);
+        const rect2 = src.letterbox(allocator, output2, .nearest);
         try expectEqual(@as(usize, 0), rect2.width());
         try expectEqual(@as(usize, 0), rect2.height());
     }
@@ -128,7 +128,7 @@ test "letterbox edge cases" {
         var output: Image(f32) = try .init(allocator, 8, 12);
         defer output.deinit(allocator);
 
-        const rect = src.letterbox(output, allocator, .bicubic);
+        const rect = src.letterbox(allocator, output, .bicubic);
 
         // Should fill entire output
         try expectEqual(@as(usize, 12), rect.width());
@@ -146,7 +146,7 @@ test "letterbox edge cases" {
         var output: Image(u8) = try .init(allocator, 10, 10);
         defer output.deinit(allocator);
 
-        const rect = src.letterbox(output, allocator, .nearest);
+        const rect = src.letterbox(allocator, output, .nearest);
 
         // 1x1 scaled to fit 10x10 = 10x10
         try expectEqual(@as(usize, 10), rect.width());
@@ -191,7 +191,7 @@ test "letterbox interpolation methods comparison" {
         var output: Image(u8) = try .init(allocator, 10, 10);
         defer output.deinit(allocator);
 
-        const rect = src.letterbox(output, allocator, method);
+        const rect = src.letterbox(allocator, output, method);
 
         // Should scale to 10x10 (no padding for square to square)
         try expectEqual(@as(usize, 10), rect.width());
@@ -214,7 +214,7 @@ test "letterbox extreme aspect ratios" {
         var output: Image(u8) = try .init(allocator, 64, 64);
         defer output.deinit(allocator);
 
-        const rect = src.letterbox(output, allocator, .bilinear);
+        const rect = src.letterbox(allocator, output, .bilinear);
 
         // Should maintain aspect ratio
         const scale = @min(@as(f32, 64.0 / 2.0), @as(f32, 64.0 / 32.0));
@@ -240,7 +240,7 @@ test "letterbox extreme aspect ratios" {
         var output: Image(u8) = try .init(allocator, 64, 64);
         defer output.deinit(allocator);
 
-        const rect = src.letterbox(output, allocator, .bicubic);
+        const rect = src.letterbox(allocator, output, .bicubic);
 
         // Should maintain aspect ratio
         const scale = @min(@as(f32, 64.0 / 32.0), @as(f32, 64.0 / 2.0));

--- a/src/qrcode/detector.zig
+++ b/src/qrcode/detector.zig
@@ -71,12 +71,12 @@ fn decodeGray(allocator: Allocator, image: Image(u8)) !?DecodeResult {
     for (0..2) |pass| {
         if (pass == 0) {
             const radius = @max(@min(image.rows, image.cols) / adaptive_radius_divisor, adaptive_radius_min);
-            image.thresholdAdaptiveMean(binary, allocator, radius, adaptive_offset) catch |err| switch (err) {
+            image.thresholdAdaptiveMean(allocator, binary, radius, adaptive_offset) catch |err| switch (err) {
                 error.OutOfMemory => return error.OutOfMemory,
                 else => continue,
             };
         } else {
-            _ = image.thresholdOtsu(binary, allocator) catch continue;
+            _ = image.thresholdOtsu(allocator, binary) catch continue;
         }
         if (try detectAndDecode(allocator, binary, modules)) |result| return result;
     }
@@ -710,7 +710,7 @@ fn photoSimulate(allocator: Allocator, clean: Image(u8), opts: struct {
     if (opts.sigma > 0) {
         var blurred = try Image(u8).initLike(allocator, out);
         errdefer blurred.deinit(allocator);
-        try out.gaussianBlur(blurred, allocator, opts.sigma);
+        try out.gaussianBlur(allocator, blurred, opts.sigma);
         out.deinit(allocator);
         return blurred;
     }


### PR DESCRIPTION
Stacked on `audit/dead-code`.

Every out-param image method now follows `(self, allocator, out, ...)`, and `diff` takes `(self, other, out, opts)`. Mechanical: the CLI, tests, Python bindings and examples are updated to match. Breaking for downstream Zig callers.