### PR TITLE
build: run the tests as one binary and right-size the thread-pool tests

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -17,9 +17,11 @@ pub fn build(b: *Build) void {
         .target = target,
     });
     const version = resolveVersion(b);
-    const version_options = b.addOptions();
-    version_options.addOption([]const u8, "version", b.fmt("{f}", .{version}));
-    zignal.addOptions("build_options", version_options);
+    const build_options = b.addOptions();
+    build_options.addOption([]const u8, "version", b.fmt("{f}", .{version}));
+    build_options.addOption(bool, "print_md5sums", print_md5sums);
+    build_options.addOption(bool, "debug_test_images", debug_test_images);
+    zignal.addOptions("build_options", build_options);
 
     const lib = b.addLibrary(.{
         .name = "zignal",
@@ -64,42 +66,19 @@ pub fn build(b: *Build) void {
     const check = b.step("check", "Check if zignal compiles");
     check.dependOn(&lib.step);
 
+    // One binary: tests come from every file reachable from the root, so per-module binaries
+    // would each re-run the whole image/codecs/terminal closure.
     const test_step = b.step("test", "Run library tests");
-    const test_options = b.addOptions();
-    test_options.addOption(bool, "print_md5sums", print_md5sums);
-    test_options.addOption(bool, "debug_test_images", debug_test_images);
-
-    const modules = [_][]const u8{
-        "color",
-        "image",
-        "geometry",
-        "matrix",
-        "perlin",
-        "canvas",
-        "codecs",
-        "fdm",
-        "pca",
-        "terminal",
-        "font",
-        "features",
-        "optimization",
-        "qrcode",
-        "meta",
-    };
-
-    for (modules) |name| {
-        const module_test = b.addTest(.{
-            .name = name,
-            .root_module = b.createModule(.{
-                .root_source_file = b.path(b.fmt("src/{s}.zig", .{name})),
-                .target = target,
-                .optimize = optimize,
-            }),
-        });
-        module_test.root_module.addOptions("build_options", test_options);
-        const module_test_run = b.addRunArtifact(module_test);
-        test_step.dependOn(&module_test_run.step);
-    }
+    const lib_test = b.addTest(.{
+        .name = "zignal",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/root.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    lib_test.root_module.addOptions("build_options", build_options);
+    test_step.dependOn(&b.addRunArtifact(lib_test).step);
 
     const fmt_step = b.step("fmt", "Check code formatting");
     const fmt = b.addFmt(.{

--- a/src/image/tests/filters.zig
+++ b/src/image/tests/filters.zig
@@ -9,6 +9,7 @@ const color = @import("../../color.zig");
 const Rectangle = @import("../../geometry.zig").Rectangle;
 const Image = @import("../../image.zig").Image;
 const BorderMode = @import("../../image.zig").BorderMode;
+const parallel = @import("../../parallel.zig");
 
 const Rgb = color.Rgb(u8);
 const Rgba = color.Rgba(u8);
@@ -1434,98 +1435,104 @@ test "filters are identical on a thread pool" {
 
     var prng = std.Random.DefaultPrng.init(0x5eed);
     const random = prng.random();
-    // 520x640 takes the fused separable path (temp plane > 1 MiB); 400x600 the two-pass one.
-    for ([_][2]u32{ .{ 520, 640 }, .{ 400, 600 } }) |shape| {
-        const rows = shape[0];
-        const cols = shape[1];
 
+    // Shapes are the smallest that still split into >= 2 bands for each path (src/parallel.zig):
+    // `small` clears the 32 K pixel floor; `fused` pushes the separable temp plane past 1 MiB with
+    // rows for two bands of the widest kernel (sigma 9 -> 55 taps -> 220 rows each); `wide_rank`
+    // has two bands of the 257-wide window that exceeds the two-level histogram limit.
+    const small = [2]u32{ 200, 400 };
+    const fused = [2]u32{ 520, 640 };
+    const wide_rank = [2]u32{ 514, 260 };
+    const wide_radius = 128;
+    try std.testing.expect(parallel.bandCount(small[0], small[1]) >= 2);
+    try std.testing.expect(parallel.bandCountFor(fused[0], fused[1], 4 * 55) >= 2);
+    try std.testing.expect(parallel.bandCountFor(wide_rank[0], wide_rank[1], 2 * wide_radius + 1) >= 2);
+
+    inline for ([_]type{ u8, f32, Rgb }) |T| {
         const Check = struct {
-            fn run(comptime filter: anytype, src: anytype, out_serial: anytype, out_pool: anytype, io_serial: std.Io, io_pool: std.Io) !void {
-                try filter(src, io_serial, out_serial);
-                try filter(src, io_pool, out_pool);
-                try std.testing.expectEqualSlices(std.meta.Child(@TypeOf(out_serial.data)), out_serial.data, out_pool.data);
+            fn run(comptime filter: anytype, shape: [2]u32, comptime Out: type, rng: std.Random, io_serial: std.Io, io_pool: std.Io) !void {
+                var src: Image(T) = try .init(allocator, shape[0], shape[1]);
+                defer src.deinit(allocator);
+                for (src.data) |*px| px.* = switch (T) {
+                    u8 => rng.int(u8),
+                    f32 => 255 * rng.float(f32),
+                    else => .{ .r = rng.int(u8), .g = rng.int(u8), .b = rng.int(u8) },
+                };
+                var a: Image(Out) = try .init(allocator, shape[0], shape[1]);
+                defer a.deinit(allocator);
+                var b: Image(Out) = try .init(allocator, shape[0], shape[1]);
+                defer b.deinit(allocator);
+                try filter(src, io_serial, a);
+                try filter(src, io_pool, b);
+                try std.testing.expectEqualSlices(Out, a.data, b.data);
             }
         };
 
-        inline for ([_]type{ u8, f32, Rgb }) |T| {
-            var src: Image(T) = try .init(allocator, rows, cols);
-            defer src.deinit(allocator);
-            for (src.data) |*px| px.* = switch (T) {
-                u8 => random.int(u8),
-                f32 => 255 * random.float(f32),
-                else => .{ .r = random.int(u8), .g = random.int(u8), .b = random.int(u8) },
-            };
-            var a: Image(T) = try .initLike(allocator, src);
-            defer a.deinit(allocator);
-            var b: Image(T) = try .initLike(allocator, src);
-            defer b.deinit(allocator);
-            var gray_a: Image(u8) = try .init(allocator, rows, cols);
-            defer gray_a.deinit(allocator);
-            var gray_b: Image(u8) = try .init(allocator, rows, cols);
-            defer gray_b.deinit(allocator);
-
-            const F = struct {
-                fn box(s: Image(T), run_io: std.Io, o: Image(T)) !void {
-                    try s.boxBlur(run_io, allocator, o, 3);
-                }
-                fn sharp(s: Image(T), run_io: std.Io, o: Image(T)) !void {
-                    try s.sharpen(run_io, allocator, o, 2);
-                }
-                fn gauss(s: Image(T), run_io: std.Io, o: Image(T)) !void {
-                    try s.gaussianBlur(run_io, allocator, o, 2.5, .default);
-                }
-                fn gaussWide(s: Image(T), run_io: std.Io, o: Image(T)) !void {
-                    try s.gaussianBlur(run_io, allocator, o, 9, .default);
-                }
-                fn gaussIir(s: Image(T), run_io: std.Io, o: Image(T)) !void {
-                    try s.gaussianBlur(run_io, allocator, o, 9, .{ .method = .iir });
-                }
-                fn conv(s: Image(T), run_io: std.Io, o: Image(T)) !void {
-                    const k = [7][7]f32{
-                        .{ 1, 2, 3, 4, 3, 2, 1 },
-                        .{ 2, 3, 4, 5, 4, 3, 2 },
-                        .{ 3, 4, 5, 6, 5, 4, 3 },
-                        .{ 4, 5, 6, 7, 6, 5, 4 },
-                        .{ 3, 4, 5, 6, 5, 4, 3 },
-                        .{ 2, 3, 4, 5, 4, 3, 2 },
-                        .{ 1, 2, 3, 4, 3, 2, 1 },
-                    };
-                    var kn = k;
-                    for (&kn) |*row| for (row) |*v| {
-                        v.* /= 175;
-                    };
-                    try s.convolve(run_io, allocator, o, kn, .mirror);
-                }
-                fn sep(s: Image(T), run_io: std.Io, o: Image(T)) !void {
-                    try s.convolveSeparable(run_io, allocator, o, &.{ 0.1, 0.2, 0.4, 0.2, 0.1 }, &.{ 0.25, 0.5, 0.25 }, .replicate);
-                }
-                fn motionH(s: Image(T), run_io: std.Io, o: Image(T)) !void {
-                    try s.motionBlur(run_io, allocator, o, .{ .linear = .{ .angle = 0, .distance = 11 } });
-                }
-                fn motionV(s: Image(T), run_io: std.Io, o: Image(T)) !void {
-                    try s.motionBlur(run_io, allocator, o, .{ .linear = .{ .angle = std.math.pi / 2.0, .distance = 11 } });
-                }
-                fn median(s: Image(T), run_io: std.Io, o: Image(T)) !void {
-                    try s.medianBlur(run_io, allocator, o, 3);
-                }
-                fn percentileWide(s: Image(T), run_io: std.Io, o: Image(T)) !void {
-                    // Radius 130 (window 261) exceeds the two-level limit and takes the flat path.
-                    try s.percentileBlur(run_io, allocator, o, 130, 0.2, .zero);
-                }
-                fn sobel(s: Image(T), run_io: std.Io, o: Image(u8)) !void {
-                    try s.sobel(run_io, allocator, o);
-                }
-            };
-            inline for (.{ F.box, F.sharp, F.gauss, F.gaussWide, F.gaussIir, F.conv, F.sep, F.motionH, F.motionV }) |filter| {
-                try Check.run(filter, src, a, b, serial_io, pool_io);
+        const F = struct {
+            fn box(s: Image(T), run_io: std.Io, o: Image(T)) !void {
+                try s.boxBlur(run_io, allocator, o, 3);
             }
-            // Order-statistic filters take u8 planes only.
-            if (T != f32) {
-                try Check.run(F.median, src, a, b, serial_io, pool_io);
-                try Check.run(F.percentileWide, src, a, b, serial_io, pool_io);
+            fn sharp(s: Image(T), run_io: std.Io, o: Image(T)) !void {
+                try s.sharpen(run_io, allocator, o, 2);
             }
-            try Check.run(F.sobel, src, gray_a, gray_b, serial_io, pool_io);
+            fn gauss(s: Image(T), run_io: std.Io, o: Image(T)) !void {
+                try s.gaussianBlur(run_io, allocator, o, 2.5, .default);
+            }
+            fn gaussWide(s: Image(T), run_io: std.Io, o: Image(T)) !void {
+                try s.gaussianBlur(run_io, allocator, o, 9, .default);
+            }
+            fn gaussIir(s: Image(T), run_io: std.Io, o: Image(T)) !void {
+                try s.gaussianBlur(run_io, allocator, o, 9, .{ .method = .iir });
+            }
+            fn conv(s: Image(T), run_io: std.Io, o: Image(T)) !void {
+                const k = [7][7]f32{
+                    .{ 1, 2, 3, 4, 3, 2, 1 },
+                    .{ 2, 3, 4, 5, 4, 3, 2 },
+                    .{ 3, 4, 5, 6, 5, 4, 3 },
+                    .{ 4, 5, 6, 7, 6, 5, 4 },
+                    .{ 3, 4, 5, 6, 5, 4, 3 },
+                    .{ 2, 3, 4, 5, 4, 3, 2 },
+                    .{ 1, 2, 3, 4, 3, 2, 1 },
+                };
+                var kn = k;
+                for (&kn) |*row| for (row) |*v| {
+                    v.* /= 175;
+                };
+                try s.convolve(run_io, allocator, o, kn, .mirror);
+            }
+            fn sep(s: Image(T), run_io: std.Io, o: Image(T)) !void {
+                try s.convolveSeparable(run_io, allocator, o, &.{ 0.1, 0.2, 0.4, 0.2, 0.1 }, &.{ 0.25, 0.5, 0.25 }, .replicate);
+            }
+            fn motionH(s: Image(T), run_io: std.Io, o: Image(T)) !void {
+                try s.motionBlur(run_io, allocator, o, .{ .linear = .{ .angle = 0, .distance = 11 } });
+            }
+            fn motionV(s: Image(T), run_io: std.Io, o: Image(T)) !void {
+                try s.motionBlur(run_io, allocator, o, .{ .linear = .{ .angle = std.math.pi / 2.0, .distance = 11 } });
+            }
+            fn median(s: Image(T), run_io: std.Io, o: Image(T)) !void {
+                try s.medianBlur(run_io, allocator, o, 3);
+            }
+            fn percentileWide(s: Image(T), run_io: std.Io, o: Image(T)) !void {
+                try s.percentileBlur(run_io, allocator, o, wide_radius, 0.2, .zero);
+            }
+            fn sobel(s: Image(T), run_io: std.Io, o: Image(u8)) !void {
+                try s.sobel(run_io, allocator, o);
+            }
+        };
+        // Separable filters take the two-pass path on `small` and the fused ring-buffer path on `fused`.
+        inline for (.{ F.gauss, F.gaussWide, F.sep }) |filter| {
+            try Check.run(filter, small, T, random, serial_io, pool_io);
+            try Check.run(filter, fused, T, random, serial_io, pool_io);
         }
+        inline for (.{ F.box, F.sharp, F.gaussIir, F.conv, F.motionH, F.motionV }) |filter| {
+            try Check.run(filter, small, T, random, serial_io, pool_io);
+        }
+        // Order-statistic filters take u8 planes only.
+        if (T != f32) {
+            try Check.run(F.median, small, T, random, serial_io, pool_io);
+            try Check.run(F.percentileWide, wide_rank, T, random, serial_io, pool_io);
+        }
+        try Check.run(F.sobel, small, u8, random, serial_io, pool_io);
     }
 }
 

--- a/src/image/tests/transforms.zig
+++ b/src/image/tests/transforms.zig
@@ -9,6 +9,7 @@ const color = @import("../../color.zig");
 const Rectangle = @import("../../geometry.zig").Rectangle;
 const Image = @import("../../image.zig").Image;
 const Interpolation = @import("../../root.zig").Interpolation;
+const parallel = @import("../../parallel.zig");
 
 const Rgb = color.Rgb(u8);
 const Rgba = color.Rgba(u8);
@@ -520,8 +521,13 @@ test "transforms are identical on a thread pool" {
     var prng = std.Random.DefaultPrng.init(0x7ea);
     const random = prng.random();
 
+    // Every output is at least 64 K pixels, the floor for two bands (src/parallel.zig); the smallest
+    // is the 200x330 downscale, and the resize row pass bands on (src rows, dst cols).
+    try std.testing.expect(parallel.bandCount(200, 330) >= 2);
+    try std.testing.expect(parallel.bandCount(300, 330) >= 2);
+
     inline for ([_]type{ u8, f32, Rgb }) |T| {
-        var src: Image(T) = try .init(allocator, 720, 960);
+        var src: Image(T) = try .init(allocator, 300, 400);
         defer src.deinit(allocator);
         for (src.data) |*px| px.* = switch (T) {
             u8 => random.int(u8),
@@ -538,7 +544,7 @@ test "transforms are identical on a thread pool" {
         // Resize up and down with every method (Rgb takes the u8 plane path, the rest the generic one).
         const methods = [_]Interpolation{ .nearest, .bilinear, .bicubic, .catmull_rom, .{ .mitchell = .default }, .lanczos };
         for (methods) |method| {
-            for ([_][2]u32{ .{ 1000, 1400 }, .{ 300, 400 } }) |shape| {
+            for ([_][2]u32{ .{ 400, 560 }, .{ 200, 330 } }) |shape| {
                 var a: Image(T) = try .init(allocator, shape[0], shape[1]);
                 defer a.deinit(allocator);
                 var b: Image(T) = try .init(allocator, shape[0], shape[1]);
@@ -549,9 +555,9 @@ test "transforms are identical on a thread pool" {
             }
         }
 
-        var rot_a: Image(T) = try .init(allocator, 900, 1100);
+        var rot_a: Image(T) = try .init(allocator, 300, 400);
         defer rot_a.deinit(allocator);
-        var rot_b: Image(T) = try .init(allocator, 900, 1100);
+        var rot_b: Image(T) = try .init(allocator, 300, 400);
         defer rot_b.deinit(allocator);
         src.rotateInto(io, rot_a, 0.5, .bilinear, .mirror);
         src.rotateInto(pool_io, rot_b, 0.5, .bilinear, .mirror);
@@ -560,19 +566,19 @@ test "transforms are identical on a thread pool" {
         const from = [_]Point(2, f32){ .init(.{ 0, 0 }), .init(.{ 100, 0 }), .init(.{ 0, 100 }) };
         const to = [_]Point(2, f32){ .init(.{ 10, 20 }), .init(.{ 90, 35 }), .init(.{ -5, 110 }) };
         const transform = try SimilarityTransform(f32).init(&from, &to);
-        var warp_a: Image(T) = try .init(allocator, 700, 900);
+        var warp_a: Image(T) = try .init(allocator, 300, 400);
         defer warp_a.deinit(allocator);
-        var warp_b: Image(T) = try .init(allocator, 700, 900);
+        var warp_b: Image(T) = try .init(allocator, 300, 400);
         defer warp_b.deinit(allocator);
         src.warp(io, warp_a, transform, .bicubic);
         src.warp(pool_io, warp_b, transform, .bicubic);
         try Check.same(warp_a, warp_b);
 
-        var ext_a: Image(T) = try .init(allocator, 400, 400);
+        var ext_a: Image(T) = try .init(allocator, 300, 300);
         defer ext_a.deinit(allocator);
-        var ext_b: Image(T) = try .init(allocator, 400, 400);
+        var ext_b: Image(T) = try .init(allocator, 300, 300);
         defer ext_b.deinit(allocator);
-        const rect: Rectangle(f32) = .init(200, 150, 650, 600);
+        const rect: Rectangle(f32) = .init(50, 40, 350, 300);
         src.extract(io, ext_a, rect, 0.3, .bilinear, .zero);
         src.extract(pool_io, ext_b, rect, 0.3, .bilinear, .zero);
         try Check.same(ext_a, ext_b);

--- a/src/root.zig
+++ b/src/root.zig
@@ -142,3 +142,21 @@ pub const findGlobalOptimum = optimization.findGlobalOptimum;
 const stats = @import("stats.zig");
 pub const RunningStats = stats.RunningStats;
 pub const RunningStatsConfig = stats.RunningStatsConfig;
+
+test {
+    _ = @import("color.zig");
+    _ = @import("image.zig");
+    _ = @import("geometry.zig");
+    _ = @import("matrix.zig");
+    _ = @import("perlin.zig");
+    _ = @import("canvas.zig");
+    _ = @import("codecs.zig");
+    _ = @import("fdm.zig");
+    _ = @import("pca.zig");
+    _ = @import("terminal.zig");
+    _ = @import("font.zig");
+    _ = @import("features.zig");
+    _ = @import("optimization.zig");
+    _ = @import("qrcode.zig");
+    _ = @import("meta.zig");
+}


### PR DESCRIPTION
## Why

Zig includes the tests of every file reachable from a test root, so the eight per-module test binaries that import `image.zig` each re-ran the same 547-test closure: 5193 test executions for 792 unique tests, 3 min wall and 14 CPU-minutes on an uncached `zig build test`.

## What

- `build.zig` builds one test binary rooted at `src/root.zig`; `root.zig` gets an explicit test block referencing every module so nothing depends on lazy analysis. The version and test flags live in one options step shared by the library module and the tests.
- The thread-pool identity tests for filters and transforms were ~75 % of the closure's run time. Each filter now runs on the smallest shape that still splits into two bands for its path (the 32 K pixel floor, the 1 MiB fused separable temp-plane threshold, or two windows of the wide rank filter); the transforms use a 300x400 source. Both tests assert the band count so a future floor change cannot silently make them single-band.

## Numbers (uncached, 8 cores, Debug)

| | before | after |
|---|---|---|
| wall | 3m01s | 31s |
| CPU | 14m20s | 38s |
| test executions | 5193 | 792 |

The set of test names is identical before and after.