### PR TITLE
refactor: share the band plumbing and trim the duplicated helpers

### DIFF
--- a/bindings/python/src/image/core.zig
+++ b/bindings/python/src/image/core.zig
@@ -102,7 +102,7 @@ fn loadBytes(comptime format: ImageFormat, data: []const u8) ?*c.PyObject {
                 return null;
             };
             defer decoded.deinit(allocator);
-            const native = zignal.gif.toNativeImage(allocator, decoded) catch |err| {
+            const native = zignal.gif.toNativeImage(python.io, allocator, decoded) catch |err| {
                 setDecodeError(kind, err);
                 return null;
             };
@@ -228,7 +228,7 @@ fn decodeFile(comptime format: ImageFormat, data: []const u8, path: []const u8, 
                 return null;
             };
             defer decoded.deinit(allocator);
-            const native = zignal.gif.toNativeImage(allocator, decoded) catch |err| {
+            const native = zignal.gif.toNativeImage(python.io, allocator, decoded) catch |err| {
                 python.setErrorWithPath(err, path);
                 return null;
             };

--- a/src/codecs/gif.zig
+++ b/src/codecs/gif.zig
@@ -573,13 +573,13 @@ pub const NativeImage = union(enum) {
 
 /// Composes the first frame and returns it as `NativeImage`. Used by language
 /// bindings that pick the pixel type based on file metadata.
-pub fn toNativeImage(allocator: Allocator, state: GifState) !NativeImage {
+pub fn toNativeImage(io: Io, allocator: Allocator, state: GifState) !NativeImage {
     if (state.frames.len == 0) return error.MissingPixelData;
     const has_transparency = if (state.frames[0].gce) |g| g.has_transparent else false;
     if (has_transparency) {
-        return .{ .rgba = try composeFirstFrame(Rgba, parallel.inline_io, allocator, state) };
+        return .{ .rgba = try composeFirstFrame(Rgba, io, allocator, state) };
     }
-    return .{ .rgb = try composeFirstFrame(Rgb, parallel.inline_io, allocator, state) };
+    return .{ .rgb = try composeFirstFrame(Rgb, io, allocator, state) };
 }
 
 /// Loads a GIF from in-memory bytes. Returns frame 0 only — see
@@ -789,8 +789,6 @@ fn writeLzwImageData(allocator: Allocator, out: *std.ArrayList(u8), indices: []c
 
 /// Encodes a single-frame GIF from `image`. Caller frees the returned slice.
 pub fn encode(comptime T: type, io: Io, allocator: Allocator, image: Image(T), options: EncodeOptions) ![]u8 {
-    // Serial encoder; `io` keeps the codec entry points uniform.
-    _ = io;
     if (image.cols == 0 or image.rows == 0) return error.InvalidDimensions;
     if (image.cols > 65535 or image.rows > 65535) return error.ImageTooLarge;
 
@@ -824,7 +822,7 @@ pub fn encode(comptime T: type, io: Io, allocator: Allocator, image: Image(T), o
         } else {
             palette = custom;
         }
-        try mapImageToPalette(T, allocator, image, palette, indices, options.dither, if (has_transparent) transparent_index else null);
+        try mapImageToPalette(T, io, allocator, image, palette, indices, options.dither, if (has_transparent) transparent_index else null);
     } else if (T == u8) {
         // u8 → 256-entry linear gray palette; indices are the pixel values.
         @memcpy(&palette_buf, &quantize.linear_gray_256);
@@ -854,7 +852,7 @@ pub fn encode(comptime T: type, io: Io, allocator: Allocator, image: Image(T), o
             palette_size += 1;
         }
         palette = palette_buf[0..palette_size];
-        try mapImageToPalette(T, allocator, image, palette, indices, options.dither, if (has_transparent) transparent_index else null);
+        try mapImageToPalette(T, io, allocator, image, palette, indices, options.dither, if (has_transparent) transparent_index else null);
     }
 
     var min_code_size: u4 = 2;
@@ -911,6 +909,7 @@ inline fn writeU16Le(allocator: Allocator, out: *std.ArrayList(u8), v: u16) !voi
 /// the no-dither path converts per-pixel.
 fn mapImageToPalette(
     comptime T: type,
+    io: Io,
     allocator: Allocator,
     image: Image(T),
     palette: []const Rgb,
@@ -922,7 +921,7 @@ fn mapImageToPalette(
     const lut = quantize.ColorLookupTable.init(lookup_palette);
 
     if (use_dither) {
-        var work = try image.convert(parallel.inline_io, allocator, Rgb);
+        var work = try image.convert(io, allocator, Rgb);
         defer work.deinit(allocator);
         dither.applyFloydSteinberg(work, lookup_palette, lut);
         var i: usize = 0;
@@ -1103,7 +1102,7 @@ fn emitAnimatedFrame(
 
     const indices = try gpa.alloc(u8, num_pixels);
     defer gpa.free(indices);
-    try mapImageToPalette(T, gpa, frame, palette, indices, options.dither, if (has_transparent) transparent_index else null);
+    try mapImageToPalette(T, parallel.inline_io, gpa, frame, palette, indices, options.dither, if (has_transparent) transparent_index else null);
 
     var min_code_size: u4 = 2;
     while ((@as(u16, 1) << min_code_size) < palette.len) min_code_size += 1;

--- a/src/codecs/jpeg.zig
+++ b/src/codecs/jpeg.zig
@@ -9,6 +9,7 @@ const Io = std.Io;
 const parallel = @import("../parallel.zig");
 
 const convertColor = @import("../color.zig").convertColor;
+const bt601 = @import("../color.zig").bt601;
 const Image = @import("../image.zig").Image;
 
 const Rgb = @import("../color.zig").Rgb(u8);
@@ -338,12 +339,7 @@ pub fn encode(comptime T: type, io: Io, allocator: Allocator, image: Image(T), o
     }
 
     switch (T) {
-        u8 => {
-            if (image.isContiguous()) return encodeGrayscale(io, allocator, image.asBytes(), @intCast(image.cols), @intCast(image.rows), options);
-            var contiguous = try image.dupe(allocator);
-            defer contiguous.deinit(allocator);
-            return encodeGrayscale(io, allocator, contiguous.asBytes(), @intCast(image.cols), @intCast(image.rows), options);
-        },
+        u8 => return encodeGrayscale(io, allocator, image, options),
         Rgb => return encodeRgb(io, allocator, image, options),
         else => {
             var converted = try image.convert(io, allocator, Rgb);
@@ -594,6 +590,18 @@ fn writeSOS(dst: *std.ArrayList(u8), gpa: Allocator, grayscale: bool) !void {
 // Encoder: entropy writer
 // -----------------------------
 
+/// Whether any byte of `word` is 0xFF (SWAR: the carry out of the low seven bits meets bit 7).
+inline fn hasByteFF(word: anytype) bool {
+    const T = @TypeOf(word);
+    const ones: T = std.math.maxInt(T) / 255;
+    return (word & (ones * 0x7F)) + ones & word & (ones * 0x80) != 0;
+}
+
+/// RSTn marker byte (0xD0..0xD7).
+inline fn isRstn(byte: u8) bool {
+    return byte >= 0xD0 and byte <= 0xD7;
+}
+
 /// Big-endian bit packer; every 0xFF byte gets its stuffed zero. Callers reserve room per
 /// block so the hot path never allocates, and code a block through a `Bits` register copy
 /// of the pending bits.
@@ -630,9 +638,8 @@ const BitWriter = struct {
     inline fn emitWord(self: *BitWriter, bits: *Bits) void {
         bits.count -= 32;
         const word: u32 = @truncate(bits.acc >> @intCast(bits.count));
-        const has_ff = (word & 0x7F7F7F7F) + 0x01010101 & word & 0x80808080;
         const bytes: [4]u8 = @bitCast(std.mem.nativeToBig(u32, word));
-        if (has_ff == 0) {
+        if (!hasByteFF(word)) {
             self.list.appendSliceAssumeCapacity(&bytes);
         } else {
             for (bytes) |byte| self.putByte(byte);
@@ -789,7 +796,7 @@ const Fdct = struct {
 
     const const_bits = 13;
     fn fix(comptime x: f32) i16 {
-        return @intFromFloat(@round(x * (1 << const_bits)));
+        return @round(x * (1 << const_bits));
     }
     const f0298 = fix(0.298631336);
     const f0390 = fix(0.390180644);
@@ -865,7 +872,7 @@ const Fdct = struct {
         for (0..8) |i| {
             const row_a: @Vector(8, u8) = a[i * stride ..][0..8].*;
             const row_b: @Vector(8, u8) = b[i * stride ..][0..8].*;
-            const samples: V16 = @intCast(@shuffle(u8, row_a, row_b, Dct.concat));
+            const samples: V16 = @shuffle(u8, row_a, row_b, Dct.concat);
             r[i] = samples - @as(V16, @splat(128));
         }
         // Rows first (lanes are rows after a transpose), then columns.
@@ -990,12 +997,12 @@ const EncodeBand = struct {
     }
 
     /// Copies grayscale rows into the luma plane, replicating edges.
-    fn fillGray(self: *EncodeBand, bytes: []const u8, cols: usize, rows_total: usize, mcu_y: usize) void {
+    fn fillGray(self: *EncodeBand, image: Image(u8), mcu_y: usize) void {
         for (0..8) |r| {
-            const src_row = @min(mcu_y * 8 + r, rows_total - 1);
+            const src_row = @min(mcu_y * 8 + r, image.rows - 1);
             const row = self.y[r * self.y_stride ..][0..self.y_stride];
-            @memcpy(row[0..cols], bytes[src_row * cols ..][0..cols]);
-            @memset(row[cols..], row[cols - 1]);
+            @memcpy(row[0..image.cols], image.data[src_row * image.stride ..][0..image.cols]);
+            @memset(row[image.cols..], row[image.cols - 1]);
         }
     }
 
@@ -1007,16 +1014,16 @@ const EncodeBand = struct {
         if (RenderBand.packed_rgb) {
             while (px + 16 <= src.len) : (px += 16) {
                 const bytes: @Vector(48, u8) = std.mem.sliceAsBytes(src[px..][0..16])[0..48].*;
-                const r: V = @intCast(@shuffle(u8, bytes, undefined, deinterleave_r));
-                const g: V = @intCast(@shuffle(u8, bytes, undefined, deinterleave_g));
-                const b: V = @intCast(@shuffle(u8, bytes, undefined, deinterleave_b));
+                const r: V = @shuffle(u8, bytes, undefined, deinterleave_r);
+                const g: V = @shuffle(u8, bytes, undefined, deinterleave_g);
+                const b: V = @shuffle(u8, bytes, undefined, deinterleave_b);
                 const half: V = @splat(32768);
                 const bias: V = @splat(128);
                 const lo: V = @splat(0);
                 const hi: V = @splat(255);
-                const yv = (@as(V, @splat(19595)) * r + @as(V, @splat(38470)) * g + @as(V, @splat(7471)) * b + half) >> @splat(16);
-                const cbv = ((@as(V, @splat(-11059)) * r + @as(V, @splat(-21710)) * g + @as(V, @splat(32768)) * b + half) >> @splat(16)) + bias;
-                const crv = ((@as(V, @splat(32768)) * r + @as(V, @splat(-27439)) * g + @as(V, @splat(-5329)) * b + half) >> @splat(16)) + bias;
+                const yv = (@as(V, @splat(bt601.y_r)) * r + @as(V, @splat(bt601.y_g)) * g + @as(V, @splat(bt601.y_b)) * b + half) >> @splat(16);
+                const cbv = ((@as(V, @splat(bt601.cb_r)) * r + @as(V, @splat(bt601.cb_g)) * g + @as(V, @splat(bt601.cb_b)) * b + half) >> @splat(16)) + bias;
+                const crv = ((@as(V, @splat(bt601.cr_r)) * r + @as(V, @splat(bt601.cr_g)) * g + @as(V, @splat(bt601.cr_b)) * b + half) >> @splat(16)) + bias;
                 y[px..][0..16].* = meta.narrowToBytes(std.math.clamp(yv, lo, hi));
                 cb[px..][0..16].* = meta.narrowToBytes(std.math.clamp(cbv, lo, hi));
                 cr[px..][0..16].* = meta.narrowToBytes(std.math.clamp(crv, lo, hi));
@@ -1063,11 +1070,11 @@ const EncodeBand = struct {
         const V = @Vector(16, u16);
         var cx: usize = 0;
         while (cx < count) : (cx += 16) {
-            var sum: W = @intCast(@as(@Vector(32, u8), top[2 * cx ..][0..32].*));
-            if (vertical) sum += @as(W, @intCast(@as(@Vector(32, u8), bottom[2 * cx ..][0..32].*)));
+            var sum: W = @as(@Vector(32, u8), top[2 * cx ..][0..32].*);
+            if (vertical) sum += @as(@Vector(32, u8), bottom[2 * cx ..][0..32].*);
             const pairs: V = @shuffle(u16, sum, undefined, evens) + @shuffle(u16, sum, undefined, odds);
             const avg = if (vertical) (pairs + @as(V, @splat(2))) >> @splat(2) else (pairs + @as(V, @splat(1))) >> @splat(1);
-            dst[cx..][0..16].* = @as(@Vector(16, u8), @intCast(avg));
+            dst[cx..][0..16].* = meta.narrowToBytes(avg);
         }
     }
 
@@ -1152,19 +1159,14 @@ fn encodeRgb(io: Io, allocator: Allocator, image: Image(Rgb), options: EncodeOpt
     try writeDQT(&out, allocator, &ql, &qc);
     try writeSOF0(&out, allocator, @intCast(image.cols), @intCast(image.rows), false, options.subsampling);
     try writeDHT(&out, allocator, false);
-    const mcu_width: usize = 8 * @as(usize, options.subsampling.lumaFactors() >> 4);
+    const factors = options.subsampling.lumaFactors();
+    const h_max: usize = factors >> 4;
+    const v_max: usize = factors & 0xF;
+    const mcu_width = 8 * h_max;
     const restart_interval = options.restart_interval.mcusFor((image.cols + mcu_width - 1) / mcu_width);
     if (restart_interval != 0) try writeDRI(&out, allocator, restart_interval);
     try writeSOS(&out, allocator, false);
 
-    const h_max: usize = switch (options.subsampling) {
-        .yuv444 => 1,
-        .yuv422, .yuv420 => 2,
-    };
-    const v_max: usize = switch (options.subsampling) {
-        .yuv444, .yuv422 => 1,
-        .yuv420 => 2,
-    };
     const tables = scanTables(&ql, &qc);
     try encodeScan(io, allocator, &out, .{ .rgb = image }, &tables, image.cols, image.rows, h_max, v_max, true, restart_interval);
 
@@ -1178,12 +1180,12 @@ fn encodeRgb(io: Io, allocator: Allocator, image: Image(Rgb), options: EncodeOpt
 /// Pixel source of an encode; a band fills its planes from it one MCU row at a time.
 const EncodeSource = union(enum) {
     rgb: Image(Rgb),
-    gray: struct { bytes: []const u8, cols: usize, rows: usize },
+    gray: Image(u8),
 
     fn fill(self: EncodeSource, band: *EncodeBand, mcu_y: usize) void {
         switch (self) {
             .rgb => |img| band.fillRgb(img, mcu_y),
-            .gray => |g| band.fillGray(g.bytes, g.cols, g.rows, mcu_y),
+            .gray => |img| band.fillGray(img, mcu_y),
         }
     }
 };
@@ -1199,15 +1201,8 @@ fn encodeScan(io: Io, allocator: Allocator, out: *std.ArrayList(u8), source: Enc
     const total = mcu_cols * mcu_rows;
     const interval: usize = restart_interval;
     const segments = if (interval == 0) 1 else (total + interval - 1) / interval;
-    const bands = @min(parallel.bandCount(mcu_rows, cols * 8 * v_max), segments);
+    const bands = parallel.bandCount(segments, interval * 64 * h_max * v_max);
 
-    const Band = struct {
-        mcu0: usize,
-        mcu1: usize,
-        seg0: usize,
-        w: BitWriter,
-        err: ?anyerror = null,
-    };
     const Ctx = struct {
         allocator: Allocator,
         source: EncodeSource,
@@ -1218,24 +1213,23 @@ fn encodeScan(io: Io, allocator: Allocator, out: *std.ArrayList(u8), source: Enc
         chroma: bool,
         mcu_cols: usize,
         restart_interval: u16,
-        bands: []Band,
+        total: usize,
+        segments: usize,
+        writers: []BitWriter,
 
-        fn run(ctx: *const @This(), k: usize, _: usize, _: usize) void {
-            ctx.bands[k].err = null;
-            ctx.encodeBand(&ctx.bands[k], k + 1 == ctx.bands.len) catch |err| {
-                ctx.bands[k].err = err;
-            };
-        }
-
-        fn encodeBand(ctx: *const @This(), band: *Band, last: bool) !void {
+        fn run(ctx: *const @This(), k: usize, seg0: usize, seg1: usize) !void {
+            const w = &ctx.writers[k];
+            const last = seg1 == ctx.segments;
+            const mcu0 = seg0 * ctx.restart_interval;
+            const mcu1 = if (last) ctx.total else seg1 * ctx.restart_interval;
             var planes: EncodeBand = try .init(ctx.allocator, ctx.cols, ctx.h_max, ctx.v_max, ctx.chroma);
             defer planes.deinit();
             var prev_dc: [3]i32 = @splat(0);
             var mcus_in_interval: u16 = 0;
             // The marker before this band's first segment is written by the previous band.
-            var rst_index: u3 = @intCast(band.seg0 % 8);
-            const row0 = band.mcu0 / ctx.mcu_cols;
-            const row1 = (band.mcu1 - 1) / ctx.mcu_cols + 1;
+            var rst_index: u3 = @intCast(seg0 % 8);
+            const row0 = mcu0 / ctx.mcu_cols;
+            const row1 = (mcu1 - 1) / ctx.mcu_cols + 1;
             for (row0..row1) |mcu_y| {
                 ctx.source.fill(&planes, mcu_y);
                 EncodeBand.transformPlane(planes.y, planes.y_stride, ctx.v_max, &ctx.tables.y_quant, planes.y_coefs);
@@ -1244,28 +1238,19 @@ fn encodeScan(io: Io, allocator: Allocator, out: *std.ArrayList(u8), source: Enc
                     EncodeBand.transformPlane(planes.cr, planes.c_stride, 1, &ctx.tables.c_quant, planes.cr_coefs);
                 }
                 const row_start = mcu_y * ctx.mcu_cols;
-                const x0 = @max(band.mcu0, row_start) - row_start;
-                const x1 = @min(band.mcu1, row_start + ctx.mcu_cols) - row_start;
-                try encodeBandScan(&band.w, &planes, ctx.tables, ctx.chroma, ctx.restart_interval, &mcus_in_interval, &rst_index, &prev_dc, x0, x1);
+                const x0 = @max(mcu0, row_start) - row_start;
+                const x1 = @min(mcu1, row_start + ctx.mcu_cols) - row_start;
+                try encodeBandScan(w, &planes, ctx.tables, ctx.chroma, ctx.restart_interval, &mcus_in_interval, &rst_index, &prev_dc, x0, x1);
             }
-            try band.w.reserve();
-            if (last) band.w.flush() else band.w.restart(rst_index);
+            try w.reserve();
+            if (last) w.flush() else w.restart(rst_index);
         }
     };
 
-    const band_list = try allocator.alloc(Band, bands);
-    defer allocator.free(band_list);
-    for (band_list, 0..) |*band, k| {
-        const seg0 = k * segments / bands;
-        const seg1 = (k + 1) * segments / bands;
-        band.* = .{
-            .mcu0 = seg0 * interval,
-            .mcu1 = if (k + 1 == bands) total else seg1 * interval,
-            .seg0 = seg0,
-            .w = .{ .gpa = allocator },
-        };
-    }
-    defer for (band_list) |*band| band.w.deinit();
+    const writers = try allocator.alloc(BitWriter, bands);
+    defer allocator.free(writers);
+    for (writers) |*w| w.* = .{ .gpa = allocator };
+    defer for (writers) |*w| w.deinit();
 
     const ctx: Ctx = .{
         .allocator = allocator,
@@ -1277,19 +1262,18 @@ fn encodeScan(io: Io, allocator: Allocator, out: *std.ArrayList(u8), source: Enc
         .chroma = chroma,
         .mcu_cols = mcu_cols,
         .restart_interval = restart_interval,
-        .bands = band_list,
+        .total = total,
+        .segments = segments,
+        .writers = writers,
     };
-    parallel.forRowBands(io, bands, bands, &ctx, Ctx.run);
+    try parallel.forRowBandsTry(io, segments, bands, &ctx, Ctx.run);
     var bytes: usize = 0;
-    for (band_list) |band| {
-        if (band.err) |err| return err;
-        bytes += band.w.list.items.len;
-    }
+    for (writers) |w| bytes += w.list.items.len;
     try out.ensureUnusedCapacity(allocator, bytes);
-    for (band_list) |band| out.appendSliceAssumeCapacity(band.w.list.items);
+    for (writers) |w| out.appendSliceAssumeCapacity(w.list.items);
 }
 
-fn encodeGrayscale(io: Io, allocator: Allocator, bytes: []const u8, width: u32, height: u32, options: EncodeOptions) ![]u8 {
+fn encodeGrayscale(io: Io, allocator: Allocator, image: Image(u8), options: EncodeOptions) ![]u8 {
     var out = std.ArrayList(u8).empty;
     defer out.deinit(allocator);
 
@@ -1310,14 +1294,14 @@ fn encodeGrayscale(io: Io, allocator: Allocator, bytes: []const u8, width: u32, 
     for (0..64) |i| try tmp_dqt.append(allocator, ql[zigzag[i]]);
     try writeSegment(&out, allocator, 0xFFDB, tmp_dqt.items);
 
-    try writeSOF0(&out, allocator, @intCast(width), @intCast(height), true, .yuv444);
+    try writeSOF0(&out, allocator, @intCast(image.cols), @intCast(image.rows), true, .yuv444);
     try writeDHT(&out, allocator, true);
-    const restart_interval = options.restart_interval.mcusFor((width + 7) / 8);
+    const restart_interval = options.restart_interval.mcusFor((image.cols + 7) / 8);
     if (restart_interval != 0) try writeDRI(&out, allocator, restart_interval);
     try writeSOS(&out, allocator, true);
 
     const tables = scanTables(&ql, &qc);
-    try encodeScan(io, allocator, &out, .{ .gray = .{ .bytes = bytes, .cols = width, .rows = height } }, &tables, width, height, 1, 1, false, restart_interval);
+    try encodeScan(io, allocator, &out, .{ .gray = image }, &tables, image.cols, image.rows, 1, 1, false, restart_interval);
 
     // EOI
     try out.append(allocator, 0xFF);
@@ -1951,8 +1935,7 @@ pub const BitReader = struct {
         // Fast path: no stuffing or marker in the next eight bytes, so load as many as fit at once.
         if (!self.marker_hit and self.byte_pos + 8 <= self.data.len) {
             const word = std.mem.readInt(u64, self.data[self.byte_pos..][0..8], .big);
-            const has_ff = (word & 0x7F7F7F7F7F7F7F7F) + 0x0101010101010101 & word & 0x8080808080808080;
-            if (has_ff == 0) {
+            if (!hasByteFF(word)) {
                 const free = 64 - self.bit_count;
                 self.bit_buffer |= word >> @intCast(self.bit_count);
                 self.byte_pos += free / 8;
@@ -2059,7 +2042,7 @@ pub const BitReader = struct {
         while (self.byte_pos + 1 < self.data.len) : (self.byte_pos += 1) {
             if (self.data[self.byte_pos] != 0xFF) continue;
             const m = self.data[self.byte_pos + 1];
-            if (m >= 0xD0 and m <= 0xD7) {
+            if (isRstn(m)) {
                 self.byte_pos += 2;
                 return true;
             }
@@ -2290,7 +2273,7 @@ fn findScanEnd(data: []const u8, start_pos: usize) usize {
         const ff = std.mem.indexOfScalarPos(u8, data, pos, 0xFF) orelse break;
         if (ff >= data.len - 1) return ff;
         const next = data[ff + 1];
-        if (next == 0x00 or (next >= 0xD0 and next <= 0xD7)) {
+        if (next == 0x00 or isRstn(next)) {
             pos = ff + 2;
             continue;
         }
@@ -2510,10 +2493,10 @@ const Dct = struct {
     }
     /// `x[2i] * c[2i] + x[2i+1] * c[2i+1]` as i32 (pmaddwd).
     inline fn madd(x: V16, c: V16) V8 {
-        const xe: V8 = @intCast(@shuffle(i16, x, undefined, even));
-        const xo: V8 = @intCast(@shuffle(i16, x, undefined, odd));
-        const ce: V8 = @intCast(@shuffle(i16, c, undefined, even));
-        const co: V8 = @intCast(@shuffle(i16, c, undefined, odd));
+        const xe: V8 = @shuffle(i16, x, undefined, even);
+        const xo: V8 = @shuffle(i16, x, undefined, odd);
+        const ce: V8 = @shuffle(i16, c, undefined, even);
+        const co: V8 = @shuffle(i16, c, undefined, odd);
         return xe * ce + xo * co;
     }
     /// Saturating pack of two halves (elements 0-3, 8-11 in `l`, the rest in `h`) into
@@ -2537,36 +2520,29 @@ const Dct = struct {
 const Idct = struct {
     const V16 = Dct.V16;
     const V8 = Dct.V8;
-    const pair = Dct.pair;
-    const unpacklo = Dct.unpacklo;
-    const unpackhi = Dct.unpackhi;
-    const madd = Dct.madd;
-    const packs = Dct.packs;
-    const transpose = Dct.transpose;
-    const concat = Dct.concat;
 
     fn f2f(comptime x: f32) i16 {
-        return @intFromFloat(@round(x * 4096));
+        return @round(x * 4096);
     }
-    const rot0_0 = pair(f2f(0.5411961), f2f(0.5411961) + f2f(-1.847759065));
-    const rot0_1 = pair(f2f(0.5411961) + f2f(0.765366865), f2f(0.5411961));
-    const rot1_0 = pair(f2f(1.175875602) + f2f(-0.899976223), f2f(1.175875602));
-    const rot1_1 = pair(f2f(1.175875602), f2f(1.175875602) + f2f(-2.562915447));
-    const rot2_0 = pair(f2f(-1.961570560) + f2f(0.298631336), f2f(-1.961570560));
-    const rot2_1 = pair(f2f(-1.961570560), f2f(-1.961570560) + f2f(3.072711026));
-    const rot3_0 = pair(f2f(-0.390180644) + f2f(2.053119869), f2f(-0.390180644));
-    const rot3_1 = pair(f2f(-0.390180644), f2f(-0.390180644) + f2f(1.501321110));
+    const rot0_0 = Dct.pair(f2f(0.5411961), f2f(0.5411961) + f2f(-1.847759065));
+    const rot0_1 = Dct.pair(f2f(0.5411961) + f2f(0.765366865), f2f(0.5411961));
+    const rot1_0 = Dct.pair(f2f(1.175875602) + f2f(-0.899976223), f2f(1.175875602));
+    const rot1_1 = Dct.pair(f2f(1.175875602), f2f(1.175875602) + f2f(-2.562915447));
+    const rot2_0 = Dct.pair(f2f(-1.961570560) + f2f(0.298631336), f2f(-1.961570560));
+    const rot2_1 = Dct.pair(f2f(-1.961570560), f2f(-1.961570560) + f2f(3.072711026));
+    const rot3_0 = Dct.pair(f2f(-0.390180644) + f2f(2.053119869), f2f(-0.390180644));
+    const rot3_1 = Dct.pair(f2f(-0.390180644), f2f(-0.390180644) + f2f(1.501321110));
 
     /// 32-bit intermediates: `l` holds elements 0-3 and 8-11, `h` the rest, the unpack order.
     const Wide = struct { l: V8, h: V8 };
     inline fn rot(x: V16, y: V16, c0: V16, c1: V16) struct { Wide, Wide } {
-        const lo = unpacklo(x, y);
-        const hi = unpackhi(x, y);
-        return .{ .{ .l = madd(lo, c0), .h = madd(hi, c0) }, .{ .l = madd(lo, c1), .h = madd(hi, c1) } };
+        const lo = Dct.unpacklo(x, y);
+        const hi = Dct.unpackhi(x, y);
+        return .{ .{ .l = Dct.madd(lo, c0), .h = Dct.madd(hi, c0) }, .{ .l = Dct.madd(lo, c1), .h = Dct.madd(hi, c1) } };
     }
     inline fn widen(x: V16) Wide {
-        const l: V8 = @intCast(@shuffle(i16, x, undefined, Dct.low_half));
-        const h: V8 = @intCast(@shuffle(i16, x, undefined, Dct.high_half));
+        const l: V8 = @shuffle(i16, x, undefined, Dct.low_half);
+        const h: V8 = @shuffle(i16, x, undefined, Dct.high_half);
         return .{ .l = l << @splat(12), .h = h << @splat(12) };
     }
     inline fn wadd(a: Wide, b: Wide) Wide {
@@ -2579,7 +2555,7 @@ const Idct = struct {
         const ab: Wide = .{ .l = a.l + @as(V8, @splat(bias)), .h = a.h + @as(V8, @splat(bias)) };
         const sum = wadd(ab, b);
         const dif = wsub(ab, b);
-        return .{ packs(sum.l >> @splat(shift), sum.h >> @splat(shift)), packs(dif.l >> @splat(shift), dif.h >> @splat(shift)) };
+        return .{ Dct.packs(sum.l >> @splat(shift), sum.h >> @splat(shift)), Dct.packs(dif.l >> @splat(shift), dif.h >> @splat(shift)) };
     }
 
     /// One 1-D pass over the eight vectors, with libjpeg's even/odd butterflies.
@@ -2612,8 +2588,8 @@ const Idct = struct {
         var r: [8]V16 = undefined;
         for (0..8) |i| {
             const q: @Vector(8, i16) = dequant[i * 8 ..][0..8].*;
-            const scale = @shuffle(i16, q, q, concat);
-            r[i] = @shuffle(i16, @as(@Vector(8, i16), a[i * 8 ..][0..8].*), @as(@Vector(8, i16), b[i * 8 ..][0..8].*), concat) *% scale;
+            const scale = @shuffle(i16, q, q, Dct.concat);
+            r[i] = @shuffle(i16, @as(@Vector(8, i16), a[i * 8 ..][0..8].*), @as(@Vector(8, i16), b[i * 8 ..][0..8].*), Dct.concat) *% scale;
         }
         var ac = r[0] & @as(V16, [_]i16{ 0, -1, -1, -1, -1, -1, -1, -1, 0, -1, -1, -1, -1, -1, -1, -1 });
         inline for (1..8) |i| ac |= r[i];
@@ -2627,9 +2603,9 @@ const Idct = struct {
             return;
         }
         pass(&r, 512, 10);
-        transpose(&r);
+        Dct.transpose(&r);
         pass(&r, 65536 + (128 << 17), 17);
-        transpose(&r);
+        Dct.transpose(&r);
         for (0..8) |i| {
             const bytes: [16]u8 = meta.narrowToBytes(std.math.clamp(r[i], @as(V16, @splat(0)), @as(V16, @splat(255))));
             if (single) dst[i * stride ..][0..8].* = bytes[0..8].* else dst[i * stride ..][0..16].* = bytes;
@@ -2771,7 +2747,7 @@ fn restartSegments(allocator: Allocator, data: []const u8) ![]usize {
         const ff = std.mem.indexOfScalarPos(u8, data, pos, 0xFF) orelse break;
         if (ff + 1 >= data.len) break;
         const m = data[ff + 1];
-        if (m >= 0xD0 and m <= 0xD7) try starts.append(allocator, ff + 2);
+        if (isRstn(m)) try starts.append(allocator, ff + 2);
         pos = ff + 1;
     }
     return starts.toOwnedSlice(allocator);
@@ -2789,31 +2765,25 @@ fn performBlockScanBanded(comptime T: type, io: Io, state: *JpegState, img: *Ima
     const bw: usize = state.block_width_actual;
 
     const Band = struct {
-        row0: usize,
-        row1: usize,
         render: RenderBand,
         blocks: [][4][64]i16,
-        err: ?anyerror = null,
     };
     const Ctx = struct {
         state: *const JpegState,
         layout: ScanLayout,
         img: *Image(T),
         starts: []const usize,
+        segments: usize,
         bands: []Band,
 
-        fn run(ctx: *const @This(), k: usize, _: usize, _: usize) void {
+        /// Each band owns whole MCU rows from the first row at or after its first segment.
+        fn run(ctx: *const @This(), k: usize, seg0: usize, seg1: usize) !void {
             const band = &ctx.bands[k];
-            band.err = null;
-            ctx.decodeBand(band) catch |err| {
-                band.err = err;
-            };
-        }
-
-        fn decodeBand(ctx: *const @This(), band: *Band) !void {
             const st = ctx.state;
             const lay = ctx.layout;
-            const first_mcu = band.row0 * lay.mcus_per_row;
+            const row0 = @min(lay.mcu_rows, (seg0 * st.restart_interval + lay.mcus_per_row - 1) / lay.mcus_per_row);
+            const row1 = if (seg1 == ctx.segments) lay.mcu_rows else @min(lay.mcu_rows, (seg1 * st.restart_interval + lay.mcus_per_row - 1) / lay.mcus_per_row);
+            const first_mcu = row0 * lay.mcus_per_row;
             const seg = first_mcu / st.restart_interval;
             // Past the last marker everything is zero, as in the single sweep.
             const has_data = seg < ctx.starts.len;
@@ -2824,7 +2794,7 @@ fn performBlockScanBanded(comptime T: type, io: Io, state: *JpegState, img: *Ima
                 _ = try cursor.next(st, lay, null, x);
                 x = if ((mcu + 1) % lay.mcus_per_row == 0) 0 else x + lay.x_step;
             }
-            for (band.row0..band.row1) |row| {
+            for (row0..row1) |row| {
                 try decodeRenderMcuRow(T, st, lay, &cursor, &band.render, band.blocks, row, ctx.img);
             }
         }
@@ -2837,26 +2807,16 @@ fn performBlockScanBanded(comptime T: type, io: Io, state: *JpegState, img: *Ima
         band.render.deinit();
         allocator.free(band.blocks);
     };
-    // Balance by restart segments; each band owns whole MCU rows from the first row at or after its first segment.
-    const segments = (layout.mcu_rows * layout.mcus_per_row + interval - 1) / interval;
-    for (band_list, 0..) |*band, k| {
-        const seg0 = k * segments / bands;
-        const seg1 = (k + 1) * segments / bands;
-        const row0 = @min(layout.mcu_rows, (seg0 * interval + layout.mcus_per_row - 1) / layout.mcus_per_row);
-        const row1 = if (k + 1 == bands) layout.mcu_rows else @min(layout.mcu_rows, (seg1 * interval + layout.mcus_per_row - 1) / layout.mcus_per_row);
-        band.* = .{
-            .row0 = row0,
-            .row1 = row1,
-            .render = try .init(allocator, state),
-            .blocks = undefined,
-        };
-        made = k + 1;
-        band.blocks = try allocator.alloc([4][64]i16, bw * layout.y_step);
+    for (band_list) |*band| {
+        const blocks = try allocator.alloc([4][64]i16, bw * layout.y_step);
+        errdefer allocator.free(blocks);
+        band.* = .{ .render = try .init(allocator, state), .blocks = blocks };
+        made += 1;
     }
 
-    const ctx: Ctx = .{ .state = state, .layout = layout, .img = img, .starts = starts, .bands = band_list };
-    parallel.forRowBands(io, bands, bands, &ctx, Ctx.run);
-    for (band_list) |band| if (band.err) |err| return err;
+    const segments = (layout.mcu_rows * layout.mcus_per_row + interval - 1) / interval;
+    const ctx: Ctx = .{ .state = state, .layout = layout, .img = img, .starts = starts, .segments = segments, .bands = band_list };
+    try parallel.forRowBandsTry(io, segments, bands, &ctx, Ctx.run);
 }
 
 /// Sample planes for one MCU row plus the chroma upsampling scratch, reused for every band.
@@ -3019,9 +2979,9 @@ const RenderBand = struct {
                 const v = c2 - bias;
                 const lo: V = @splat(0);
                 const hi: V = @splat(255);
-                r = meta.narrowToBytes(std.math.clamp(yv + ((@as(V, @splat(91881)) * v + rounding) >> @splat(16)), lo, hi));
-                g = meta.narrowToBytes(std.math.clamp(yv - ((@as(V, @splat(22554)) * u + @as(V, @splat(46802)) * v + rounding) >> @splat(16)), lo, hi));
-                b = meta.narrowToBytes(std.math.clamp(yv + ((@as(V, @splat(116130)) * u + rounding) >> @splat(16)), lo, hi));
+                r = meta.narrowToBytes(std.math.clamp(yv + ((@as(V, @splat(bt601.r_cr)) * v + rounding) >> @splat(16)), lo, hi));
+                g = meta.narrowToBytes(std.math.clamp(yv - ((@as(V, @splat(bt601.g_cb)) * u + @as(V, @splat(bt601.g_cr)) * v + rounding) >> @splat(16)), lo, hi));
+                b = meta.narrowToBytes(std.math.clamp(yv + ((@as(V, @splat(bt601.b_cb)) * u + rounding) >> @splat(16)), lo, hi));
             }
             const n = @min(lanes, width - px);
             const out = dst[px..][0..n];
@@ -3114,21 +3074,16 @@ fn renderBlockRows(comptime T: type, state: *const JpegState, band: *RenderBand,
 
 /// Baseline frames stream their scan; progressive frames render the full store band by band.
 fn decodeInto(comptime T: type, io: Io, state: *JpegState, img: *Image(T)) !void {
-    if (state.header.frame_type == .baseline) {
-        if (state.restart_interval != 0) {
-            const layout: ScanLayout = .init(state);
-            const starts = try restartSegments(state.allocator, state.bit_reader.data);
-            defer state.allocator.free(starts);
-            // One band per CPU, never more than there are segments or MCU rows.
-            const bands = @min(parallel.bandCount(layout.mcu_rows, @as(usize, state.header.width) * 8 * layout.y_step), starts.len);
-            if (bands > 1) return performBlockScanBanded(T, io, state, img, starts, bands);
-        }
-        var band: RenderBand = try .init(state.allocator, state);
-        defer band.deinit();
-        return performBlockScan(T, state, &band, img);
+    if (state.header.frame_type == .baseline and state.restart_interval != 0) {
+        const layout: ScanLayout = .init(state);
+        const starts = try restartSegments(state.allocator, state.bit_reader.data);
+        defer state.allocator.free(starts);
+        const bands = parallel.bandCount(starts.len, state.restart_interval * 64 * layout.x_step * layout.y_step);
+        if (bands > 1) return performBlockScanBanded(T, io, state, img, starts, bands);
     }
     var band: RenderBand = try .init(state.allocator, state);
     defer band.deinit();
+    if (state.header.frame_type == .baseline) return performBlockScan(T, state, &band, img);
     const full = state.block_storage orelse return error.BlockStorageNotAllocated;
     _, const max_v = state.maxSamplingFactors();
     const bw: usize = state.block_width_actual;

--- a/src/codecs/png.zig
+++ b/src/codecs/png.zig
@@ -1280,7 +1280,8 @@ fn adaptiveSampleRate(header: Header) u32 {
 
 /// Filters rows `[r0, r1)` of `data` into `filtered` (filter byte plus row each). Adaptive
 /// mode analyzes rows at the sample rate and the first and last three, reusing the last
-/// analyzed filter in between; `r0` must be on the sample rate.
+/// analyzed filter in between; `r0` must be on the sample rate. `filtered` holds rows
+/// `[r0, r1)` from its start.
 fn filterRows(filtered: []u8, data: []const u8, header: Header, mode: FilterMode, temp: []u8, r0: u32, r1: u32) void {
     const scanline_bytes = header.scanlineBytes();
     const bytes_per_pixel = header.bytesPerPixel();
@@ -1288,7 +1289,7 @@ fn filterRows(filtered: []u8, data: []const u8, header: Header, mode: FilterMode
     var last = FilterType.none;
     for (r0..r1) |y| {
         const src_row = data[y * scanline_bytes ..][0..scanline_bytes];
-        const dst_row = filtered[y * (scanline_bytes + 1) + 1 ..][0..scanline_bytes];
+        const dst_row = filtered[(y - r0) * (scanline_bytes + 1) + 1 ..][0..scanline_bytes];
         const previous_row: ?[]const u8 = if (y > 0) data[(y - 1) * scanline_bytes ..][0..scanline_bytes] else null;
         const filter: FilterType = switch (mode) {
             .none => .none,
@@ -1300,7 +1301,7 @@ fn filterRows(filtered: []u8, data: []const u8, header: Header, mode: FilterMode
                 break :blk last;
             },
         };
-        filtered[y * (scanline_bytes + 1)] = @backingInt(filter);
+        filtered[(y - r0) * (scanline_bytes + 1)] = @backingInt(filter);
         filterRow(filter, dst_row, src_row, previous_row, bytes_per_pixel);
     }
 }
@@ -1377,49 +1378,39 @@ fn adlerCombine(a: u32, b: u32, b_len: usize) u32 {
 /// the stream, and the zlib header and adler32 over all rows are written here. The
 /// compression itself is `std.compress.flate`; only the chunking is ours.
 fn deflateRows(io: Io, gpa: Allocator, image_data: []const u8, header: Header, options: EncodeOptions) ![]u8 {
-    const row_bytes = header.scanlineBytes() + 1;
     const rows_per_chunk: usize = chunkRows(header);
     const chunks = @max(1, (@as(usize, header.height) + rows_per_chunk - 1) / rows_per_chunk);
-    const bands = @min(parallel.bandCount(header.height, header.scanlineBytes()), chunks);
-
-    const filtered = try gpa.alloc(u8, @as(usize, header.height) * row_bytes);
-    defer gpa.free(filtered);
+    const bands = parallel.bandCount(chunks, rows_per_chunk * header.scanlineBytes());
 
     const Band = struct {
         out: Io.Writer.Allocating,
         adler: u32 = 1,
         len: usize = 0,
-        err: ?anyerror = null,
     };
     const Ctx = struct {
         gpa: Allocator,
         image_data: []const u8,
-        filtered: []u8,
         header: Header,
         options: EncodeOptions,
         rows_per_chunk: usize,
         chunks: usize,
         bands: []Band,
 
-        fn run(ctx: *const @This(), k: usize, c0: usize, c1: usize) void {
-            ctx.bands[k].err = null;
-            ctx.encodeChunks(&ctx.bands[k], c0, c1) catch |err| {
-                ctx.bands[k].err = err;
-            };
-        }
-
-        fn encodeChunks(ctx: *const @This(), band: *Band, c0: usize, c1: usize) !void {
+        fn run(ctx: *const @This(), k: usize, c0: usize, c1: usize) !void {
+            const band = &ctx.bands[k];
             const hdr = ctx.header;
             const rb = hdr.scanlineBytes() + 1;
             const window = try ctx.gpa.alloc(u8, flate.max_window_len);
             defer ctx.gpa.free(window);
             const temp = try ctx.gpa.alloc(u8, hdr.scanlineBytes());
             defer ctx.gpa.free(temp);
+            const filtered = try ctx.gpa.alloc(u8, ctx.rows_per_chunk * rb);
+            defer ctx.gpa.free(filtered);
             for (c0..c1) |chunk| {
                 const r0: u32 = @intCast(chunk * ctx.rows_per_chunk);
                 const r1: u32 = @intCast(@min(hdr.height, (chunk + 1) * ctx.rows_per_chunk));
-                filterRows(ctx.filtered, ctx.image_data, hdr, ctx.options.filter, temp, r0, r1);
-                const rows = ctx.filtered[r0 * rb .. r1 * rb];
+                filterRows(filtered, ctx.image_data, hdr, ctx.options.filter, temp, r0, r1);
+                const rows = filtered[0 .. (r1 - r0) * rb];
                 // The compressor needs a sized output buffer; half the input is the usual ratio.
                 try band.out.ensureUnusedCapacity(rows.len / 2 + 64);
                 var compressor: flate.Compress = try .init(&band.out.writer, window, .raw, ctx.options.compress_options);
@@ -1438,19 +1429,17 @@ fn deflateRows(io: Io, gpa: Allocator, image_data: []const u8, header: Header, o
     const ctx: Ctx = .{
         .gpa = gpa,
         .image_data = image_data,
-        .filtered = filtered,
         .header = header,
         .options = options,
         .rows_per_chunk = rows_per_chunk,
         .chunks = chunks,
         .bands = band_list,
     };
-    parallel.forRowBands(io, chunks, bands, &ctx, Ctx.run);
+    try parallel.forRowBandsTry(io, chunks, bands, &ctx, Ctx.run);
 
     var total: usize = flate.Container.zlib.size();
     var adler: u32 = 1;
     for (band_list) |*band| {
-        if (band.err) |err| return err;
         total += band.out.written().len;
         adler = adlerCombine(adler, band.adler, band.len);
     }

--- a/src/color.zig
+++ b/src/color.zig
@@ -982,29 +982,37 @@ pub fn Ycbcr(comptime T: type) type {
 }
 
 /// Converts RGB to Ycbcr using ITU-R BT.601 coefficients.
+/// BT.601 RGB<->YCbCr coefficients with 16 fractional bits; the JPEG vector paths use the same
+/// constants so they match `convertColor` exactly.
+pub const bt601 = struct {
+    pub const y_r = 19595;
+    pub const y_g = 38470;
+    pub const y_b = 7471;
+    pub const cb_r = -11059;
+    pub const cb_g = -21710;
+    pub const cb_b = 32768;
+    pub const cr_r = 32768;
+    pub const cr_g = -27439;
+    pub const cr_b = -5329;
+    pub const r_cr = 91881;
+    pub const g_cb = 22554;
+    pub const g_cr = 46802;
+    pub const b_cb = 116130;
+};
+
 /// All components in [0, 255] range for u8, with Cb/Cr having 128 as neutral.
 /// Uses 16-bit fixed-point arithmetic for precision when T is u8.
 fn rgbToYcbcr(comptime T: type, rgb: Rgb(T)) Ycbcr(T) {
     if (T == u8) {
         // Integer (fixed-point) BT.601: 16-bit fractional precision, rounding at +32768.
-        const r: i32 = rgb.r;
-        const g: i32 = rgb.g;
-        const b: i32 = rgb.b;
-
-        const y_r: i64 = 19595;
-        const y_g: i64 = 38470;
-        const y_b: i64 = 7471;
-        const cb_r: i64 = -11059;
-        const cb_g: i64 = -21710;
-        const cb_b: i64 = 32768;
-        const cr_r: i64 = 32768;
-        const cr_g: i64 = -27439;
-        const cr_b: i64 = -5329;
-
+        const r: i64 = rgb.r;
+        const g: i64 = rgb.g;
+        const b: i64 = rgb.b;
+        const k = bt601;
         return .{
-            .y = @intCast(clamp((y_r * r + y_g * g + y_b * b + 32768) >> 16, 0, 255)),
-            .cb = @intCast(clamp(((cb_r * r + cb_g * g + cb_b * b + 32768) >> 16) + 128, 0, 255)),
-            .cr = @intCast(clamp(((cr_r * r + cr_g * g + cr_b * b + 32768) >> 16) + 128, 0, 255)),
+            .y = @intCast(clamp((k.y_r * r + k.y_g * g + k.y_b * b + 32768) >> 16, 0, 255)),
+            .cb = @intCast(clamp(((k.cb_r * r + k.cb_g * g + k.cb_b * b + 32768) >> 16) + 128, 0, 255)),
+            .cr = @intCast(clamp(((k.cr_r * r + k.cr_g * g + k.cr_b * b + 32768) >> 16) + 128, 0, 255)),
         };
     } else {
         const y = clamp(0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b, 0, 1);
@@ -1060,9 +1068,10 @@ fn ycbcrToRgb(comptime T: type, ycbcr: Ycbcr(T)) Rgb(T) {
         const cb: i64 = @as(i64, ycbcr.cb) - 128;
         const cr: i64 = @as(i64, ycbcr.cr) - 128;
 
-        const r: u8 = @intCast(clamp((65536 * y + 91881 * cr + 32768) >> 16, 0, 255));
-        const g: u8 = @intCast(clamp((65536 * y - 22554 * cb - 46802 * cr + 32768) >> 16, 0, 255));
-        const b: u8 = @intCast(clamp((65536 * y + 116130 * cb + 32768) >> 16, 0, 255));
+        const k = bt601;
+        const r: u8 = @intCast(clamp((65536 * y + k.r_cr * cr + 32768) >> 16, 0, 255));
+        const g: u8 = @intCast(clamp((65536 * y - k.g_cb * cb - k.g_cr * cr + 32768) >> 16, 0, 255));
+        const b: u8 = @intCast(clamp((65536 * y + k.b_cb * cb + 32768) >> 16, 0, 255));
 
         return .{ .r = r, .g = g, .b = b };
     } else {

--- a/src/image.zig
+++ b/src/image.zig
@@ -1102,7 +1102,7 @@ pub fn Image(comptime T: type) type {
                 return error.DimensionMismatch;
             }
             switch (motion) {
-                .linear => |params| try MotionBlurOps(T).linear(io, self, out, allocator, params.angle, params.distance),
+                .linear => |params| try MotionBlurOps(T).linear(self, io, out, allocator, params.angle, params.distance),
                 .radial_zoom => |params| try MotionBlurOps(T).radial(self, out, allocator, params.center_x, params.center_y, params.strength, .zoom),
                 .radial_spin => |params| try MotionBlurOps(T).radial(self, out, allocator, params.center_x, params.center_y, params.strength, .spin),
             }

--- a/src/image/box_blur.zig
+++ b/src/image/box_blur.zig
@@ -95,9 +95,7 @@ inline fn finishU8(comptime len: usize, comptime mode: Mode, src_row: []const u8
             break :blk orig_f + orig_f - blurred;
         },
     };
-    const zero: @Vector(len, f32) = @splat(0);
-    const max: @Vector(len, f32) = @splat(255);
-    return @round(@max(zero, @min(max, value)));
+    return meta.roundToBytes(value);
 }
 
 /// Accumulator type: exact u32 sums for u8 planes, f64 for f32.
@@ -121,7 +119,7 @@ fn plane(comptime P: type, comptime mode: Mode, io: Io, src: Image(P), dst: Imag
     // Integer sums are exact, so bands seeded mid-image match one sweep; f32 planes (f64 sums) stay one band.
     // Each band re-seeds `2·radius + 1` rows, hence four windows tall.
     const bands = if (@typeInfo(SumT(P)) == .int) parallel.bandCountFor(rows, cols, 4 * (2 * radius + 1)) else 1;
-    const ctx: BandContext(P, SumT(P), InvT(P), planeRows(P, mode)) = .{
+    const ctx: BandContext(P, mode, false) = .{
         .src = src,
         .dst = dst,
         .radius = radius,
@@ -135,32 +133,29 @@ fn plane(comptime P: type, comptime mode: Mode, io: Io, src: Image(P), dst: Imag
 }
 
 /// Read-only state shared by the row bands; `width` is the element count of one row of
-/// column sums (`cols`, or `cols * channels` for the interleaved path).
-fn BandContext(comptime P: type, comptime Sum: type, comptime Inv: type, comptime rowsFn: anytype) type {
+/// column sums (`cols`, or `cols * channels` when `interleaved`).
+fn BandContext(comptime P: type, comptime mode: Mode, comptime interleaved: bool) type {
     return struct {
         src: Image(P),
         dst: Image(P),
         radius: usize,
         width: usize,
-        col_sums: []Sum,
-        inv_widths: []const Inv,
+        col_sums: []if (interleaved) u32 else SumT(P),
+        inv_widths: []const if (interleaved) f32 else InvT(P),
 
         fn rowBand(ctx: *const @This(), band: usize, r0: usize, r1: usize) void {
-            rowsFn(ctx.src, ctx.dst, ctx.col_sums[band * ctx.width ..][0..ctx.width], ctx.inv_widths, ctx.radius, r0, r1);
+            const sums = ctx.col_sums[band * ctx.width ..][0..ctx.width];
+            if (interleaved) {
+                interleavedRows(P, mode, ctx.src, ctx.dst, sums, ctx.inv_widths, ctx.radius, r0, r1);
+            } else {
+                planeRows(P, mode, ctx.src, ctx.dst, sums, ctx.inv_widths, ctx.radius, r0, r1);
+            }
         }
     };
 }
 
 /// Rows `[r_start, r_end)` of one plane; `col_sums` is seeded for `r_start` here.
-fn planeRows(comptime P: type, comptime mode: Mode) fn (Image(P), Image(P), []SumT(P), []const InvT(P), usize, usize, usize) void {
-    return struct {
-        fn run(src: Image(P), dst: Image(P), col_sums: []SumT(P), inv_widths: []const InvT(P), radius: usize, r_start: usize, r_end: usize) void {
-            planeRowsImpl(P, mode, src, dst, col_sums, inv_widths, radius, r_start, r_end);
-        }
-    }.run;
-}
-
-fn planeRowsImpl(comptime P: type, comptime mode: Mode, src: Image(P), dst: Image(P), col_sums: []SumT(P), inv_widths: []const InvT(P), radius: usize, r_start: usize, r_end: usize) void {
+fn planeRows(comptime P: type, comptime mode: Mode, src: Image(P), dst: Image(P), col_sums: []SumT(P), inv_widths: []const InvT(P), radius: usize, r_start: usize, r_end: usize) void {
     const rows: usize = src.rows;
     const cols: usize = src.cols;
 
@@ -256,7 +251,7 @@ inline fn emitAndSlide(
 fn interleavedU8(comptime T: type, comptime mode: Mode, io: Io, image: Image(T), out: Image(T), allocator: Allocator, radius: usize) !void {
     const width_e = @as(usize, image.cols) * comptime Image(T).channels();
     const bands = parallel.bandCountFor(image.rows, image.cols, 4 * (2 * radius + 1));
-    const ctx: BandContext(T, u32, f32, interleavedRows(T, mode)) = .{
+    const ctx: BandContext(T, mode, true) = .{
         .src = image,
         .dst = out,
         .radius = radius,
@@ -270,15 +265,7 @@ fn interleavedU8(comptime T: type, comptime mode: Mode, io: Io, image: Image(T),
 }
 
 /// Rows `[r_start, r_end)` of the interleaved path; `col_sums` is seeded for `r_start` here.
-fn interleavedRows(comptime T: type, comptime mode: Mode) fn (Image(T), Image(T), []u32, []const f32, usize, usize, usize) void {
-    return struct {
-        fn run(image: Image(T), out: Image(T), col_sums: []u32, inv_widths: []const f32, radius: usize, r_start: usize, r_end: usize) void {
-            interleavedRowsImpl(T, mode, image, out, col_sums, inv_widths, radius, r_start, r_end);
-        }
-    }.run;
-}
-
-fn interleavedRowsImpl(comptime T: type, comptime mode: Mode, image: Image(T), out: Image(T), col_sums: []u32, inv_widths: []const f32, radius: usize, r_start: usize, r_end: usize) void {
+fn interleavedRows(comptime T: type, comptime mode: Mode, image: Image(T), out: Image(T), col_sums: []u32, inv_widths: []const f32, radius: usize, r_start: usize, r_end: usize) void {
     const n = comptime Image(T).channels();
     const rows: usize = image.rows;
     const cols: usize = image.cols;
@@ -294,16 +281,8 @@ fn interleavedRowsImpl(comptime T: type, comptime mode: Mode, image: Image(T), o
     // width so both paths run one-multiply rounding over the exact same pixel range.
     const px_block = std.simd.suggestVectorLength(i32) orelse 1;
     const B = px_block * n;
-    const repeat_mask = comptime blk: {
-        var m: [B]i32 = undefined;
-        for (&m, 0..) |*e, j| e.* = @intCast(j % n);
-        break :blk m;
-    };
-    const tail_mask = comptime blk: {
-        var m: [n]i32 = undefined;
-        for (&m, 0..) |*e, t| e.* = @intCast(B - n + t);
-        break :blk m;
-    };
+    const repeat_mask = meta.StrideMasks(B, n).repeat;
+    const tail_mask = meta.StrideMasks(B, n).tail;
 
     for (r_start..r_end) |r| {
         if (r > r_start) {

--- a/src/image/channel_ops.zig
+++ b/src/image/channel_ops.zig
@@ -10,6 +10,7 @@ const Image = @import("../image.zig").Image;
 const meta = @import("../meta.zig");
 const parallel = @import("../parallel.zig");
 const resolveIndex = @import("border.zig").resolveIndex;
+const quantizeKernel = @import("convolution.zig").quantizeKernel;
 
 /// Find the uniform value of a channel if all values are the same.
 /// Returns the uniform value if all elements are identical, null otherwise.
@@ -245,65 +246,56 @@ const Interpolation = interpolation.Interpolation;
 /// Fixed-point weight precision; two passes leave 2·weight_shift bits of headroom in an i32
 /// (255 · 1.4 · 1024 per pass with the negative lobes).
 pub const weight_shift = 10;
-pub const weight_scale: i32 = 1 << weight_shift;
+pub const weight_scale = 1 << weight_shift;
 pub const max_taps = 6;
 
 /// Mirror-resolved source indices and weights for every output position along one axis,
 /// as fixed point for u8 planes (each position sums to exactly `weight_scale`) and as unit
 /// gain floats for f32 planes, so the passes need no per-pixel normalization; the kernel is
 /// evaluated `taps` times per output position instead of `taps²` per pixel.
-pub const AxisTaps = struct {
-    taps: usize,
-    indices: []u32,
-    weights: []i32,
-    floats: []f32,
+pub fn AxisTaps(comptime P: type) type {
+    return struct {
+        const Self = @This();
 
-    pub fn init(allocator: std.mem.Allocator, src_len: u32, dst_len: u32, method: Interpolation) !AxisTaps {
-        const taps = interpolation.kernelTaps(method);
-        const indices = try allocator.alloc(u32, @as(usize, dst_len) * taps);
-        errdefer allocator.free(indices);
-        const weights = try allocator.alloc(i32, @as(usize, dst_len) * taps);
-        errdefer allocator.free(weights);
-        const floats = try allocator.alloc(f32, @as(usize, dst_len) * taps);
-        const ratio = @as(f32, @floatFromInt(src_len)) / @as(f32, @floatFromInt(dst_len));
+        taps: usize,
+        indices: []u32,
+        weights: []Accum(P),
 
-        for (0..dst_len) |i| {
-            const center = (@as(f32, @floatFromInt(i)) + 0.5) * ratio - 0.5;
-            const base: isize = @as(isize, @intFromFloat(@floor(center))) - @as(isize, @intCast(taps / 2 - 1));
-            var raw: [max_taps]f32 = undefined;
-            var sum: f32 = 0;
-            for (0..taps) |t| {
-                const x = base + @as(isize, @intCast(t));
-                raw[t] = interpolation.kernelWeight(method, center - @as(f32, @floatFromInt(x)));
-                sum += raw[t];
-                indices[i * taps + t] = @intCast(resolveIndex(x, @intCast(src_len), .mirror).?);
+        pub fn init(allocator: std.mem.Allocator, src_len: u32, dst_len: u32, method: Interpolation) !Self {
+            const taps = interpolation.kernelTaps(method);
+            const indices = try allocator.alloc(u32, @as(usize, dst_len) * taps);
+            errdefer allocator.free(indices);
+            const weights = try allocator.alloc(Accum(P), @as(usize, dst_len) * taps);
+            const ratio = @as(f32, @floatFromInt(src_len)) / @as(f32, @floatFromInt(dst_len));
+
+            for (0..dst_len) |i| {
+                const center = (@as(f32, @floatFromInt(i)) + 0.5) * ratio - 0.5;
+                const base: isize = @as(isize, @floor(center)) - @as(isize, @intCast(taps / 2 - 1));
+                var raw: [max_taps]f32 = undefined;
+                var sum: f32 = 0;
+                for (0..taps) |t| {
+                    const x = base + @as(isize, @intCast(t));
+                    raw[t] = interpolation.kernelWeight(method, center - @as(f32, @floatFromInt(x)));
+                    sum += raw[t];
+                    indices[i * taps + t] = @intCast(resolveIndex(x, @intCast(src_len), .mirror).?);
+                }
+                for (raw[0..taps]) |*r| r.* /= sum;
+                const w = weights[i * taps ..][0..taps];
+                if (P == u8) quantizeKernel(w, raw[0..taps], weight_scale) else @memcpy(w, raw[0..taps]);
             }
-            // Quantize to unit gain; the rounding residual lands on the largest tap.
-            const w = weights[i * taps ..][0..taps];
-            var quantized_sum: i32 = 0;
-            var largest: usize = 0;
-            for (w, 0..) |*q, t| {
-                q.* = @intFromFloat(@round(raw[t] / sum * @as(f32, @floatFromInt(weight_scale))));
-                quantized_sum += q.*;
-                if (@abs(q.*) > @abs(w[largest])) largest = t;
-            }
-            w[largest] += weight_scale - quantized_sum;
-            for (floats[i * taps ..][0..taps], raw[0..taps]) |*f, r| f.* = r / sum;
+            return .{ .taps = taps, .indices = indices, .weights = weights };
         }
-        return .{ .taps = taps, .indices = indices, .weights = weights, .floats = floats };
-    }
 
-    pub fn deinit(self: AxisTaps, allocator: std.mem.Allocator) void {
-        allocator.free(self.indices);
-        allocator.free(self.weights);
-        allocator.free(self.floats);
-    }
+        pub fn deinit(self: Self, allocator: std.mem.Allocator) void {
+            allocator.free(self.indices);
+            allocator.free(self.weights);
+        }
 
-    /// Weights in the accumulator type of plane type `P`.
-    fn weightsFor(self: AxisTaps, comptime P: type, pos: usize) []const Accum(P) {
-        return (if (P == u8) self.weights else self.floats)[pos * self.taps ..][0..self.taps];
-    }
-};
+        fn weightsAt(self: Self, pos: usize) []const Accum(P) {
+            return self.weights[pos * self.taps ..][0..self.taps];
+        }
+    };
+}
 
 /// Intermediate plane and accumulator type of the separable passes for plane type `P`.
 pub fn Accum(comptime P: type) type {
@@ -317,7 +309,7 @@ pub fn Accum(comptime P: type) type {
 /// Horizontal pass: source rows `[r_start, r_end)` of `src` (`src_cols` pixels wide)
 /// resampled through `x_taps` into `mid` (`dst_cols` pixels wide) as unnormalized sums.
 /// `channels` > 1 means interleaved pixels; the taps index pixels, every channel of each.
-pub fn resizeRows(comptime P: type, comptime channels: usize, src: []const P, src_cols: u32, x_taps: AxisTaps, mid: []Accum(P), dst_cols: u32, r_start: usize, r_end: usize) void {
+pub fn resizeRows(comptime P: type, comptime channels: usize, src: []const P, src_cols: u32, x_taps: AxisTaps(P), mid: []Accum(P), dst_cols: u32, r_start: usize, r_end: usize) void {
     const A = Accum(P);
     const taps = x_taps.taps;
     for (r_start..r_end) |r| {
@@ -325,7 +317,7 @@ pub fn resizeRows(comptime P: type, comptime channels: usize, src: []const P, sr
         const out = mid[r * dst_cols * channels ..][0 .. dst_cols * channels];
         for (0..dst_cols) |c| {
             var acc: [channels]A = @splat(0);
-            for (x_taps.indices[c * taps ..][0..taps], x_taps.weightsFor(P, c)) |idx, w| {
+            for (x_taps.indices[c * taps ..][0..taps], x_taps.weightsAt(c)) |idx, w| {
                 inline for (0..channels) |ch| acc[ch] += w * @as(A, row[idx * channels + ch]);
             }
             out[c * channels ..][0..channels].* = acc;
@@ -335,7 +327,7 @@ pub fn resizeRows(comptime P: type, comptime channels: usize, src: []const P, sr
 
 /// Vertical pass: output rows `[r_start, r_end)` of `dst` (`cols` elements wide) from `mid`
 /// through `y_taps`; u8 planes are rounded and clamped, f32 planes stored as is.
-pub fn resizeColumns(comptime P: type, mid: []const Accum(P), cols: usize, y_taps: AxisTaps, dst: []P, r_start: usize, r_end: usize) void {
+pub fn resizeColumns(comptime P: type, mid: []const Accum(P), cols: usize, y_taps: AxisTaps(P), dst: []P, r_start: usize, r_end: usize) void {
     const A = Accum(P);
     const vec_len = std.simd.suggestVectorLength(A) orelse 1;
     const V = @Vector(vec_len, A);
@@ -345,7 +337,7 @@ pub fn resizeColumns(comptime P: type, mid: []const Accum(P), cols: usize, y_tap
 
     for (r_start..r_end) |r| {
         const rows = y_taps.indices[r * taps ..][0..taps];
-        const weights = y_taps.weightsFor(P, r);
+        const weights = y_taps.weightsAt(r);
         const out = dst[r * cols ..][0..cols];
         var c: usize = 0;
         while (c + vec_len <= cols) : (c += vec_len) {
@@ -355,9 +347,7 @@ pub fn resizeColumns(comptime P: type, mid: []const Accum(P), cols: usize, y_tap
             }
             if (P == u8) {
                 const scaled = acc >> @splat(shift);
-                const clamped = @max(@as(V, @splat(0)), @min(@as(V, @splat(255)), scaled));
-                const bytes: @Vector(vec_len, u8) = meta.narrowToBytes(clamped);
-                out[c..][0..vec_len].* = bytes;
+                out[c..][0..vec_len].* = meta.narrowToBytes(std.math.clamp(scaled, @as(V, @splat(0)), @as(V, @splat(255))));
             } else {
                 out[c..][0..vec_len].* = acc;
             }
@@ -374,7 +364,7 @@ test "axis taps sum to unit gain and stay in bounds" {
     const allocator = std.testing.allocator;
     for ([_]Interpolation{ .bilinear, .bicubic, .catmull_rom, .{ .mitchell = .default }, .lanczos }) |method| {
         for ([_][2]u32{ .{ 640, 97 }, .{ 13, 401 }, .{ 5, 5 } }) |lens| {
-            const taps: AxisTaps = try .init(allocator, lens[0], lens[1], method);
+            const taps: AxisTaps(u8) = try .init(allocator, lens[0], lens[1], method);
             defer taps.deinit(allocator);
             for (0..lens[1]) |i| {
                 var sum: i32 = 0;

--- a/src/image/convolution.zig
+++ b/src/image/convolution.zig
@@ -48,18 +48,18 @@ inline fn divClampU8Vec(
 /// to 30*9 = 270/256, brightening by +5.5% and clipping highlights.
 /// For all-equal taps the strict `>` puts the residual on tap 0 — `isUniformBody`
 /// relies on that shape to detect uniform kernels after quantization.
-fn quantizeKernel(taps: []i32, weights: []const f32) void {
+pub fn quantizeKernel(taps: []i32, weights: []const f32, comptime scale: comptime_int) void {
     if (taps.len == 0) return;
     var weight_sum: f64 = 0;
     var sum: i64 = 0;
     var largest: usize = 0;
     for (taps, weights, 0..) |*t, w, i| {
-        t.* = @round(w * fixed_point_scale);
+        t.* = @round(w * scale);
         weight_sum += w;
         sum += t.*;
         if (@abs(t.*) > @abs(taps[largest])) largest = i;
     }
-    const target: i64 = @round(fixed_point_scale * weight_sum);
+    const target: i64 = @round(scale * weight_sum);
     taps[largest] += @intCast(target - sum);
 }
 
@@ -102,7 +102,7 @@ fn ConvolutionKernel(comptime T: type, comptime rows: usize, comptime cols: usiz
             }
             if (T == f32) return weights;
             var result: [size]i32 = undefined;
-            quantizeKernel(&result, &weights);
+            quantizeKernel(&result, &weights, fixed_point_scale);
             return result;
         }
 
@@ -423,7 +423,7 @@ pub fn convolvePlanes(
 
 fn scaleKernelToInt(allocator: Allocator, kernel: []const f32) ![]i32 {
     const result = try allocator.alloc(i32, kernel.len);
-    quantizeKernel(result, kernel);
+    quantizeKernel(result, kernel, fixed_point_scale);
     return result;
 }
 
@@ -525,6 +525,9 @@ fn convolveSeparableAutoImpl(
 /// `image`'s bytes as a `cols * channels` wide u8 image: every channel of a pixel is a
 /// column, so the separable passes run over interleaved struct pixels without a split.
 pub fn elementView(comptime T: type, image: Image(T)) Image(u8) {
+    comptime if (@typeInfo(T) != .@"struct" or !meta.allFieldsAreU8(T)) {
+        @compileError("elementView needs a struct of u8 fields, got " ++ @typeName(T));
+    };
     const n = comptime Image(T).channels();
     return .{
         .rows = image.rows,
@@ -800,6 +803,8 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
             kernel: []const KernelT,
             table: BorderIndexTable,
             bases: []usize = &.{},
+            /// Vertical interior rows through the O(1) column sums instead of the tap loop.
+            box: bool = false,
 
             fn horizontalBand(ctx: *const BandContext, _: usize, r0: usize, r1: usize) void {
                 const folded = isSymmetric(ctx.kernel);
@@ -811,27 +816,22 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
             }
 
             fn verticalBand(ctx: *const BandContext, band: usize, r0: usize, r1: usize) void {
-                const folded = isSymmetric(ctx.kernel);
-                const dense = isDense(ctx.kernel);
                 ctx.verticalBorderRows(band, r0, @min(r1, ctx.table.low_end));
                 const inner0 = @max(r0, ctx.table.low_end);
                 const inner1 = @min(r1, ctx.table.high_start);
                 if (inner0 < inner1) {
-                    if (dense) verticalTiles(true, ctx.src, ctx.dst, ctx.kernel, folded, inner0, inner1) else verticalTiles(false, ctx.src, ctx.dst, ctx.kernel, folded, inner0, inner1);
+                    if (ctx.box) {
+                        verticalBoxRows(ctx.src, ctx.dst, ctx.kernel, inner0, inner1);
+                    } else {
+                        const folded = isSymmetric(ctx.kernel);
+                        if (isDense(ctx.kernel)) verticalTiles(true, ctx.src, ctx.dst, ctx.kernel, folded, inner0, inner1) else verticalTiles(false, ctx.src, ctx.dst, ctx.kernel, folded, inner0, inner1);
+                    }
                 }
                 ctx.verticalBorderRows(band, @max(r0, ctx.table.high_start), r1);
             }
 
             fn horizontalBoxBand(ctx: *const BandContext, _: usize, r0: usize, r1: usize) void {
                 horizontalBoxRows(ctx.src, ctx.dst, ctx.kernel, ctx.table, r0, r1);
-            }
-
-            fn verticalBoxBand(ctx: *const BandContext, band: usize, r0: usize, r1: usize) void {
-                ctx.verticalBorderRows(band, r0, @min(r1, ctx.table.low_end));
-                const inner0 = @max(r0, ctx.table.low_end);
-                const inner1 = @min(r1, ctx.table.high_start);
-                if (inner0 < inner1) verticalBoxRows(ctx.src, ctx.dst, ctx.kernel, inner0, inner1);
-                ctx.verticalBorderRows(band, @max(r0, ctx.table.high_start), r1);
             }
 
             /// Top/bottom border rows `[r0, r1)` from the row-resolved table; shared by the
@@ -907,19 +907,19 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
         /// Column-tiled 1D pass along rows (src -> dst); tiling keeps the working set cache-resident
         /// and, unlike per-row bases, lets LLVM hoist the tap offsets (row-major measured 0.9x on f32).
         fn vertical(io: Io, src: Image(SrcT), dst: Image(DstT), allocator: Allocator, kernel: []const KernelT, border_mode: BorderMode) !void {
-            try verticalPass(io, src, dst, allocator, kernel, border_mode, BandContext.verticalBand);
+            try verticalPass(io, src, dst, allocator, kernel, border_mode, false);
         }
 
         /// Bands cover every row; each band emits its border rows from the row table and its
-        /// interior rows through `band_fn`'s fast path, so no rows wait on the caller thread.
-        fn verticalPass(io: Io, src: Image(SrcT), dst: Image(DstT), allocator: Allocator, kernel: []const KernelT, border_mode: BorderMode, comptime band_fn: anytype) !void {
+        /// interior rows through the tiled (or `box`) fast path, so no rows wait on the caller thread.
+        fn verticalPass(io: Io, src: Image(SrcT), dst: Image(DstT), allocator: Allocator, kernel: []const KernelT, border_mode: BorderMode, box: bool) !void {
             const table: BorderIndexTable = try .init(allocator, src.rows, kernel.len, border_mode);
             defer table.deinit(allocator);
             const bands = parallel.bandCount(src.rows, src.cols);
             const bases = try allocator.alloc(usize, bands * kernel.len);
             defer allocator.free(bases);
-            const ctx: BandContext = .{ .src = src, .dst = dst, .kernel = kernel, .table = table, .bases = bases };
-            parallel.forRowBands(io, src.rows, bands, &ctx, band_fn);
+            const ctx: BandContext = .{ .src = src, .dst = dst, .kernel = kernel, .table = table, .bases = bases, .box = box };
+            parallel.forRowBands(io, src.rows, bands, &ctx, BandContext.verticalBand);
         }
 
         /// Column-tiled interior rows `[r_start, r_end)`; tiling keeps the working set
@@ -1013,45 +1013,33 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
                     var sum: Lane = @splat(0);
                     for (0..len) |i| {
                         const px: @Vector(channels, SrcT) = src.data[src_offset + e - tap + i * channels ..][0..channels].*;
-                        sum += if (AccumT == f32) px else @intCast(px);
+                        sum += px;
                     }
 
                     if (AccumT == i32 and SrcT == u8) {
                         // The running sum as a stride-`channels` prefix sum of window deltas; exact integers, so identical to the scalar loop.
                         const k_vec: @Vector(B, AccumT) = @splat(k);
                         const r_vec: @Vector(B, AccumT) = @splat(residual);
-                        const repeat_mask = comptime blk: {
-                            var m: [B]i32 = undefined;
-                            for (&m, 0..) |*m_e, j| m_e.* = @intCast(j % channels);
-                            break :blk m;
-                        };
-                        const tail_mask = comptime blk: {
-                            var m: [channels]i32 = undefined;
-                            for (&m, 0..) |*m_e, t| m_e.* = @intCast(B - channels + t);
-                            break :blk m;
-                        };
+                        const masks = meta.StrideMasks(B, channels);
                         // The last slide delta reads one pixel past the block, hence `+ channels`.
                         while (e + B + channels <= e_end) : (e += B) {
-                            const firsts: @Vector(B, AccumT) = @intCast(@as(@Vector(B, SrcT), src.data[src_offset + e - tap ..][0..B].*));
-                            const highs: @Vector(B, AccumT) = @intCast(@as(@Vector(B, SrcT), src.data[src_offset + e - tap + window ..][0..B].*));
+                            const firsts: @Vector(B, AccumT) = @as(@Vector(B, SrcT), src.data[src_offset + e - tap ..][0..B].*);
+                            const highs: @Vector(B, AccumT) = @as(@Vector(B, SrcT), src.data[src_offset + e - tap + window ..][0..B].*);
                             const deltas = std.simd.prefixScan(.Add, channels, highs - firsts);
-                            const w_vec = @shuffle(AccumT, sum, undefined, repeat_mask) +
+                            const w_vec = @shuffle(AccumT, sum, undefined, masks.repeat) +
                                 std.simd.shiftElementsRight(deltas, channels, 0);
                             storeVec(k_vec * w_vec + r_vec * firsts, dst_row[e..].ptr);
-                            sum += @shuffle(AccumT, deltas, undefined, tail_mask);
+                            sum += @shuffle(AccumT, deltas, undefined, masks.tail);
                         }
                     }
 
                     while (e < e_end) : (e += channels) {
-                        const first: Lane = blk: {
-                            const px: @Vector(channels, SrcT) = src.data[src_offset + e - tap ..][0..channels].*;
-                            break :blk if (AccumT == f32) px else @intCast(px);
-                        };
+                        const first: Lane = @as(@Vector(channels, SrcT), src.data[src_offset + e - tap ..][0..channels].*);
                         const out: Lane = @as(Lane, @splat(k)) * sum + @as(Lane, @splat(residual)) * first;
                         inline for (0..channels) |ch| dst_row[e + ch] = store(out[ch]);
                         if (e + channels < e_end) {
                             const next: @Vector(channels, SrcT) = src.data[src_offset + e - tap + window ..][0..channels].*;
-                            sum += @as(Lane, if (AccumT == f32) next else @intCast(next)) - first;
+                            sum += @as(Lane, next) - first;
                         }
                     }
                 }
@@ -1063,7 +1051,7 @@ fn SeparablePass(comptime SrcT: type, comptime DstT: type, comptime AccumIntT: t
         /// O(1)-per-pixel vertical pass for uniform-body kernels: SIMD column sums slide
         /// down the rows. Same exactness contract as `horizontalBox`.
         fn verticalBox(io: Io, src: Image(SrcT), dst: Image(DstT), allocator: Allocator, kernel: []const KernelT, border_mode: BorderMode) !void {
-            try verticalPass(io, src, dst, allocator, kernel, border_mode, BandContext.verticalBoxBand);
+            try verticalPass(io, src, dst, allocator, kernel, border_mode, true);
         }
 
         /// Interior rows `[r_start, r_end)` of the vertical box pass; the column sums are

--- a/src/image/iir_gaussian.zig
+++ b/src/image/iir_gaussian.zig
@@ -10,6 +10,7 @@ const Allocator = std.mem.Allocator;
 
 const Image = @import("../image.zig").Image;
 const convolution = @import("convolution.zig");
+const meta = @import("../meta.zig");
 const parallel = @import("../parallel.zig");
 
 /// Below this the fit is visibly off the exact kernel (mean error ~2 units at sigma 0.5).
@@ -290,8 +291,7 @@ fn filterRowBlock(comptime T: type, comptime channels: usize, src: Image(T), tem
 }
 
 inline fn loadRowVec(comptime T: type, comptime W: usize, img: Image(T), row: usize, col: usize) @Vector(W, f32) {
-    const v: @Vector(W, T) = img.data[row * img.stride + col ..][0..W].*;
-    return if (T == f32) v else @floatFromInt(v);
+    return @as(@Vector(W, T), img.data[row * img.stride + col ..][0..W].*);
 }
 
 /// In-register transpose of a `W`×`W` block (`W` a power of two): `log2(W)` rounds of
@@ -392,14 +392,7 @@ fn ColumnLanes(comptime T: type, comptime W: usize) type {
 
         inline fn storeDst(a: @This(), row: usize, v: V) void {
             const out = a.dst.data[row * a.dst.stride + a.c0 ..][0..W];
-            if (T == f32) {
-                out.* = v;
-            } else {
-                const zero: V = @splat(0);
-                const max: V = @splat(255);
-                const rounded: @Vector(W, u8) = @round(@max(zero, @min(max, v)));
-                out.* = rounded;
-            }
+            out.* = if (T == f32) v else meta.roundToBytes(v);
         }
     };
 }
@@ -424,7 +417,6 @@ test "register transpose" {
 test "iir gaussian approximates the exact kernel" {
     const allocator = std.testing.allocator;
     const io = Io.Threaded.global_single_threaded.io();
-    const meta = @import("../meta.zig");
     var prng = std.Random.DefaultPrng.init(3);
     const random = prng.random();
 

--- a/src/image/interpolation.zig
+++ b/src/image/interpolation.zig
@@ -141,9 +141,9 @@ fn resizePlane(comptime P: type, comptime channels: usize, io: Io, src: []const 
             parallel.forRowBands(io, dst_rows, parallel.bandCount(dst_rows, dst_cols), &ctx, DirectPlane(P, channels).band);
         },
         .bilinear, .bicubic, .catmull_rom, .mitchell, .lanczos => {
-            const x_taps: channel_ops.AxisTaps = try .init(allocator, src_cols, dst_cols, method);
+            const x_taps: channel_ops.AxisTaps(P) = try .init(allocator, src_cols, dst_cols, method);
             defer x_taps.deinit(allocator);
-            const y_taps: channel_ops.AxisTaps = try .init(allocator, src_rows, dst_rows, method);
+            const y_taps: channel_ops.AxisTaps(P) = try .init(allocator, src_rows, dst_rows, method);
             defer y_taps.deinit(allocator);
             const mid = try allocator.alloc(channel_ops.Accum(P), @as(usize, src_rows) * dst_cols * channels);
             defer allocator.free(mid);
@@ -177,8 +177,8 @@ fn SeparablePlane(comptime P: type, comptime channels: usize) type {
         dst: []P,
         src_cols: u32,
         dst_cols: u32,
-        x_taps: channel_ops.AxisTaps,
-        y_taps: channel_ops.AxisTaps,
+        x_taps: channel_ops.AxisTaps(P),
+        y_taps: channel_ops.AxisTaps(P),
 
         fn rowsBand(ctx: *const @This(), _: usize, r0: usize, r1: usize) void {
             channel_ops.resizeRows(P, channels, ctx.src, ctx.src_cols, ctx.x_taps, ctx.mid, ctx.dst_cols, r0, r1);
@@ -249,14 +249,12 @@ fn bicubicKernel(t: f32) f32 {
 pub fn Sampler(comptime T: type) type {
     return struct {
         const Self = @This();
-        const Kind = enum { nearest, bilinear, cubic4, lanczos6 };
         const lut_size = 256;
         const max_taps = 6;
 
         image: Image(T),
         method: Interpolation,
         border: BorderMode,
-        kind: Kind,
         /// Per-axis kernel weights for fractional position `i / lut_size`, normalized to unit
         /// gain; unused for nearest and bilinear.
         lut: [lut_size][max_taps]f32,
@@ -266,15 +264,9 @@ pub fn Sampler(comptime T: type) type {
                 .image = image,
                 .method = method,
                 .border = border,
-                .kind = switch (method) {
-                    .nearest => .nearest,
-                    .bilinear => .bilinear,
-                    .bicubic, .catmull_rom, .mitchell => .cubic4,
-                    .lanczos => .lanczos6,
-                },
                 .lut = undefined,
             };
-            if (self.kind == .cubic4 or self.kind == .lanczos6) {
+            if (method != .nearest and method != .bilinear) {
                 const taps = kernelTaps(method);
                 for (&self.lut, 0..) |*row, i| {
                     const frac = @as(f32, @floatFromInt(i)) / lut_size;
@@ -293,11 +285,11 @@ pub fn Sampler(comptime T: type) type {
 
         /// The pixel at (`x`, `y`); zeroes where `interpolate` would return null.
         pub inline fn sample(self: *const Self, x: f32, y: f32) T {
-            return switch (self.kind) {
+            return switch (self.method) {
                 .nearest => self.sampleNearest(x, y),
                 .bilinear => self.sampleBilinear(x, y),
-                .cubic4 => self.sampleKernel(4, x, y),
-                .lanczos6 => self.sampleKernel(6, x, y),
+                .bicubic, .catmull_rom, .mitchell => self.sampleKernel(4, x, y),
+                .lanczos => self.sampleKernel(6, x, y),
             };
         }
 
@@ -317,8 +309,8 @@ pub fn Sampler(comptime T: type) type {
             const rx = @round(x);
             const ry = @round(y);
             if (rx >= 0 and ry >= 0 and rx < @as(f32, @floatFromInt(img.cols)) and ry < @as(f32, @floatFromInt(img.rows))) {
-                const c: usize = @intFromFloat(rx);
-                const r: usize = @intFromFloat(ry);
+                const c: usize = @trunc(rx);
+                const r: usize = @trunc(ry);
                 return img.data[r * img.stride + c];
             }
             return self.fallback(x, y);
@@ -332,8 +324,8 @@ pub fn Sampler(comptime T: type) type {
             if (!(fx_floor >= 0 and fy_floor >= 0 and fx_floor + 1 < @as(f32, @floatFromInt(img.cols)) and fy_floor + 1 < @as(f32, @floatFromInt(img.rows)))) {
                 return self.fallback(x, y);
             }
-            const left: usize = @intFromFloat(fx_floor);
-            const top: usize = @intFromFloat(fy_floor);
+            const left: usize = @trunc(fx_floor);
+            const top: usize = @trunc(fy_floor);
             const base = top * img.stride + left;
             const tl = img.data[base];
             const tr = img.data[base + 1];
@@ -381,10 +373,10 @@ pub fn Sampler(comptime T: type) type {
             if (!(fx_floor - lead >= 0 and fy_floor - lead >= 0 and fx_floor - lead + taps <= @as(f32, @floatFromInt(img.cols)) and fy_floor - lead + taps <= @as(f32, @floatFromInt(img.rows)))) {
                 return self.fallback(x, y);
             }
-            const left: usize = @intFromFloat(fx_floor - lead);
-            const top: usize = @intFromFloat(fy_floor - lead);
-            const wx = self.lut[@intFromFloat((x - fx_floor) * lut_size)][0..taps];
-            const wy = self.lut[@intFromFloat((y - fy_floor) * lut_size)][0..taps];
+            const left: usize = @trunc(fx_floor - lead);
+            const top: usize = @trunc(fy_floor - lead);
+            const wx = self.lut[@as(usize, @trunc((x - fx_floor) * lut_size))][0..taps];
+            const wy = self.lut[@as(usize, @trunc((y - fy_floor) * lut_size))][0..taps];
 
             var out: T = undefined;
             switch (@typeInfo(T)) {

--- a/src/image/motion_blur.zig
+++ b/src/image/motion_blur.zig
@@ -97,7 +97,7 @@ pub fn MotionBlurOps(comptime T: type) type {
 
         /// Applies linear motion blur by averaging pixels along a line at the given `angle`
         /// (radians, 0 = horizontal) and `distance` (pixels).
-        pub fn linear(io: Io, image: Image(T), out: Image(T), allocator: Allocator, angle: f32, distance: usize) !void {
+        pub fn linear(image: Image(T), io: Io, out: Image(T), allocator: Allocator, angle: f32, distance: usize) !void {
             if (distance == 0) {
                 image.copy(out);
                 return;

--- a/src/image/order_statistic_blur.zig
+++ b/src/image/order_statistic_blur.zig
@@ -85,8 +85,8 @@ inline fn scanFine(rank: usize, cum_below: u32, bucket: usize, fine_win: Vec16) 
 /// selected bucket is maintained incrementally alongside the coarse window and only
 /// rebuilt (O(window)) when the selected bucket changes between adjacent pixels.
 fn applyScalarOpTwoLevel(
-    io: Io,
     image: Image(u8),
+    io: Io,
     allocator: Allocator,
     radius: usize,
     out: Image(u8),
@@ -206,8 +206,8 @@ const TwoLevelBands = struct {
 };
 
 fn applyScalarOp(
-    io: Io,
     image: Image(u8),
+    io: Io,
     allocator: Allocator,
     radius: usize,
     out: Image(u8),
@@ -220,14 +220,14 @@ fn applyScalarOp(
     // window^2, so the rank is constant for the whole plane.
     const window = radius * 2 + 1;
     if (@hasDecl(@TypeOf(reducer_in), "rankFor") and window <= TwoLevelColumn.max_window) {
-        return applyScalarOpTwoLevel(io, image, allocator, radius, out, border, reducer_in.rankFor(window * window));
+        return applyScalarOpTwoLevel(image, io, allocator, radius, out, border, reducer_in.rankFor(window * window));
     }
-    return applyScalarOpFlat(io, image, allocator, radius, out, border, reducer_in);
+    return applyScalarOpFlat(image, io, allocator, radius, out, border, reducer_in);
 }
 
 fn applyScalarOpFlat(
-    io: Io,
     image: Image(u8),
+    io: Io,
     allocator: Allocator,
     radius: usize,
     out: Image(u8),
@@ -249,13 +249,9 @@ fn applyScalarOpFlat(
         .border = border,
         .reducer = reducer_in,
         .column_hists = try allocator.alloc(Histogram(u8), bands * image.cols),
-        .errors = try allocator.alloc(?Error, bands),
     };
     defer allocator.free(ctx.column_hists);
-    defer allocator.free(ctx.errors);
-    @memset(ctx.errors, null);
-    parallel.forRowBands(io, image.rows, bands, &ctx, Bands.band);
-    for (ctx.errors) |err| if (err) |e| return e;
+    try parallel.forRowBandsTry(io, image.rows, bands, &ctx, Bands.band);
 }
 
 fn FlatBands(comptime Reducer: type) type {
@@ -267,14 +263,8 @@ fn FlatBands(comptime Reducer: type) type {
         reducer: Reducer,
         /// `cols` column histograms per band.
         column_hists: []Histogram(u8),
-        /// First reducer error per band, reported after the group.
-        errors: []?Error,
 
-        fn band(ctx: *const @This(), b: usize, r0: usize, r1: usize) void {
-            ctx.errors[b] = if (ctx.bandRows(b, r0, r1)) null else |err| err;
-        }
-
-        fn bandRows(ctx: *const @This(), b: usize, r0: usize, r1: usize) Error!void {
+        fn band(ctx: *const @This(), b: usize, r0: usize, r1: usize) Error!void {
             const image = ctx.image;
             const out = ctx.out;
             const border = ctx.border;
@@ -555,7 +545,7 @@ pub fn OrderStatisticBlurOps(comptime T: type) type {
             switch (@typeInfo(T)) {
                 .int => {
                     if (T != u8) return Error.UnsupportedPixelType;
-                    try applyScalarOp(io, image, allocator, radius, target, border, reducer);
+                    try applyScalarOp(image, io, allocator, radius, target, border, reducer);
                 },
                 .@"struct" => {
                     if (!comptime meta.allFieldsAreU8(T)) return Error.UnsupportedPixelType;
@@ -590,7 +580,7 @@ pub fn OrderStatisticBlurOps(comptime T: type) type {
             inline for (src_planes, dst_planes) |src_data, dst_data| {
                 const src_plane = Image(u8).initFromSlice(image.rows, image.cols, src_data);
                 const dst_plane = Image(u8).initFromSlice(image.rows, image.cols, dst_data);
-                try applyScalarOp(io, src_plane, allocator, radius, dst_plane, border, reducer);
+                try applyScalarOp(src_plane, io, allocator, radius, dst_plane, border, reducer);
             }
 
             channel_ops.mergeChannels(T, io, dst_planes, target);
@@ -624,8 +614,8 @@ test "two-level rank filter matches flat histogram path" {
                 for (percentiles) |p| {
                     const window = radius * 2 + 1;
                     const flat_reducer = PercentileReducer{ .percentile = p };
-                    try applyScalarOpFlat(std.Io.Threaded.global_single_threaded.io(), img, allocator, radius, flat, mode, flat_reducer);
-                    try applyScalarOpTwoLevel(std.Io.Threaded.global_single_threaded.io(), img, allocator, radius, two, mode, flat_reducer.rankFor(window * window));
+                    try applyScalarOpFlat(img, std.Io.Threaded.global_single_threaded.io(), allocator, radius, flat, mode, flat_reducer);
+                    try applyScalarOpTwoLevel(img, std.Io.Threaded.global_single_threaded.io(), allocator, radius, two, mode, flat_reducer.rankFor(window * window));
                     try testing.expectEqualSlices(u8, flat.data, two.data);
                 }
             }
@@ -658,8 +648,8 @@ test "two-level rank filter matches flat histogram path" {
                 for ([_]f64{ 0.0, 0.5, 1.0 }) |p| {
                     const window = radius * 2 + 1;
                     const flat_reducer = PercentileReducer{ .percentile = p };
-                    try applyScalarOpFlat(std.Io.Threaded.global_single_threaded.io(), img, allocator, radius, flat, mode, flat_reducer);
-                    try applyScalarOpTwoLevel(std.Io.Threaded.global_single_threaded.io(), img, allocator, radius, two, mode, flat_reducer.rankFor(window * window));
+                    try applyScalarOpFlat(img, std.Io.Threaded.global_single_threaded.io(), allocator, radius, flat, mode, flat_reducer);
+                    try applyScalarOpTwoLevel(img, std.Io.Threaded.global_single_threaded.io(), allocator, radius, two, mode, flat_reducer.rankFor(window * window));
                     try testing.expectEqualSlices(u8, flat.data, two.data);
                 }
             }

--- a/src/image/transforms.zig
+++ b/src/image/transforms.zig
@@ -221,7 +221,7 @@ pub fn Transform(comptime T: type) type {
                 .src_cx = center.x(),
                 .src_cy = center.y(),
             };
-            parallel.forRowBands(io, out.rows, parallel.bandCount(out.rows, out.cols), &ctx, Resample.rotateBand);
+            parallel.forRowBands(io, out.rows, parallel.bandCount(out.rows, out.cols), &ctx, Resample.band);
         }
 
         /// Inverse-mapped resampling shared by the general rotate and extract paths: output
@@ -242,28 +242,15 @@ pub fn Transform(comptime T: type) type {
             origin_x: f32 = 0,
             origin_y: f32 = 0,
 
-            fn rotateBand(ctx: *const Resample, _: usize, r0: usize, r1: usize) void {
+            /// Output pixel centres map through scale and origin (identity for rotate), then
+            /// rotate by +angle (CCW) about `dst_c` onto `src_c`.
+            fn band(ctx: *const Resample, _: usize, r0: usize, r1: usize) void {
                 for (r0..r1) |r| {
-                    const dy = @as(f32, @floatFromInt(r)) - ctx.dst_cy;
+                    const dy = ctx.origin_y + (@as(f32, @floatFromInt(r)) + 0.5) * ctx.scale_y - 0.5 - ctx.dst_cy;
                     for (0..ctx.out.cols) |c| {
-                        const dx = @as(f32, @floatFromInt(c)) - ctx.dst_cx;
+                        const dx = ctx.origin_x + (@as(f32, @floatFromInt(c)) + 0.5) * ctx.scale_x - 0.5 - ctx.dst_cx;
                         const src_x = ctx.cos * dx - ctx.sin * dy + ctx.src_cx;
                         const src_y = ctx.sin * dx + ctx.cos * dy + ctx.src_cy;
-                        ctx.out.at(r, c).* = ctx.sampler.sample(src_x, src_y);
-                    }
-                }
-            }
-
-            fn extractBand(ctx: *const Resample, _: usize, r0: usize, r1: usize) void {
-                for (r0..r1) |r| {
-                    const y_rect = ctx.origin_y + (@as(f32, @floatFromInt(r)) + 0.5) * ctx.scale_y - 0.5;
-                    const dy = y_rect - ctx.src_cy;
-                    for (0..ctx.out.cols) |c| {
-                        const x_rect = ctx.origin_x + (@as(f32, @floatFromInt(c)) + 0.5) * ctx.scale_x - 0.5;
-                        // Rotate around rectangle center by +angle (CCW)
-                        const dx = x_rect - ctx.src_cx;
-                        const src_x = ctx.src_cx + ctx.cos * dx - ctx.sin * dy;
-                        const src_y = ctx.src_cy + ctx.sin * dx + ctx.cos * dy;
                         ctx.out.at(r, c).* = ctx.sampler.sample(src_x, src_y);
                     }
                 }
@@ -330,7 +317,7 @@ pub fn Transform(comptime T: type) type {
                 .origin_x = rect.l,
                 .origin_y = rect.t,
             };
-            parallel.forRowBands(io, out.rows, parallel.bandCount(out.rows, out.cols), &ctx, Resample.extractBand);
+            parallel.forRowBands(io, out.rows, parallel.bandCount(out.rows, out.cols), &ctx, Resample.band);
         }
 
         /// Inserts `source` into `self` at the destination rectangle, with optional rotation

--- a/src/matrix/Matrix.zig
+++ b/src/matrix/Matrix.zig
@@ -585,11 +585,11 @@ pub fn Matrix(comptime T: type) type {
         /// C += alpha * A * B for row-major A (m×k) and B (k×n).
         /// Blocked over k and n so the B block stays in L2 while every row of A streams past it,
         /// with a `micro_rows` × `2·vec_len` register tile so each B load feeds `2·micro_rows` FMAs.
-        fn blockedGemm(comptime VecType: type, io: Io, c: *Matrix(T), a: Matrix(T), b: Matrix(T), alpha: T) void {
+        fn blockedGemm(comptime VecType: type, io: Io, c: Matrix(T), a: Matrix(T), b: Matrix(T), alpha: T) void {
             // Bands are groups of `micro_rows` rows of C; the same k order per element makes the split invisible.
             const groups = (@as(usize, a.rows) + micro_rows - 1) / micro_rows;
-            const ctx: GemmBands(VecType) = .{ .c = c.*, .a = a, .b = b, .alpha = alpha };
-            parallel.forRowBands(io, groups, parallel.bandCount(a.rows, b.cols), &ctx, GemmBands(VecType).band);
+            const ctx: GemmBands(VecType) = .{ .c = c, .a = a, .b = b, .alpha = alpha };
+            parallel.forRowBands(io, groups, parallel.bandCount(groups, micro_rows * b.cols), &ctx, GemmBands(VecType).band);
         }
 
         fn GemmBands(comptime VecType: type) type {
@@ -612,7 +612,6 @@ pub fn Matrix(comptime T: type) type {
                     const n: usize = ctx.b.cols;
                     const i_start = g0 * micro_rows;
                     const i_end = @min(g1 * micro_rows, m);
-                    var c = ctx.c;
 
                     var j0: usize = 0;
                     while (j0 < n) : (j0 += block_n) {
@@ -623,7 +622,7 @@ pub fn Matrix(comptime T: type) type {
                             var i: usize = i_start;
                             while (i < i_end) : (i += micro_rows) {
                                 switch (@min(micro_rows, i_end - i)) {
-                                    inline 1...micro_rows => |rows| microTile(VecType, rows, &c, ctx.a, ctx.b, ctx.alpha, i, k0, k1, j0, j1),
+                                    inline 1...micro_rows => |rows| microTile(VecType, rows, ctx.c, ctx.a, ctx.b, ctx.alpha, i, k0, k1, j0, j1),
                                     else => unreachable,
                                 }
                             }
@@ -639,7 +638,7 @@ pub fn Matrix(comptime T: type) type {
         fn microTile(
             comptime VecType: type,
             comptime rows: usize,
-            c: *Matrix(T),
+            c: Matrix(T),
             a: Matrix(T),
             b: Matrix(T),
             alpha: T,
@@ -753,7 +752,7 @@ pub fn Matrix(comptime T: type) type {
                     defer if (a_t) |*t| t.deinit();
                     var b_t: ?Matrix(T) = if (trans_b) try other.transpose() else null;
                     defer if (b_t) |*t| t.deinit();
-                    blockedGemm(@Vector(vec_len, T), io, &result, a_t orelse self, b_t orelse other, alpha);
+                    blockedGemm(@Vector(vec_len, T), io, result, a_t orelse self, b_t orelse other, alpha);
                 } else {
                     for (0..a_rows) |i| {
                         for (0..b_cols) |j| {

--- a/src/meta.zig
+++ b/src/meta.zig
@@ -137,6 +137,29 @@ pub fn narrowToBytes(v: anytype) @Vector(@typeInfo(@TypeOf(v)).vector.len, u8) {
     return @truncate(@as(Unsigned, @bitCast(v)));
 }
 
+/// Rounds f32 lanes to bytes, clamping to 0..255 first.
+pub fn roundToBytes(v: anytype) @Vector(@typeInfo(@TypeOf(v)).vector.len, u8) {
+    const V = @TypeOf(v);
+    return @round(std.math.clamp(v, @as(V, @splat(0)), @as(V, @splat(255))));
+}
+
+/// Shuffle masks for a stride-`n` running window over `B` lanes: `repeat` broadcasts the
+/// `n` window sums across the block and `tail` picks the block's last `n` lanes.
+pub fn StrideMasks(comptime B: usize, comptime n: usize) type {
+    return struct {
+        pub const repeat: [B]i32 = blk: {
+            var m: [B]i32 = undefined;
+            for (&m, 0..) |*e, j| e.* = @intCast(j % n);
+            break :blk m;
+        };
+        pub const tail: [n]i32 = blk: {
+            var m: [n]i32 = undefined;
+            for (&m, 0..) |*e, t| e.* = @intCast(B - n + t);
+            break :blk m;
+        };
+    };
+}
+
 /// Check if a type is an RGB or RGBA type with u8 components.
 /// Returns true for structs with 3 or 4 u8 fields named r, g, b[, a].
 ///

--- a/src/parallel.zig
+++ b/src/parallel.zig
@@ -49,3 +49,28 @@ pub fn forRowBands(io: Io, rows: usize, bands: usize, ctx: anytype, comptime fun
     }
     group.await(io) catch {};
 }
+
+/// `forRowBands` for fallible band functions: the first error any band returns is the result.
+pub fn forRowBandsTry(io: Io, rows: usize, bands: usize, ctx: anytype, comptime func: anytype) ErrorSetOf(func)!void {
+    if (bands <= 1 or rows == 0) return func(ctx, 0, 0, rows);
+    const Code = @Int(.unsigned, @bitSizeOf(anyerror));
+    const Wrap = struct {
+        fn run(first: *std.atomic.Value(Code), c: @TypeOf(ctx), band: usize, r0: usize, r1: usize) void {
+            func(c, band, r0, r1) catch |err| {
+                _ = first.cmpxchgStrong(0, @intFromError(err), .monotonic, .monotonic);
+            };
+        }
+    };
+    var first: std.atomic.Value(Code) = .init(0);
+    var group: Io.Group = .init;
+    for (0..bands) |band| {
+        group.async(io, Wrap.run, .{ &first, ctx, band, rows * band / bands, rows * (band + 1) / bands });
+    }
+    group.await(io) catch {};
+    const code = first.load(.monotonic);
+    if (code != 0) return @errorCast(@errorFromInt(code));
+}
+
+fn ErrorSetOf(comptime func: anytype) type {
+    return @typeInfo(@typeInfo(@TypeOf(func)).@"fn".return_type.?).error_union.error_set;
+}


### PR DESCRIPTION
Cleanup pass over the perf work from the last two days (#437-#470): reuse, simplification and efficiency findings, no intended behaviour change.

## Shared mechanisms
- `parallel.forRowBandsTry` returns the first error a band raises. The PNG encoder, both JPEG band drivers and the order-statistic blur drop their hand-rolled error slots. The JPEG drivers band over restart segments through the helper's own split instead of passing `bands, bands` and recomputing it.
- `bandCount` receives the unit actually iterated (chunks, segments, row groups) with its pixel weight, so the three `@min` wrappers and gemm's empty bands for small `m` go away.
- BT.601 coefficients live once in `color.zig` as `bt601`, shared by the scalar conversions and the JPEG vector paths.
- `meta.roundToBytes` and `meta.StrideMasks` replace the copies in `box_blur`, `iir_gaussian` and `convolution`; `jpeg.zig` gets `hasByteFF` for the two SWAR scans and `isRstn` for the marker tests. The last vector `@intCast` to `u8` uses `narrowToBytes`.
- `AxisTaps(P)` keeps one weight table in the plane's accumulator type and quantizes through `convolution.quantizeKernel` (now `pub`, with a scale parameter).

## Simplifications
- One `verticalBand` with a per-pass `box` flag; `BandContext(P, mode, interleaved)` in `box_blur` without the two partial-application shims; one `Resample.band` for rotate and extract; `Sampler` switches on `method` directly; the `Idct` alias block is gone; `encodeRgb` derives the subsampling factors once; grayscale JPEG encoding takes an `Image(u8)` and no longer dupes non-contiguous input; gemm passes C by value.
- Widening vector casts and `@intFromFloat` on already-rounded values rely on implicit coercion. `applyScalarOp*` and `MotionBlur.linear` take `image, io, ...` like their siblings.

## Efficiency
- The PNG encoder filters into a per-band chunk buffer instead of an image-sized copy.
- GIF threads `io` into the palette mapping and `toNativeImage` instead of discarding it.

## Comments
- Narrative multi-line comments from the batch trimmed to one line; a block above the JPEG DCT section that duplicated the doc comments below it is removed.

## Note
The merged rotate/extract band uses rotate's addition order for the final source coordinate, so extract's sum is evaluated in a different order than before. In-tree transform tests pass; anything pinning extract output bit-for-bit could move by an ulp.