### PR TITLE
fix(codecs): narrow vector lanes to bytes without the saturating @intCast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,11 @@ jobs:
         run: |
           zig build test --summary all
 
+      # Debug uses the self-hosted backend; LLVM-only miscompiles (e.g. vector narrowing) show up here.
+      - name: Tests ReleaseSafe
+        run: |
+          zig build test -Doptimize=ReleaseSafe --summary all
+
       - name: Linux modules
         run: |
           zig build check -Dtarget=x86_64-linux-gnu -Doptimize=ReleaseFast

--- a/src/codecs/jpeg.zig
+++ b/src/codecs/jpeg.zig
@@ -12,6 +12,7 @@ const Image = @import("../image.zig").Image;
 
 const Rgb = @import("../color.zig").Rgb(u8);
 const Ycbcr = @import("../color.zig").Ycbcr(u8);
+const meta = @import("../meta.zig");
 
 const max_file_size: usize = 100 * 1024 * 1024;
 
@@ -981,7 +982,6 @@ const EncodeBand = struct {
     /// `convertColor`, so the result matches the scalar conversion exactly.
     fn convertRow(src: []const Rgb, y: []u8, cb: []u8, cr: []u8) void {
         const V = @Vector(16, i32);
-        const B = @Vector(16, u8);
         var px: usize = 0;
         if (RenderBand.packed_rgb) {
             while (px + 16 <= src.len) : (px += 16) {
@@ -996,9 +996,9 @@ const EncodeBand = struct {
                 const yv = (@as(V, @splat(19595)) * r + @as(V, @splat(38470)) * g + @as(V, @splat(7471)) * b + half) >> @splat(16);
                 const cbv = ((@as(V, @splat(-11059)) * r + @as(V, @splat(-21710)) * g + @as(V, @splat(32768)) * b + half) >> @splat(16)) + bias;
                 const crv = ((@as(V, @splat(32768)) * r + @as(V, @splat(-27439)) * g + @as(V, @splat(-5329)) * b + half) >> @splat(16)) + bias;
-                y[px..][0..16].* = @as(B, @intCast(std.math.clamp(yv, lo, hi)));
-                cb[px..][0..16].* = @as(B, @intCast(std.math.clamp(cbv, lo, hi)));
-                cr[px..][0..16].* = @as(B, @intCast(std.math.clamp(crv, lo, hi)));
+                y[px..][0..16].* = meta.narrowToBytes(std.math.clamp(yv, lo, hi));
+                cb[px..][0..16].* = meta.narrowToBytes(std.math.clamp(cbv, lo, hi));
+                cr[px..][0..16].* = meta.narrowToBytes(std.math.clamp(crv, lo, hi));
             }
         }
         for (src[px..], y[px..src.len], cb[px..src.len], cr[px..src.len]) |p, *yo, *cbo, *cro| {
@@ -2532,7 +2532,7 @@ const Idct = struct {
         if (@reduce(.Or, ac) == 0) {
             // DC only: (dc + 4) >> 3 + 128 for every sample, exactly the two-pass result.
             const dc = std.math.clamp(((r[0] + @as(V16, @splat(4))) >> @splat(3)) + @as(V16, @splat(128)), @as(V16, @splat(0)), @as(V16, @splat(255)));
-            const bytes: [16]u8 = @as(@Vector(16, u8), @intCast(@shuffle(i16, dc, undefined, [16]i32{ 0, 0, 0, 0, 0, 0, 0, 0, 8, 8, 8, 8, 8, 8, 8, 8 })));
+            const bytes: [16]u8 = meta.narrowToBytes(@shuffle(i16, dc, undefined, [16]i32{ 0, 0, 0, 0, 0, 0, 0, 0, 8, 8, 8, 8, 8, 8, 8, 8 }));
             for (0..8) |i| {
                 if (single) dst[i * stride ..][0..8].* = bytes[0..8].* else dst[i * stride ..][0..16].* = bytes;
             }
@@ -2543,7 +2543,7 @@ const Idct = struct {
         pass(&r, 65536 + (128 << 17), 17);
         transpose(&r);
         for (0..8) |i| {
-            const bytes: [16]u8 = @as(@Vector(16, u8), @intCast(std.math.clamp(r[i], @as(V16, @splat(0)), @as(V16, @splat(255)))));
+            const bytes: [16]u8 = meta.narrowToBytes(std.math.clamp(r[i], @as(V16, @splat(0)), @as(V16, @splat(255))));
             if (single) dst[i * stride ..][0..8].* = bytes[0..8].* else dst[i * stride ..][0..16].* = bytes;
         }
     }
@@ -2709,7 +2709,7 @@ const RenderBand = struct {
                 var i: usize = 0;
                 while (i < cw) : (i += lanes) {
                     const v: V = self.vrow[1 + i ..][0..lanes].*;
-                    crow[i..][0..lanes].* = @as(B, @intCast((v + @as(V, @splat(128))) >> @splat(8)));
+                    crow[i..][0..lanes].* = meta.narrowToBytes((v + @as(V, @splat(128))) >> @splat(8));
                 }
             },
             2 => self.upsampleRow(2, crow, cw),
@@ -2746,7 +2746,7 @@ const RenderBand = struct {
             const src: V = self.vrow[x / factor ..][0..lanes].*;
             const lo = @shuffle(i32, src, undefined, taps.lo);
             const hi = @shuffle(i32, src, undefined, taps.hi);
-            crow[x..][0..lanes].* = @as(B, @intCast((lo * w_lo + hi * w_hi + rounding) >> @splat(16)));
+            crow[x..][0..lanes].* = meta.narrowToBytes((lo * w_lo + hi * w_hi + rounding) >> @splat(16));
         }
     }
 
@@ -2763,17 +2763,17 @@ const RenderBand = struct {
             var g: B = undefined;
             var b: B = undefined;
             if (rgb_model) {
-                r = @intCast(yv);
-                g = @intCast(c1);
-                b = @intCast(c2);
+                r = meta.narrowToBytes(yv);
+                g = meta.narrowToBytes(c1);
+                b = meta.narrowToBytes(c2);
             } else {
                 const u = c1 - bias;
                 const v = c2 - bias;
                 const lo: V = @splat(0);
                 const hi: V = @splat(255);
-                r = @intCast(std.math.clamp(yv + ((@as(V, @splat(91881)) * v + rounding) >> @splat(16)), lo, hi));
-                g = @intCast(std.math.clamp(yv - ((@as(V, @splat(22554)) * u + @as(V, @splat(46802)) * v + rounding) >> @splat(16)), lo, hi));
-                b = @intCast(std.math.clamp(yv + ((@as(V, @splat(116130)) * u + rounding) >> @splat(16)), lo, hi));
+                r = meta.narrowToBytes(std.math.clamp(yv + ((@as(V, @splat(91881)) * v + rounding) >> @splat(16)), lo, hi));
+                g = meta.narrowToBytes(std.math.clamp(yv - ((@as(V, @splat(22554)) * u + @as(V, @splat(46802)) * v + rounding) >> @splat(16)), lo, hi));
+                b = meta.narrowToBytes(std.math.clamp(yv + ((@as(V, @splat(116130)) * u + rounding) >> @splat(16)), lo, hi));
             }
             const n = @min(lanes, width - px);
             const out = dst[px..][0..n];

--- a/src/image/channel_ops.zig
+++ b/src/image/channel_ops.zig
@@ -332,7 +332,7 @@ pub fn resizeColumnsU8(mid: []const i32, dst_cols: u32, y_taps: AxisTaps, dst: [
             }
             const scaled = acc >> @splat(shift);
             const clamped = @max(@as(V, @splat(0)), @min(@as(V, @splat(255)), scaled));
-            const bytes: @Vector(vec_len, u8) = @intCast(clamped);
+            const bytes: @Vector(vec_len, u8) = meta.narrowToBytes(clamped);
             out[c..][0..vec_len].* = bytes;
         }
         while (c < dst_cols) : (c += 1) {

--- a/src/image/dither.zig
+++ b/src/image/dither.zig
@@ -153,7 +153,7 @@ pub fn applyOrdered(img: Image(Rgb), pal: []const Rgb, lut: ColorLookupTable) vo
 
                 const clamped = @min(@max(result_i16, min_vec), max_vec);
 
-                const result_u8: @Vector(24, u8) = @intCast(clamped);
+                const result_u8: @Vector(24, u8) = meta.narrowToBytes(clamped);
                 const quantized_vec = result_u8 >> @as(@Vector(24, u3), @splat(8 - color_quantize_bits));
                 const q_arr: [24]u8 = quantized_vec;
 

--- a/src/meta.zig
+++ b/src/meta.zig
@@ -124,6 +124,19 @@ pub fn clamp(comptime T: type, value: anytype) T {
     }
 }
 
+/// Narrows integer vector lanes already in 0..255 to bytes. `@intCast` to `u8` lanes is lowered
+/// as a signed saturating pack in release builds (zig 0.17.0-dev.1970), which turns 128..255
+/// into 127; truncating the unsigned view of the lanes sidesteps it.
+pub fn narrowToBytes(v: anytype) @Vector(@typeInfo(@TypeOf(v)).vector.len, u8) {
+    const info = @typeInfo(@TypeOf(v)).vector;
+    const V = @TypeOf(v);
+    if (std.debug.runtime_safety) {
+        std.debug.assert(@reduce(.And, v >= @as(V, @splat(0))) and @reduce(.And, v <= @as(V, @splat(255))));
+    }
+    const Unsigned = @Vector(info.len, @Int(.unsigned, @typeInfo(info.child).int.bits));
+    return @truncate(@as(Unsigned, @bitCast(v)));
+}
+
 /// Check if a type is an RGB or RGBA type with u8 components.
 /// Returns true for structs with 3 or 4 u8 fields named r, g, b[, a].
 ///
@@ -189,6 +202,16 @@ pub fn safeCast(comptime T: type, value: anytype) !T {
         },
         else => @compileError("safeCast only supports numeric target types"),
     }
+}
+
+test "meta.narrowToBytes keeps lanes above 127" {
+    var lanes: [16]i32 = undefined;
+    for (&lanes, 0..) |*lane, i| lane.* = @intCast(120 + 9 * i);
+    std.mem.doNotOptimizeAway(&lanes);
+    const bytes: [16]u8 = narrowToBytes(@as(@Vector(16, i32), lanes));
+    for (bytes, lanes) |byte, lane| try std.testing.expectEqual(lane, byte);
+    const wide: [8]u8 = narrowToBytes(@as(@Vector(8, i16), .{ 0, 1, 127, 128, 129, 200, 254, 255 }));
+    try std.testing.expectEqualSlices(u8, &.{ 0, 1, 127, 128, 129, 200, 254, 255 }, &wide);
 }
 
 test "meta.clamp" {


### PR DESCRIPTION
## Why

The four JPEG round-trip tests fail under `-Doptimize=ReleaseSafe` while passing in Debug. Bisecting today's JPEG commits puts the first failure at #453. The cause is a compiler-level miscompile: on zig 0.17.0-dev.1970 the LLVM backend lowers `@intCast` from a signed integer vector to a `u8` vector as a signed saturating pack, so lanes 128..255 come out as 127. A minimal repro shows it in both ReleaseSafe and ReleaseFast; Debug is correct because the self-hosted backend does not use that lowering.

The horizontal chroma upsample in `RenderBand.upsampleRow` ends in exactly that cast, which capped every upsampled Cb/Cr row at 127. Sites that clamp to 0..255 before casting only worked by luck of the lowering, and the stored-RGB path had the same latent problem.

## What

- `src/meta.zig`: `narrowToBytes` truncates the unsigned bit view of the lanes and asserts the 0..255 range under runtime safety, with a test that feeds it lanes above 127.
- Every signed-vector-to-u8 cast goes through it: eight sites in `src/codecs/jpeg.zig` (encoder colour conversion, DC-only and full IDCT output, chroma upsample, decoder colour conversion), plus the u8 resize path in `src/image/channel_ops.zig` and the vector dither in `src/image/dither.zig`.
- `.github/workflows/test.yml` runs the suite under ReleaseSafe as well, since Debug never sees LLVM-only miscompiles. This step gets much faster once #458 lands (one binary instead of fifteen).

Encoded JPEG bytes are unchanged and pinned decode/encode timings on `assets/liza.jpg` match master within noise.