### PR TITLE
perf: resize views separably, pack the transposed gemm panel, band the rest

### DIFF
--- a/src/codecs/jpeg.zig
+++ b/src/codecs/jpeg.zig
@@ -1436,6 +1436,8 @@ pub const JpegState = struct {
     // Scan data
     scan_components: []ScanComponent = undefined,
     restart_interval: u16 = 0,
+    /// Baseline scans with restart markers: offset of each segment's data within the scan.
+    restart_starts: []usize = &.{},
 
     // Bit reader for entropy-coded data
     bit_reader: BitReader = undefined,
@@ -1522,6 +1524,7 @@ pub const JpegState = struct {
 
     pub fn deinit(self: *JpegState) void {
         self.allocator.free(self.scan_components);
+        self.allocator.free(self.restart_starts);
         if (self.block_storage) |storage| {
             self.allocator.free(storage);
         }
@@ -2265,15 +2268,18 @@ fn decodeBlockBits(br: *BitReader, dc_table: *const HuffmanTable, ac_table: *con
 
 // Parse JPEG file and decode image
 // Helper function to find the end of entropy-coded scan data
-fn findScanEnd(data: []const u8, start_pos: usize) usize {
+/// End of the entropy-coded scan starting at `start_pos`. Only 0xFF can start a marker;
+/// stuffed zeros and RSTn stay inside the scan, and `starts`, when given, receives the
+/// offset (from `start_pos`) of the data after each RSTn.
+fn findScanEnd(data: []const u8, start_pos: usize, allocator: Allocator, starts: ?*std.ArrayList(usize)) !usize {
     if (data.len == 0) return 0;
     var pos = start_pos;
-    // Only 0xFF can start a marker; stuffed zeros and RSTn stay inside the scan.
     while (pos < data.len - 1) {
         const ff = std.mem.indexOfScalarPos(u8, data, pos, 0xFF) orelse break;
         if (ff >= data.len - 1) return ff;
         const next = data[ff + 1];
         if (next == 0x00 or isRstn(next)) {
+            if (starts) |list| if (isRstn(next)) try list.append(allocator, ff + 2 - start_pos);
             pos = ff + 2;
             continue;
         }
@@ -2300,7 +2306,15 @@ fn processScanMarker(state: *JpegState, data: []const u8, pos: usize) !usize {
     const scan_info = try state.parseSOS(data[payload_start..marker_end]);
     const scan_start = marker_end;
 
-    const scan_end = findScanEnd(data, scan_start);
+    const banded = state.header.frame_type == .baseline and state.restart_interval != 0;
+    var starts: std.ArrayList(usize) = .empty;
+    defer starts.deinit(state.allocator);
+    if (banded) try starts.append(state.allocator, 0);
+    const scan_end = try findScanEnd(data, scan_start, state.allocator, if (banded) &starts else null);
+    if (banded) {
+        state.allocator.free(state.restart_starts);
+        state.restart_starts = try starts.toOwnedSlice(state.allocator);
+    }
     state.bit_reader = BitReader.init(data[scan_start..scan_end]);
 
     // Baseline: the single scan is decoded by performBlockScan after the marker loop
@@ -2738,21 +2752,6 @@ fn performBlockScan(comptime T: type, state: *JpegState, band: *RenderBand, img:
 /// Byte offsets into the entropy data at which restart segments begin: `starts[k]` is the
 /// first byte after the k-th RSTn marker (`starts[0] = 0`), so segment k holds MCUs
 /// `[k * interval, (k + 1) * interval)`.
-fn restartSegments(allocator: Allocator, data: []const u8) ![]usize {
-    var starts: std.ArrayList(usize) = .empty;
-    errdefer starts.deinit(allocator);
-    try starts.append(allocator, 0);
-    var pos: usize = 0;
-    while (pos + 1 < data.len) {
-        const ff = std.mem.indexOfScalarPos(u8, data, pos, 0xFF) orelse break;
-        if (ff + 1 >= data.len) break;
-        const m = data[ff + 1];
-        if (isRstn(m)) try starts.append(allocator, ff + 2);
-        pos = ff + 1;
-    }
-    return starts.toOwnedSlice(allocator);
-}
-
 /// Baseline scan with restart intervals on `io`: bands own balanced runs of MCU rows, each
 /// starting its entropy decoder at the restart segment holding its first MCU (discarding
 /// the segment's earlier MCUs, under one MCU row) and rendering through its own scratch.
@@ -3072,25 +3071,56 @@ fn renderBlockRows(comptime T: type, state: *const JpegState, band: *RenderBand,
     }
 }
 
-/// Baseline frames stream their scan; progressive frames render the full store band by band.
+/// Baseline frames stream their scan; progressive frames render the full store in bands.
 fn decodeInto(comptime T: type, io: Io, state: *JpegState, img: *Image(T)) !void {
-    if (state.header.frame_type == .baseline and state.restart_interval != 0) {
+    if (state.header.frame_type != .baseline) return renderProgressive(T, io, state, img);
+    const starts = state.restart_starts;
+    if (starts.len > 1) {
         const layout: ScanLayout = .init(state);
-        const starts = try restartSegments(state.allocator, state.bit_reader.data);
-        defer state.allocator.free(starts);
         const bands = parallel.bandCount(starts.len, state.restart_interval * 64 * layout.x_step * layout.y_step);
         if (bands > 1) return performBlockScanBanded(T, io, state, img, starts, bands);
     }
     var band: RenderBand = try .init(state.allocator, state);
     defer band.deinit();
-    if (state.header.frame_type == .baseline) return performBlockScan(T, state, &band, img);
+    return performBlockScan(T, state, &band, img);
+}
+
+/// The whole-image block store of a progressive frame rendered in bands of MCU rows on
+/// `io`, each through its own scratch.
+fn renderProgressive(comptime T: type, io: Io, state: *JpegState, img: *Image(T)) !void {
     const full = state.block_storage orelse return error.BlockStorageNotAllocated;
     _, const max_v = state.maxSamplingFactors();
-    const bw: usize = state.block_width_actual;
-    var y: usize = 0;
-    while (y < state.block_height) : (y += max_v) {
-        try renderBlockRows(T, state, &band, full[y * bw ..], y, @min(max_v, state.block_height - y), img);
+    const block_rows: usize = state.block_height;
+    const mcu_rows = (block_rows + max_v - 1) / max_v;
+    const bands = parallel.bandCount(mcu_rows, @as(usize, state.header.width) * 8 * max_v);
+
+    const Ctx = struct {
+        state: *const JpegState,
+        img: *Image(T),
+        full: @TypeOf(full),
+        max_v: usize,
+        renders: []RenderBand,
+
+        fn run(ctx: *const @This(), k: usize, m0: usize, m1: usize) !void {
+            const bw: usize = ctx.state.block_width_actual;
+            const rows: usize = ctx.state.block_height;
+            var y = m0 * ctx.max_v;
+            while (y < @min(rows, m1 * ctx.max_v)) : (y += ctx.max_v) {
+                try renderBlockRows(T, ctx.state, &ctx.renders[k], ctx.full[y * bw ..], y, @min(ctx.max_v, rows - y), ctx.img);
+            }
+        }
+    };
+
+    const renders = try state.allocator.alloc(RenderBand, bands);
+    defer state.allocator.free(renders);
+    var made: usize = 0;
+    defer for (renders[0..made]) |*r| r.deinit();
+    for (renders) |*r| {
+        r.* = try .init(state.allocator, state);
+        made += 1;
     }
+    const ctx: Ctx = .{ .state = state, .img = img, .full = full, .max_v = max_v, .renders = renders };
+    try parallel.forRowBandsTry(io, mcu_rows, bands, &ctx, Ctx.run);
 }
 
 pub fn toNativeImage(io: Io, allocator: Allocator, state: *JpegState) !union(enum) {

--- a/src/image/channel_ops.zig
+++ b/src/image/channel_ops.zig
@@ -76,26 +76,12 @@ pub fn splitChannelsWithUniform(comptime T: type, io: Io, image: Image(T), alloc
     const num_channels = comptime Image(T).channels();
     const FieldType = FieldTypeOf(T);
 
-    const channels = try splitChannels(T, io, image, allocator);
-    errdefer for (channels) |plane| allocator.free(plane);
-
-    // Detecting uniformity on the split planes (SIMD, early-exit) beats per-pixel flags in the deinterleave loop.
+    // Each band checks its freshly written plane rows for uniformity (SIMD, early-exit),
+    // which beats per-pixel flags in the deinterleave loop.
     const bands = parallel.bandCount(image.rows, image.cols);
     const band_uniforms = try allocator.alloc(?FieldType, bands * num_channels);
     defer allocator.free(band_uniforms);
-    const Ctx = struct {
-        channels: [num_channels][]FieldType,
-        cols: usize,
-        band_uniforms: []?FieldType,
-
-        fn band(ctx: *const @This(), b: usize, r0: usize, r1: usize) void {
-            for (ctx.channels, 0..) |plane, i| {
-                ctx.band_uniforms[b * num_channels + i] = findUniformValue(FieldType, plane[r0 * ctx.cols .. r1 * ctx.cols]);
-            }
-        }
-    };
-    const ctx: Ctx = .{ .channels = channels, .cols = image.cols, .band_uniforms = band_uniforms };
-    parallel.forRowBands(io, image.rows, bands, &ctx, Ctx.band);
+    const channels = try splitChannelsBands(T, io, image, allocator, bands, band_uniforms);
 
     var uniforms: [num_channels]?FieldType = undefined;
     for (&uniforms, 0..) |*slot, i| {
@@ -126,11 +112,17 @@ fn fieldSlots(comptime T: type) [Image(T).channels()]usize {
 /// Allocates and fills channel planes for all fields.
 /// The caller is responsible for freeing the returned slices.
 pub fn splitChannels(comptime T: type, io: Io, image: Image(T), allocator: std.mem.Allocator) ![Image(T).channels()][]FieldTypeOf(T) {
+    return splitChannelsBands(T, io, image, allocator, parallel.bandCount(image.rows, image.cols), &.{});
+}
+
+/// `splitChannels` over `bands` bands; a non-empty `band_uniforms` (`bands * channels` slots)
+/// receives each band's per-plane uniform value.
+fn splitChannelsBands(comptime T: type, io: Io, image: Image(T), allocator: std.mem.Allocator, bands: usize, band_uniforms: []?FieldTypeOf(T)) ![Image(T).channels()][]FieldTypeOf(T) {
     const num_channels = comptime Image(T).channels();
     const plane_size = @as(usize, image.rows) * image.cols;
     const channels = try allocPlanes(FieldTypeOf(T), num_channels, allocator, plane_size);
-    const ctx: PlaneBands(T, []FieldTypeOf(T)) = .{ .image = image, .channels = channels };
-    parallel.forRowBands(io, image.rows, parallel.bandCount(image.rows, image.cols), &ctx, @TypeOf(ctx).split);
+    const ctx: PlaneBands(T, []FieldTypeOf(T)) = .{ .image = image, .channels = channels, .band_uniforms = band_uniforms };
+    parallel.forRowBands(io, image.rows, bands, &ctx, @TypeOf(ctx).split);
     return channels;
 }
 
@@ -150,10 +142,17 @@ fn PlaneBands(comptime T: type, comptime Plane: type) type {
 
         image: Image(T),
         channels: [num_channels]Plane,
+        /// Per band and plane, the plane's uniform value over the band's rows (split only).
+        band_uniforms: []?FieldType = &.{},
 
-        fn split(ctx: *const @This(), _: usize, r0: usize, r1: usize) void {
+        fn split(ctx: *const @This(), band: usize, r0: usize, r1: usize) void {
             const image = ctx.image;
             const channels = ctx.channels;
+            defer if (ctx.band_uniforms.len != 0) {
+                for (channels, 0..) |plane, i| {
+                    ctx.band_uniforms[band * num_channels + i] = findUniformValue(FieldType, plane[r0 * image.cols .. r1 * image.cols]);
+                }
+            };
             for (r0..r1) |r| {
                 const idx = r * image.cols;
                 const row = image.data[r * image.stride ..][0..image.cols];
@@ -213,7 +212,9 @@ pub fn resizePlaneNearest(
     comptime P: type,
     comptime channels: usize,
     src: []const P,
+    src_stride: usize,
     dst: []P,
+    dst_stride: usize,
     src_rows: u32,
     src_cols: u32,
     dst_rows: u32,
@@ -231,7 +232,7 @@ pub fn resizePlaneNearest(
         for (0..dst_cols) |c| {
             const src_x_f = (@as(f32, @floatFromInt(c)) + 0.5) * x_ratio - 0.5;
             const src_x = @max(0, @min(src_cols - 1, @as(u32, @round(src_x_f))));
-            dst[(r * dst_cols + c) * channels ..][0..channels].* = src[(@as(usize, src_y) * src_cols + src_x) * channels ..][0..channels].*;
+            dst[r * dst_stride + c * channels ..][0..channels].* = src[src_y * src_stride + src_x * channels ..][0..channels].*;
         }
     }
 }
@@ -306,14 +307,15 @@ pub fn Accum(comptime P: type) type {
     };
 }
 
-/// Horizontal pass: source rows `[r_start, r_end)` of `src` (`src_cols` pixels wide)
-/// resampled through `x_taps` into `mid` (`dst_cols` pixels wide) as unnormalized sums.
-/// `channels` > 1 means interleaved pixels; the taps index pixels, every channel of each.
-pub fn resizeRows(comptime P: type, comptime channels: usize, src: []const P, src_cols: u32, x_taps: AxisTaps(P), mid: []Accum(P), dst_cols: u32, r_start: usize, r_end: usize) void {
+/// Horizontal pass: source rows `[r_start, r_end)` of `src` (`src_cols` pixels wide, rows
+/// `src_stride` elements apart) resampled through `x_taps` into `mid` (`dst_cols` pixels
+/// wide) as unnormalized sums. `channels` > 1 means interleaved pixels; the taps index
+/// pixels, every channel of each.
+pub fn resizeRows(comptime P: type, comptime channels: usize, src: []const P, src_stride: usize, src_cols: u32, x_taps: AxisTaps(P), mid: []Accum(P), dst_cols: u32, r_start: usize, r_end: usize) void {
     const A = Accum(P);
     const taps = x_taps.taps;
     for (r_start..r_end) |r| {
-        const row = src[r * src_cols * channels ..][0 .. src_cols * channels];
+        const row = src[r * src_stride ..][0 .. src_cols * channels];
         const out = mid[r * dst_cols * channels ..][0 .. dst_cols * channels];
         for (0..dst_cols) |c| {
             var acc: [channels]A = @splat(0);
@@ -325,9 +327,10 @@ pub fn resizeRows(comptime P: type, comptime channels: usize, src: []const P, sr
     }
 }
 
-/// Vertical pass: output rows `[r_start, r_end)` of `dst` (`cols` elements wide) from `mid`
-/// through `y_taps`; u8 planes are rounded and clamped, f32 planes stored as is.
-pub fn resizeColumns(comptime P: type, mid: []const Accum(P), cols: usize, y_taps: AxisTaps(P), dst: []P, r_start: usize, r_end: usize) void {
+/// Vertical pass: output rows `[r_start, r_end)` of `dst` (`cols` elements wide, rows
+/// `dst_stride` apart) from `mid` through `y_taps`; u8 planes are rounded and clamped, f32
+/// planes stored as is.
+pub fn resizeColumns(comptime P: type, mid: []const Accum(P), cols: usize, y_taps: AxisTaps(P), dst: []P, dst_stride: usize, r_start: usize, r_end: usize) void {
     const A = Accum(P);
     const vec_len = std.simd.suggestVectorLength(A) orelse 1;
     const V = @Vector(vec_len, A);
@@ -338,7 +341,7 @@ pub fn resizeColumns(comptime P: type, mid: []const Accum(P), cols: usize, y_tap
     for (r_start..r_end) |r| {
         const rows = y_taps.indices[r * taps ..][0..taps];
         const weights = y_taps.weightsAt(r);
-        const out = dst[r * cols ..][0..cols];
+        const out = dst[r * dst_stride ..][0..cols];
         var c: usize = 0;
         while (c + vec_len <= cols) : (c += vec_len) {
             var acc: V = @splat(half);

--- a/src/image/iir_gaussian.zig
+++ b/src/image/iir_gaussian.zig
@@ -67,11 +67,15 @@ fn blurPlane(comptime T: type, comptime channels: usize, io: Io, src: Image(T), 
     const cols: usize = src.cols;
     if (rows == 0 or cols == 0) return;
 
-    var temp: Image(f32) = if (T == f32) dst else try .init(allocator, src.rows, src.cols);
-    defer if (T != f32) temp.deinit(allocator);
-
-    // Column tiles of `lanes` columns are the unit of vertical work.
+    // Column tiles of `lanes` columns are the unit of vertical work. The temp plane is padded
+    // to whole tiles so a ragged last tile still runs as one vector line with its `dst`
+    // stores masked; a scalar column costs a whole line of latency.
     const tiles = (cols + lanes - 1) / lanes;
+    var temp: Image(f32) = if (T == f32) dst else try .init(allocator, src.rows, @intCast(tiles * lanes));
+    defer if (T != f32) temp.deinit(allocator);
+    if (T != f32 and temp.cols != cols) {
+        for (0..rows) |r| @memset(temp.data[r * temp.stride + cols ..][0 .. temp.cols - cols], 0);
+    }
     const row_bands = parallel.bandCount(rows, cols);
     const col_bands = parallel.bandCount(tiles, rows * lanes);
     const ctx: Pass(T, channels) = .{
@@ -99,6 +103,8 @@ fn Pass(comptime T: type, comptime channels: usize) type {
             return ctx.pads[band * ctx.coeffs.pad * lanes * channels ..][0 .. ctx.coeffs.pad * width * n];
         }
 
+        /// Scalar rows past the last block are cheap (a row is one contiguous chain), so
+        /// they stay scalar.
         fn rowBand(ctx: *const @This(), band: usize, r0: usize, r1: usize) void {
             var r = r0;
             while (r + lanes <= r1) : (r += lanes) {
@@ -109,15 +115,19 @@ fn Pass(comptime T: type, comptime channels: usize) type {
             }
         }
 
-        /// Columns are channel-agnostic: a row of the element view is just `cols * channels` lanes.
+        /// Columns are channel-agnostic: a row of the element view is just `cols * channels`
+        /// lanes. The ragged last tile runs over the padded temp with its `dst` stores masked;
+        /// only the in-place f32 pass (`dst` is the temp, unpadded) goes column by column.
         fn columnBand(ctx: *const @This(), band: usize, t0: usize, t1: usize) void {
             const cols = ctx.src.cols;
             for (t0..t1) |tile| {
                 const c0 = tile * lanes;
                 if (c0 + lanes <= cols) {
-                    filterLine(lanes, 1, ColumnLanes(T, lanes){ .temp = ctx.temp, .dst = ctx.dst, .c0 = c0 }, ctx.src.rows, ctx.coeffs, ctx.bandPad(band, lanes, 1));
+                    filterLine(lanes, 1, ColumnLanes(T, lanes, false){ .temp = ctx.temp, .dst = ctx.dst, .c0 = c0 }, ctx.src.rows, ctx.coeffs, ctx.bandPad(band, lanes, 1));
+                } else if (T != f32) {
+                    filterLine(lanes, 1, ColumnLanes(T, lanes, true){ .temp = ctx.temp, .dst = ctx.dst, .c0 = c0, .valid = cols - c0 }, ctx.src.rows, ctx.coeffs, ctx.bandPad(band, lanes, 1));
                 } else {
-                    for (c0..cols) |c| filterLine(1, 1, ColumnLanes(T, 1){ .temp = ctx.temp, .dst = ctx.dst, .c0 = c }, ctx.src.rows, ctx.coeffs, ctx.bandPad(band, 1, 1));
+                    for (c0..cols) |c| filterLine(1, 1, ColumnLanes(T, 1, false){ .temp = ctx.temp, .dst = ctx.dst, .c0 = c }, ctx.src.rows, ctx.coeffs, ctx.bandPad(band, 1, 1));
                 }
             }
         }
@@ -371,12 +381,14 @@ fn RowLanes(comptime T: type, comptime W: usize) type {
 
 /// `W` adjacent columns from `c0`, indexed by row; the forward pass rewrites `temp` in place
 /// and the backward pass stores into `dst`.
-fn ColumnLanes(comptime T: type, comptime W: usize) type {
+/// `masked` lines store only `valid` lanes to `dst`; the rest read and write the temp's padding.
+fn ColumnLanes(comptime T: type, comptime W: usize, comptime masked: bool) type {
     return struct {
         const V = @Vector(W, f32);
         temp: Image(f32),
         dst: Image(T),
         c0: usize,
+        valid: usize = W,
 
         inline fn loadSrc(a: @This(), row: usize) V {
             return a.temp.data[row * a.temp.stride + a.c0 ..][0..W].*;
@@ -391,8 +403,13 @@ fn ColumnLanes(comptime T: type, comptime W: usize) type {
         }
 
         inline fn storeDst(a: @This(), row: usize, v: V) void {
-            const out = a.dst.data[row * a.dst.stride + a.c0 ..][0..W];
-            out.* = if (T == f32) v else meta.roundToBytes(v);
+            const out = a.dst.data[row * a.dst.stride + a.c0 ..];
+            if (masked) {
+                const lanes_out: [W]T = if (T == f32) v else meta.roundToBytes(v);
+                @memcpy(out[0..a.valid], lanes_out[0..a.valid]);
+            } else {
+                out[0..W].* = if (T == f32) v else meta.roundToBytes(v);
+            }
         }
     };
 }

--- a/src/image/interpolation.zig
+++ b/src/image/interpolation.zig
@@ -110,34 +110,32 @@ pub fn resize(comptime T: type, io: Io, self: Image(T), out: Image(T), allocator
         return;
     }
 
-    // Contiguous planes take the separable resizers; u8 struct pixels run through them interleaved.
-    if (self.isContiguous() and out.isContiguous()) {
-        if (T == u8 or T == f32) {
-            resizePlane(T, 1, io, self.data, out.data, self.rows, self.cols, out.rows, out.cols, allocator, method) catch {
-                resizeGeneric(T, io, self, out, method);
-            };
-            return;
-        } else if (comptime @typeInfo(T) == .@"struct" and meta.allFieldsAreU8(T)) {
-            const n = comptime Image(T).channels();
-            resizePlane(u8, n, io, std.mem.sliceAsBytes(self.data), std.mem.sliceAsBytes(out.data), self.rows, self.cols, out.rows, out.cols, allocator, method) catch {
-                resizeGeneric(T, io, self, out, method);
-            };
-            return;
-        }
+    // Planes take the separable resizers; u8 struct pixels run through them interleaved.
+    if (T == u8 or T == f32) {
+        resizePlane(T, 1, io, self.data, self.stride, out.data, out.stride, self.rows, self.cols, out.rows, out.cols, allocator, method) catch {
+            resizeGeneric(T, io, self, out, method);
+        };
+        return;
+    } else if (comptime @typeInfo(T) == .@"struct" and meta.allFieldsAreU8(T)) {
+        const n = comptime Image(T).channels();
+        resizePlane(u8, n, io, std.mem.sliceAsBytes(self.data), self.stride * n, std.mem.sliceAsBytes(out.data), out.stride * n, self.rows, self.cols, out.rows, out.cols, allocator, method) catch {
+            resizeGeneric(T, io, self, out, method);
+        };
+        return;
     }
 
     // Fall back to generic implementation
     resizeGeneric(T, io, self, out, method);
 }
 
-/// One contiguous plane of `P` (`channels` elements per pixel when interleaved): nearest
-/// samples directly in output-row bands; every other kernel runs separably, a horizontal
-/// pass into an accumulator plane over the source rows and a vertical pass over the
-/// output rows.
-fn resizePlane(comptime P: type, comptime channels: usize, io: Io, src: []const P, dst: []P, src_rows: u32, src_cols: u32, dst_rows: u32, dst_cols: u32, allocator: Allocator, method: Interpolation) !void {
+/// One plane of `P` (`channels` elements per pixel when interleaved, strides in elements):
+/// nearest samples directly in output-row bands; every other kernel runs separably, a
+/// horizontal pass into an accumulator plane over the source rows and a vertical pass over
+/// the output rows.
+fn resizePlane(comptime P: type, comptime channels: usize, io: Io, src: []const P, src_stride: usize, dst: []P, dst_stride: usize, src_rows: u32, src_cols: u32, dst_rows: u32, dst_cols: u32, allocator: Allocator, method: Interpolation) !void {
     switch (method) {
         .nearest => {
-            const ctx: DirectPlane(P, channels) = .{ .src = src, .dst = dst, .src_rows = src_rows, .src_cols = src_cols, .dst_rows = dst_rows, .dst_cols = dst_cols };
+            const ctx: DirectPlane(P, channels) = .{ .src = src, .src_stride = src_stride, .dst = dst, .dst_stride = dst_stride, .src_rows = src_rows, .src_cols = src_cols, .dst_rows = dst_rows, .dst_cols = dst_cols };
             parallel.forRowBands(io, dst_rows, parallel.bandCount(dst_rows, dst_cols), &ctx, DirectPlane(P, channels).band);
         },
         .bilinear, .bicubic, .catmull_rom, .mitchell, .lanczos => {
@@ -148,7 +146,7 @@ fn resizePlane(comptime P: type, comptime channels: usize, io: Io, src: []const 
             const mid = try allocator.alloc(channel_ops.Accum(P), @as(usize, src_rows) * dst_cols * channels);
             defer allocator.free(mid);
 
-            const ctx: SeparablePlane(P, channels) = .{ .src = src, .mid = mid, .dst = dst, .src_cols = src_cols, .dst_cols = dst_cols, .x_taps = x_taps, .y_taps = y_taps };
+            const ctx: SeparablePlane(P, channels) = .{ .src = src, .src_stride = src_stride, .mid = mid, .dst = dst, .dst_stride = dst_stride, .src_cols = src_cols, .dst_cols = dst_cols, .x_taps = x_taps, .y_taps = y_taps };
             parallel.forRowBands(io, src_rows, parallel.bandCount(src_rows, dst_cols), &ctx, SeparablePlane(P, channels).rowsBand);
             parallel.forRowBands(io, dst_rows, parallel.bandCount(dst_rows, dst_cols), &ctx, SeparablePlane(P, channels).columnsBand);
         },
@@ -158,14 +156,16 @@ fn resizePlane(comptime P: type, comptime channels: usize, io: Io, src: []const 
 fn DirectPlane(comptime P: type, comptime channels: usize) type {
     return struct {
         src: []const P,
+        src_stride: usize,
         dst: []P,
+        dst_stride: usize,
         src_rows: u32,
         src_cols: u32,
         dst_rows: u32,
         dst_cols: u32,
 
         fn band(ctx: *const @This(), _: usize, r0: usize, r1: usize) void {
-            channel_ops.resizePlaneNearest(P, channels, ctx.src, ctx.dst, ctx.src_rows, ctx.src_cols, ctx.dst_rows, ctx.dst_cols, r0, r1);
+            channel_ops.resizePlaneNearest(P, channels, ctx.src, ctx.src_stride, ctx.dst, ctx.dst_stride, ctx.src_rows, ctx.src_cols, ctx.dst_rows, ctx.dst_cols, r0, r1);
         }
     };
 }
@@ -173,19 +173,21 @@ fn DirectPlane(comptime P: type, comptime channels: usize) type {
 fn SeparablePlane(comptime P: type, comptime channels: usize) type {
     return struct {
         src: []const P,
+        src_stride: usize,
         mid: []channel_ops.Accum(P),
         dst: []P,
+        dst_stride: usize,
         src_cols: u32,
         dst_cols: u32,
         x_taps: channel_ops.AxisTaps(P),
         y_taps: channel_ops.AxisTaps(P),
 
         fn rowsBand(ctx: *const @This(), _: usize, r0: usize, r1: usize) void {
-            channel_ops.resizeRows(P, channels, ctx.src, ctx.src_cols, ctx.x_taps, ctx.mid, ctx.dst_cols, r0, r1);
+            channel_ops.resizeRows(P, channels, ctx.src, ctx.src_stride, ctx.src_cols, ctx.x_taps, ctx.mid, ctx.dst_cols, r0, r1);
         }
 
         fn columnsBand(ctx: *const @This(), _: usize, r0: usize, r1: usize) void {
-            channel_ops.resizeColumns(P, ctx.mid, @as(usize, ctx.dst_cols) * channels, ctx.y_taps, ctx.dst, r0, r1);
+            channel_ops.resizeColumns(P, ctx.mid, @as(usize, ctx.dst_cols) * channels, ctx.y_taps, ctx.dst, ctx.dst_stride, r0, r1);
         }
     };
 }

--- a/src/matrix/Matrix.zig
+++ b/src/matrix/Matrix.zig
@@ -582,17 +582,20 @@ pub fn Matrix(comptime T: type) type {
             return self.gemm(io, true, self, false, 1.0, 0.0, null);
         }
 
-        /// C += alpha * A * B for row-major A (m×k) and B (k×n).
-        /// Blocked over k and n so the B block stays in L2 while every row of A streams past it,
-        /// with a `micro_rows` × `2·vec_len` register tile so each B load feeds `2·micro_rows` FMAs.
-        fn blockedGemm(comptime VecType: type, io: Io, c: Matrix(T), a: Matrix(T), b: Matrix(T), alpha: T) void {
+        /// C += alpha * op(A) * B for row-major B (k×n) and A either m×k or, with `trans_a`,
+        /// stored k×m and read down its columns (the kernel only broadcasts A's scalars, so
+        /// no transposed copy is needed). Blocked over k and n so the B block stays in L2
+        /// while every row of A streams past it, with a `micro_rows` × `2·vec_len` register
+        /// tile so each B load feeds `2·micro_rows` FMAs.
+        fn blockedGemm(comptime VecType: type, comptime trans_a: bool, io: Io, c: Matrix(T), a: Matrix(T), b: Matrix(T), alpha: T) void {
             // Bands are groups of `micro_rows` rows of C; the same k order per element makes the split invisible.
-            const groups = (@as(usize, a.rows) + micro_rows - 1) / micro_rows;
-            const ctx: GemmBands(VecType) = .{ .c = c, .a = a, .b = b, .alpha = alpha };
-            parallel.forRowBands(io, groups, parallel.bandCount(groups, micro_rows * b.cols), &ctx, GemmBands(VecType).band);
+            const m: usize = if (trans_a) a.cols else a.rows;
+            const groups = (m + micro_rows - 1) / micro_rows;
+            const ctx: GemmBands(VecType, trans_a) = .{ .c = c, .a = a, .b = b, .alpha = alpha };
+            parallel.forRowBands(io, groups, parallel.bandCount(groups, micro_rows * b.cols), &ctx, GemmBands(VecType, trans_a).band);
         }
 
-        fn GemmBands(comptime VecType: type) type {
+        fn GemmBands(comptime VecType: type, comptime trans_a: bool) type {
             return struct {
                 c: Matrix(T),
                 a: Matrix(T),
@@ -604,11 +607,10 @@ pub fn Matrix(comptime T: type) type {
                 fn band(ctx: *const @This(), _: usize, g0: usize, g1: usize) void {
                     const vec_len = @typeInfo(VecType).vector.len;
                     const tile_cols = 2 * vec_len;
-                    const block_k: usize = 256;
                     // ~512 KB of B per block, rounded to whole register tiles.
                     const block_n: usize = @max(tile_cols, (512 * 1024 / @sizeOf(T)) / block_k / tile_cols * tile_cols);
-                    const m: usize = ctx.a.rows;
-                    const k: usize = ctx.a.cols;
+                    const m: usize = if (trans_a) ctx.a.cols else ctx.a.rows;
+                    const k: usize = if (trans_a) ctx.a.rows else ctx.a.cols;
                     const n: usize = ctx.b.cols;
                     const i_start = g0 * micro_rows;
                     const i_end = @min(g1 * micro_rows, m);
@@ -622,7 +624,7 @@ pub fn Matrix(comptime T: type) type {
                             var i: usize = i_start;
                             while (i < i_end) : (i += micro_rows) {
                                 switch (@min(micro_rows, i_end - i)) {
-                                    inline 1...micro_rows => |rows| microTile(VecType, rows, ctx.c, ctx.a, ctx.b, ctx.alpha, i, k0, k1, j0, j1),
+                                    inline 1...micro_rows => |rows| microTile(VecType, trans_a, rows, ctx.c, ctx.a, ctx.b, ctx.alpha, i, k0, k1, j0, j1),
                                     else => unreachable,
                                 }
                             }
@@ -633,10 +635,12 @@ pub fn Matrix(comptime T: type) type {
         }
 
         const micro_rows = 4;
+        const block_k: usize = 256;
 
         /// Rows `i..i+rows` of C for columns `j0..j1`, accumulating over `k0..k1`.
         fn microTile(
             comptime VecType: type,
+            comptime trans_a: bool,
             comptime rows: usize,
             c: Matrix(T),
             a: Matrix(T),
@@ -650,9 +654,21 @@ pub fn Matrix(comptime T: type) type {
         ) void {
             const vec_len = @typeInfo(VecType).vector.len;
             const tile_cols = 2 * vec_len;
-            const k: usize = a.cols;
+            const lda: usize = a.cols;
             const n: usize = b.cols;
             const alpha_v: VecType = @splat(alpha);
+
+            // Row pointers of the A panel at `k0`: the rows themselves, or for a transposed A
+            // the tile's columns gathered once into a contiguous panel (the strided walk
+            // would otherwise touch one cache line per k for every j tile).
+            var panel: [rows][block_k]T = undefined;
+            if (trans_a) {
+                for (k0..k1) |kk| {
+                    inline for (0..rows) |r| panel[r][kk - k0] = a.items[kk * lda + i + r];
+                }
+            }
+            var a_rows: [rows][*]const T = undefined;
+            inline for (0..rows) |r| a_rows[r] = if (trans_a) &panel[r] else a.items[(i + r) * lda + k0 ..].ptr;
 
             var j = j0;
             while (j + tile_cols <= j1) : (j += tile_cols) {
@@ -663,7 +679,7 @@ pub fn Matrix(comptime T: type) type {
                     const b0: VecType = b_row[0..vec_len].*;
                     const b1: VecType = b_row[vec_len..][0..vec_len].*;
                     inline for (0..rows) |r| {
-                        const a_v: VecType = @splat(a.items[(i + r) * k + kk]);
+                        const a_v: VecType = @splat(a_rows[r][kk - k0]);
                         acc0[r] += a_v * b0;
                         acc1[r] += a_v * b1;
                     }
@@ -680,7 +696,7 @@ pub fn Matrix(comptime T: type) type {
             if (j < j1) {
                 inline for (0..rows) |r| {
                     for (k0..k1) |kk| {
-                        const a_ik = alpha * a.items[(i + r) * k + kk];
+                        const a_ik = alpha * a_rows[r][kk - k0];
                         for (c.items[(i + r) * n + j .. (i + r) * n + j1], b.items[kk * n + j .. kk * n + j1]) |*cv, bv| {
                             cv.* += a_ik * bv;
                         }
@@ -747,12 +763,15 @@ pub fn Matrix(comptime T: type) type {
 
             if (alpha != 0) {
                 if (std.simd.suggestVectorLength(T)) |vec_len| {
-                    // The kernel wants op(A) and op(B) row-major; only transposed operands are copied.
-                    var a_t: ?Matrix(T) = if (trans_a) try self.transpose() else null;
-                    defer if (a_t) |*t| t.deinit();
+                    // The kernel vector-loads B row-major, so only a transposed B is copied.
                     var b_t: ?Matrix(T) = if (trans_b) try other.transpose() else null;
                     defer if (b_t) |*t| t.deinit();
-                    blockedGemm(@Vector(vec_len, T), io, result, a_t orelse self, b_t orelse other, alpha);
+                    const b_op = b_t orelse other;
+                    if (trans_a) {
+                        blockedGemm(@Vector(vec_len, T), true, io, result, self, b_op, alpha);
+                    } else {
+                        blockedGemm(@Vector(vec_len, T), false, io, result, self, b_op, alpha);
+                    }
                 } else {
                     for (0..a_rows) |i| {
                         for (0..b_cols) |j| {

--- a/src/parallel.zig
+++ b/src/parallel.zig
@@ -68,7 +68,12 @@ pub fn forRowBandsTry(io: Io, rows: usize, bands: usize, ctx: anytype, comptime 
     }
     group.await(io) catch {};
     const code = first.load(.monotonic);
-    if (code != 0) return @errorCast(@errorFromInt(code));
+    if (code != 0) {
+        const E = ErrorSetOf(func);
+        const empty = comptime if (@typeInfo(E).error_set.error_names) |names| names.len == 0 else false;
+        if (empty) unreachable;
+        return @errorCast(@errorFromInt(code));
+    }
 }
 
 fn ErrorSetOf(comptime func: anytype) type {


### PR DESCRIPTION
Follow-ups to the skipped efficiency findings from the #471 review. Everything measured (`taskset -c 0 perf stat` cycles for serial, best-of-10 wall clock for the pool, old = 15788dc).

## Resize of views
The separable u8/f32 resizers take row strides, so views no longer fall back to the per-pixel generic path. Letterbox output was only affected when the content is narrower than the target (a full-width view is still contiguous).

| pillarbox 1920x1080 -> 1280x800 | serial | pool |
|---|---|---|
| bilinear | 1.84x | 1.13x |
| bicubic | 2.60x | 1.21x |

## gemm with a transposed A
`op(A)` is no longer materialized. The micro tile gathers its 4-row panel from A's columns once per k block into a stack buffer, so the inner FMA loop reads a contiguous panel exactly as before (a plain strided walk was 1.32x slower on 1024², so the panel is needed).

| | serial | pool |
|---|---|---|
| 20000x16 covariance (PCA shape) | 2.5x | 2.6x |
| 1024² A^T B | within noise | 1.33x |
| 1024² A B (untouched path) | within noise | within noise |

## IIR Gaussian
The temp plane is padded to whole column tiles and the ragged last tile runs as one masked vector line instead of a scalar chain per column: 1.07x at 15 tail columns, neutral when the width is a multiple of 16. The row-side variant (re-running the tail rows as a full block) measured as a wash because scalar rows are cheap, so rows are unchanged.

## JPEG
- Progressive frames render their block store in MCU-row bands on the caller's `Io` through per-band scratch: 1.1x on a 2048² progressive file (entropy decoding stays serial and dominates).
- `findScanEnd` records the restart offsets while it looks for the scan end, so the banded baseline decoder no longer rescans the entropy data.

## Other
- `splitChannelsWithUniform` checks uniformity inside the split band instead of re-reading every plane in a second pass.
- `parallel.forRowBandsTry` accepts band functions whose inferred error set is empty.

Not done: the separable resize still materializes a `src_rows x dst_cols` accumulator (a rolling-window rewrite), and `insert` still uses its own per-tag sampling rather than `Sampler` (would change pixel output).