### PR TITLE
fix(transforms): extract/insert use the half-open rect like crop

### DIFF
--- a/bindings/python/src/image/transforms.zig
+++ b/bindings/python/src/image/transforms.zig
@@ -530,7 +530,8 @@ pub const image_extract_doc =
     \\Returns a new Image containing the extracted and resampled region.
     \\
     \\## Parameters
-    \\- `rect` (Rectangle): The rectangular region to extract (before rotation)
+    \\- `rect` (Rectangle): The rectangular region to extract (before rotation). Half-open like
+    \\  `crop`: `Rectangle(1, 1, 3, 3)` covers pixels 1 and 2 in each direction.
     \\- `angle` (float, optional): Rotation angle in radians (counter-clockwise). Default: 0.0
     \\- `size` (int or tuple[int, int], optional). If not specified, uses the rectangle's dimensions.
     \\  - If int: output is a square of side `size`
@@ -648,7 +649,7 @@ pub const image_insert_doc =
     \\
     \\## Parameters
     \\- `source` (Image): The image to insert
-    \\- `rect` (Rectangle): Destination rectangle where the source will be placed
+    \\- `rect` (Rectangle): Destination rectangle where the source will be placed (half-open, like `extract`)
     \\- `angle` (float, optional): Rotation angle in radians (counter-clockwise). Default: 0.0
     \\- `method` (Interpolation, optional): Interpolation method. Default: BILINEAR
     \\- `blend_mode` (Blending, optional): Compositing mode for RGBA images. Default: NONE

--- a/bindings/python/src/rectangle.zig
+++ b/bindings/python/src/rectangle.zig
@@ -734,7 +734,7 @@ pub const rectangle_properties_metadata = [_]python.PropertyWithMetadata{
 var rectangle_getset = python.toPyGetSetDefArray(&rectangle_properties_metadata);
 
 // Class documentation - keep it simple
-const rectangle_class_doc = "A rectangle defined by its `left`, `top`, `right`, and `bottom` coordinates.";
+const rectangle_class_doc = "A rectangle defined by its `left`, `top`, `right`, and `bottom` coordinates. Half-open like NumPy slices: `right` and `bottom` are exclusive, so `Rectangle(0, 0, 10, 10)` covers pixels 0..9.";
 
 // Init documentation - detailed explanation
 pub const rectangle_init_doc =

--- a/src/geometry/Rectangle.zig
+++ b/src/geometry/Rectangle.zig
@@ -6,7 +6,9 @@ const expectEqualDeep = std.testing.expectEqualDeep;
 const meta = @import("../meta.zig");
 const Point = @import("Point.zig").Point;
 
-/// A generic rectangle object with some convenience functionality.
+/// An axis-aligned rectangle. Half-open, like NumPy slices: it covers `l <= x < r` and
+/// `t <= y < b`, so `r` and `b` are one past the last pixel and `width() == r - l`. This is
+/// the convention of every rectangle in the library (views, crop, extract, drawing).
 pub fn Rectangle(comptime T: type) type {
     switch (@typeInfo(T)) {
         .int, .float => {},

--- a/src/image.zig
+++ b/src/image.zig
@@ -577,7 +577,8 @@ pub fn Image(comptime T: type) type {
 
         /// Extracts a rotated rectangular region (defined in source coordinates) and resamples it
         /// to fill the pre-allocated `out` image. `angle` is in radians, counter-clockwise around
-        /// the rect center.
+        /// the rect center. `rect` is half-open like `crop`/`view`: `(1, 1, 3, 3)` covers pixels
+        /// 1 and 2, and extracting at angle 0 into an `out` of the rect's size is exactly `crop`.
         ///
         /// Notes:
         /// - Out-of-bounds samples are filled with zeroed pixels (e.g., black/transparent).
@@ -587,7 +588,8 @@ pub fn Image(comptime T: type) type {
         }
 
         /// Inserts `source` into `self` at the destination rectangle, with optional rotation
-        /// (radians, counter-clockwise around the rect center). Complement of `extract`.
+        /// (radians, counter-clockwise around the rect center). Complement of `extract`; `rect`
+        /// is half-open (`(1, 1, 3, 3)` covers pixels 1 and 2).
         ///
         /// Notes:
         /// - The source image is scaled to fit the destination rectangle.

--- a/src/image/tests/transforms.zig
+++ b/src/image/tests/transforms.zig
@@ -240,8 +240,8 @@ test "extract rotated rectangle basic and 90deg" {
         }
     }
 
-    // Define a 3x3 square from (1,1) to (3,3)
-    const rect = Rectangle(f32){ .l = 1, .t = 1, .r = 3, .b = 3 };
+    // The 3x3 block of pixels 1..3: rects are half-open, so r = b = 4.
+    const rect = Rectangle(f32){ .l = 1, .t = 1, .r = 4, .b = 4 };
 
     // Output 3x3 buffer
     var out0: Image(u8) = try .init(allocator, 3, 3);
@@ -289,7 +289,7 @@ test "extract single-pixel axis handling centers correctly" {
         }
     }
 
-    const rect = Rectangle(f32){ .l = 1, .t = 1, .r = 3, .b = 3 }; // 3x3
+    const rect = Rectangle(f32){ .l = 1, .t = 1, .r = 4, .b = 4 }; // pixels 1..3
 
     // 1x1 output should sample rectangle center -> source (2,2) => 22
     var out1: Image(u8) = try .init(allocator, 1, 1);
@@ -466,4 +466,42 @@ test "insert with a rectangle outside the image or a NaN angle is a no-op" {
     dest.insert(source, .{ .l = -20, .t = -20, .r = -10, .b = -10 }, 0.3, .bilinear, color.Blending.none);
     dest.insert(source, .{ .l = 2, .t = 2, .r = 6, .b = 6 }, std.math.nan(f32), .bilinear, color.Blending.none);
     for (dest.data) |px| try std.testing.expectEqual(@as(u8, 0), px);
+}
+
+test "extract, crop and insert agree on the half-open rect" {
+    const allocator = std.testing.allocator;
+    var image: Image(u8) = try .init(allocator, 6, 7);
+    defer image.deinit(allocator);
+    for (0..image.rows) |r| for (0..image.cols) |c| {
+        image.at(r, c).* = @intCast(r * 10 + c);
+    };
+    const rect = Rectangle(f32){ .l = 2, .t = 1, .r = 5, .b = 4 }; // pixels 2..4 × 1..3
+
+    var cropped = try image.crop(allocator, rect);
+    defer cropped.deinit(allocator);
+    try expectEqual(@as(u32, 3), cropped.rows);
+    try expectEqual(@as(u32, 3), cropped.cols);
+
+    // A hair of rotation forces the resampling path; it must land on the same pixels.
+    var extracted: Image(u8) = try .init(allocator, 3, 3);
+    defer extracted.deinit(allocator);
+    image.extract(extracted, rect, 1e-5, .nearest, .zero);
+    try std.testing.expectEqualSlices(u8, cropped.data, extracted.data);
+
+    // The whole image through the resampling path is the identity.
+    var whole: Image(u8) = try .init(allocator, 6, 7);
+    defer whole.deinit(allocator);
+    const full: Rectangle(f32) = .{ .l = 0, .t = 0, .r = 7, .b = 6 };
+    image.extract(whole, full, 1e-5, .nearest, .zero);
+    try std.testing.expectEqualSlices(u8, image.data, whole.data);
+
+    // Inserting the crop back through the resampling path touches exactly the rect.
+    var dest: Image(u8) = try .init(allocator, 6, 7);
+    defer dest.deinit(allocator);
+    dest.fill(255);
+    dest.insert(cropped, rect, 1e-5, .nearest, color.Blending.none);
+    for (0..dest.rows) |r| for (0..dest.cols) |c| {
+        const inside = r >= 1 and r < 4 and c >= 2 and c < 5;
+        try expectEqual(if (inside) image.at(r, c).* else 255, dest.at(r, c).*);
+    };
 }

--- a/src/image/transforms.zig
+++ b/src/image/transforms.zig
@@ -223,7 +223,9 @@ pub fn Transform(comptime T: type) type {
 
         /// Extracts a rotated rectangular region (defined in source coordinates) and resamples it
         /// to fill the pre-allocated `out` image. `angle` is in radians, counter-clockwise around
-        /// the rect center.
+        /// the rect center. Like `crop` and `view`, `rect` is half-open: it covers the pixel
+        /// areas `[l, r) × [t, b)`, so `(1, 1, 3, 3)` is the 2×2 block of pixels 1 and 2, and
+        /// `extract` at angle 0 into an `out` of the rect's size is exactly `crop`.
         ///
         /// Notes:
         /// - Out-of-bounds samples are filled with zeroed pixels (e.g., black/transparent).
@@ -249,26 +251,19 @@ pub fn Transform(comptime T: type) type {
                 return;
             }
 
-            // General path: rotation and/or resampling
-            const cx: f32 = (rect.l + rect.r) * 0.5;
-            const cy: f32 = (rect.t + rect.b) * 0.5;
+            // General path: rotation and/or resampling. Pixel i's centre sits at coordinate i,
+            // so the rect's area [l, r) is the centre range [l - 0.5, r - 0.5); out pixel c
+            // samples the centre of its share of that area.
+            const cx: f32 = (rect.l + rect.r) * 0.5 - 0.5;
+            const cy: f32 = (rect.t + rect.b) * 0.5 - 0.5;
 
             const cos_a = @cos(angle);
             const sin_a = @sin(angle);
 
-            // Normalized mapping with center sampling when size == 1
             for (0..out.rows) |r| {
-                const ty: f32 = if (out.rows == 1)
-                    0.5
-                else
-                    @as(f32, @floatFromInt(r)) / (frows - 1);
-                const y_rect = rect.t + ty * height;
+                const y_rect = rect.t + (@as(f32, @floatFromInt(r)) + 0.5) / frows * height - 0.5;
                 for (0..out.cols) |c| {
-                    const tx: f32 = if (out.cols == 1)
-                        0.5
-                    else
-                        @as(f32, @floatFromInt(c)) / (fcols - 1);
-                    const x_rect = rect.l + tx * width;
+                    const x_rect = rect.l + (@as(f32, @floatFromInt(c)) + 0.5) / fcols * width - 0.5;
 
                     // Rotate around rectangle center by +angle (CCW)
                     const dx = x_rect - cx;
@@ -282,7 +277,8 @@ pub fn Transform(comptime T: type) type {
         }
 
         /// Inserts `source` into `self` at the destination rectangle, with optional rotation
-        /// (radians, counter-clockwise around the rect center). Complement of `extract`.
+        /// (radians, counter-clockwise around the rect center). Complement of `extract`; `rect`
+        /// is half-open like everywhere else (`(1, 1, 3, 3)` covers pixels 1 and 2).
         ///
         /// Notes:
         /// - The source image is scaled to fit the destination rectangle.
@@ -320,9 +316,9 @@ pub fn Transform(comptime T: type) type {
                 return;
             }
 
-            // General path with rotation/scaling
-            const cx = (rect.l + rect.r) * 0.5;
-            const cy = (rect.t + rect.b) * 0.5;
+            // General path with rotation/scaling, in pixel-centre coordinates (see `extract`).
+            const cx = (rect.l + rect.r) * 0.5 - 0.5;
+            const cy = (rect.t + rect.b) * 0.5 - 0.5;
             const cos = @cos(angle);
             const sin = @sin(angle);
 
@@ -364,16 +360,14 @@ pub fn Transform(comptime T: type) type {
                     const rect_x = cos * dx + sin * dy;
                     const rect_y = -sin * dx + cos * dy;
 
-                    // Check if inside rectangle (simplified bounds check)
-                    if (@abs(rect_x) > half_width or @abs(rect_y) > half_height) continue;
+                    // A pixel is inside when its centre lies in the half-open rect area.
+                    if (rect_x < -half_width or rect_x >= half_width or rect_y < -half_height or rect_y >= half_height) continue;
 
-                    // Map to normalized [0,1] coordinates
+                    // Normalized [0,1) position within the rect, then source pixel-centre coordinates
                     const norm_x = (rect_x + half_width) * inv_width;
                     const norm_y = (rect_y + half_height) * inv_height;
-
-                    // Map to source image coordinates
-                    const src_x = if (source.cols == 1) 0 else norm_x * (fcols - 1);
-                    const src_y = if (source.rows == 1) 0 else norm_y * (frows - 1);
+                    const src_x = if (source.cols == 1) 0 else norm_x * fcols - 0.5;
+                    const src_y = if (source.rows == 1) 0 else norm_y * frows - 0.5;
 
                     // Sample from source
                     if (interpolate(SourcePixelType, source, src_x, src_y, method, .mirror)) |src_val| {


### PR DESCRIPTION
Stacked on `audit/param-order`.

The rotated `extract`/`insert` path treated rect corners as pixel centres (dlib's inclusive convention), so `extract` at a hair of rotation was stretched by `cols/(cols-1)` relative to `crop` of the same rect. Rectangles are half-open everywhere else in the library; the resampling path now covers the pixel areas `[l, r) × [t, b)` and samples their centres, so `crop`, `extract` and `insert` agree. The convention is now documented on `Rectangle` (Zig and Python).