### PR TITLE
perf(image): resample through a per-band ring instead of a full accumulator plane

### DIFF
--- a/src/image/channel_ops.zig
+++ b/src/image/channel_ops.zig
@@ -292,7 +292,7 @@ pub fn AxisTaps(comptime P: type) type {
             allocator.free(self.weights);
         }
 
-        fn weightsAt(self: Self, pos: usize) []const Accum(P) {
+        pub fn weightsAt(self: Self, pos: usize) []const Accum(P) {
             return self.weights[pos * self.taps ..][0..self.taps];
         }
     };
@@ -307,59 +307,48 @@ pub fn Accum(comptime P: type) type {
     };
 }
 
-/// Horizontal pass: source rows `[r_start, r_end)` of `src` (`src_cols` pixels wide, rows
-/// `src_stride` elements apart) resampled through `x_taps` into `mid` (`dst_cols` pixels
-/// wide) as unnormalized sums. `channels` > 1 means interleaved pixels; the taps index
-/// pixels, every channel of each.
-pub fn resizeRows(comptime P: type, comptime channels: usize, src: []const P, src_stride: usize, src_cols: u32, x_taps: AxisTaps(P), mid: []Accum(P), dst_cols: u32, r_start: usize, r_end: usize) void {
+/// Horizontal pass: one source row (`src_cols` pixels) resampled through `x_taps` into `out`
+/// (`dst_cols` pixels) as unnormalized sums. `channels` > 1 means interleaved pixels; the
+/// taps index pixels, every channel of each.
+pub fn resizeRow(comptime P: type, comptime channels: usize, row: []const P, x_taps: AxisTaps(P), out: []Accum(P), dst_cols: usize) void {
     const A = Accum(P);
     const taps = x_taps.taps;
-    for (r_start..r_end) |r| {
-        const row = src[r * src_stride ..][0 .. src_cols * channels];
-        const out = mid[r * dst_cols * channels ..][0 .. dst_cols * channels];
-        for (0..dst_cols) |c| {
-            var acc: [channels]A = @splat(0);
-            for (x_taps.indices[c * taps ..][0..taps], x_taps.weightsAt(c)) |idx, w| {
-                inline for (0..channels) |ch| acc[ch] += w * @as(A, row[idx * channels + ch]);
-            }
-            out[c * channels ..][0..channels].* = acc;
+    for (0..dst_cols) |c| {
+        var acc: [channels]A = @splat(0);
+        for (x_taps.indices[c * taps ..][0..taps], x_taps.weightsAt(c)) |idx, w| {
+            inline for (0..channels) |ch| acc[ch] += w * @as(A, row[idx * channels + ch]);
         }
+        out[c * channels ..][0..channels].* = acc;
     }
 }
 
-/// Vertical pass: output rows `[r_start, r_end)` of `dst` (`cols` elements wide, rows
-/// `dst_stride` apart) from `mid` through `y_taps`; u8 planes are rounded and clamped, f32
-/// planes stored as is.
-pub fn resizeColumns(comptime P: type, mid: []const Accum(P), cols: usize, y_taps: AxisTaps(P), dst: []P, dst_stride: usize, r_start: usize, r_end: usize) void {
+/// Vertical pass: one output row of `cols` elements as the weighted sum of the horizontally
+/// resampled `rows`; u8 planes are rounded and clamped, f32 planes stored as is.
+pub fn blendRows(comptime P: type, rows: []const [*]const Accum(P), weights: []const Accum(P), out: []P) void {
     const A = Accum(P);
     const vec_len = std.simd.suggestVectorLength(A) orelse 1;
     const V = @Vector(vec_len, A);
-    const taps = y_taps.taps;
     const shift = 2 * weight_shift;
     const half: A = if (P == u8) 1 << (shift - 1) else 0;
+    const cols = out.len;
 
-    for (r_start..r_end) |r| {
-        const rows = y_taps.indices[r * taps ..][0..taps];
-        const weights = y_taps.weightsAt(r);
-        const out = dst[r * dst_stride ..][0..cols];
-        var c: usize = 0;
-        while (c + vec_len <= cols) : (c += vec_len) {
-            var acc: V = @splat(half);
-            for (rows, weights) |row, w| {
-                acc += @as(V, @splat(w)) * @as(V, mid[row * cols + c ..][0..vec_len].*);
-            }
-            if (P == u8) {
-                const scaled = acc >> @splat(shift);
-                out[c..][0..vec_len].* = meta.narrowToBytes(std.math.clamp(scaled, @as(V, @splat(0)), @as(V, @splat(255))));
-            } else {
-                out[c..][0..vec_len].* = acc;
-            }
+    var c: usize = 0;
+    while (c + vec_len <= cols) : (c += vec_len) {
+        var acc: V = @splat(half);
+        for (rows, weights) |row, w| {
+            acc += @as(V, @splat(w)) * @as(V, row[c..][0..vec_len].*);
         }
-        while (c < cols) : (c += 1) {
-            var acc: A = half;
-            for (rows, weights) |row, w| acc += w * mid[row * cols + c];
-            out[c] = if (P == u8) meta.clamp(u8, acc >> shift) else acc;
+        if (P == u8) {
+            const scaled = acc >> @splat(shift);
+            out[c..][0..vec_len].* = meta.narrowToBytes(std.math.clamp(scaled, @as(V, @splat(0)), @as(V, @splat(255))));
+        } else {
+            out[c..][0..vec_len].* = acc;
         }
+    }
+    while (c < cols) : (c += 1) {
+        var acc: A = half;
+        for (rows, weights) |row, w| acc += w * row[c];
+        out[c] = if (P == u8) meta.clamp(u8, acc >> shift) else acc;
     }
 }
 

--- a/src/image/interpolation.zig
+++ b/src/image/interpolation.zig
@@ -129,9 +129,9 @@ pub fn resize(comptime T: type, io: Io, self: Image(T), out: Image(T), allocator
 }
 
 /// One plane of `P` (`channels` elements per pixel when interleaved, strides in elements):
-/// nearest samples directly in output-row bands; every other kernel runs separably, a
-/// horizontal pass into an accumulator plane over the source rows and a vertical pass over
-/// the output rows.
+/// nearest samples directly in output-row bands; every other kernel runs separably in
+/// output-row bands, each band resampling the source rows its output taps horizontally
+/// into a small ring and blending them vertically from there.
 fn resizePlane(comptime P: type, comptime channels: usize, io: Io, src: []const P, src_stride: usize, dst: []P, dst_stride: usize, src_rows: u32, src_cols: u32, dst_rows: u32, dst_cols: u32, allocator: Allocator, method: Interpolation) !void {
     switch (method) {
         .nearest => {
@@ -143,12 +143,16 @@ fn resizePlane(comptime P: type, comptime channels: usize, io: Io, src: []const 
             defer x_taps.deinit(allocator);
             const y_taps: channel_ops.AxisTaps(P) = try .init(allocator, src_rows, dst_rows, method);
             defer y_taps.deinit(allocator);
-            const mid = try allocator.alloc(channel_ops.Accum(P), @as(usize, src_rows) * dst_cols * channels);
-            defer allocator.free(mid);
+            // Consecutive output rows tap windows that slide by the row ratio; twice the taps
+            // keeps every window that overlaps the previous one resident.
+            const ring_rows = 2 * x_taps.taps;
+            const row_len = @as(usize, dst_cols) * channels;
+            const bands = parallel.bandCount(dst_rows, dst_cols);
+            const rings = try allocator.alloc(channel_ops.Accum(P), bands * ring_rows * row_len);
+            defer allocator.free(rings);
 
-            const ctx: SeparablePlane(P, channels) = .{ .src = src, .src_stride = src_stride, .mid = mid, .dst = dst, .dst_stride = dst_stride, .src_cols = src_cols, .dst_cols = dst_cols, .x_taps = x_taps, .y_taps = y_taps };
-            parallel.forRowBands(io, src_rows, parallel.bandCount(src_rows, dst_cols), &ctx, SeparablePlane(P, channels).rowsBand);
-            parallel.forRowBands(io, dst_rows, parallel.bandCount(dst_rows, dst_cols), &ctx, SeparablePlane(P, channels).columnsBand);
+            const ctx: SeparablePlane(P, channels) = .{ .src = src, .src_stride = src_stride, .dst = dst, .dst_stride = dst_stride, .src_cols = src_cols, .dst_cols = dst_cols, .x_taps = x_taps, .y_taps = y_taps, .rings = rings, .ring_rows = ring_rows };
+            parallel.forRowBands(io, dst_rows, bands, &ctx, SeparablePlane(P, channels).band);
         },
     }
 }
@@ -172,22 +176,52 @@ fn DirectPlane(comptime P: type, comptime channels: usize) type {
 
 fn SeparablePlane(comptime P: type, comptime channels: usize) type {
     return struct {
+        const A = channel_ops.Accum(P);
+
         src: []const P,
         src_stride: usize,
-        mid: []channel_ops.Accum(P),
         dst: []P,
         dst_stride: usize,
         src_cols: u32,
         dst_cols: u32,
         x_taps: channel_ops.AxisTaps(P),
         y_taps: channel_ops.AxisTaps(P),
+        /// `ring_rows` horizontally resampled source rows per band, slot `row % ring_rows`.
+        rings: []A,
+        ring_rows: usize,
 
-        fn rowsBand(ctx: *const @This(), _: usize, r0: usize, r1: usize) void {
-            channel_ops.resizeRows(P, channels, ctx.src, ctx.src_stride, ctx.src_cols, ctx.x_taps, ctx.mid, ctx.dst_cols, r0, r1);
-        }
-
-        fn columnsBand(ctx: *const @This(), _: usize, r0: usize, r1: usize) void {
-            channel_ops.resizeColumns(P, ctx.mid, @as(usize, ctx.dst_cols) * channels, ctx.y_taps, ctx.dst, ctx.dst_stride, r0, r1);
+        /// Output rows `[r0, r1)`. The ring holds the contiguous source rows `[lo, hi)`; a
+        /// window sliding forward extends it, anything else (a gap on a steep downscale, the
+        /// mirrored bottom edge folding back) restarts it, so untapped source rows are never
+        /// resampled and each band recomputes at most one window of halo.
+        fn band(ctx: *const @This(), k: usize, r0: usize, r1: usize) void {
+            const taps = ctx.x_taps.taps;
+            const row_len = @as(usize, ctx.dst_cols) * channels;
+            const ring = ctx.rings[k * ctx.ring_rows * row_len ..][0 .. ctx.ring_rows * row_len];
+            var lo: usize = 0;
+            var hi: usize = 0;
+            for (r0..r1) |r| {
+                const rows = ctx.y_taps.indices[r * taps ..][0..taps];
+                var need_lo: usize = rows[0];
+                var need_hi: usize = rows[0] + 1;
+                for (rows) |sr| {
+                    need_lo = @min(need_lo, sr);
+                    need_hi = @max(need_hi, sr + 1);
+                }
+                if (need_lo < lo or need_hi > hi) {
+                    var from = need_lo;
+                    if (need_lo >= lo and need_lo <= hi) from = hi else lo = need_lo;
+                    for (from..need_hi) |sr| {
+                        const src_row = ctx.src[sr * ctx.src_stride ..][0 .. @as(usize, ctx.src_cols) * channels];
+                        channel_ops.resizeRow(P, channels, src_row, ctx.x_taps, ring[(sr % ctx.ring_rows) * row_len ..][0..row_len], ctx.dst_cols);
+                    }
+                    hi = need_hi;
+                    lo = @max(lo, hi -| ctx.ring_rows);
+                }
+                var srcs: [channel_ops.max_taps][*]const A = undefined;
+                for (rows, 0..) |sr, t| srcs[t] = ring[(sr % ctx.ring_rows) * row_len ..].ptr;
+                channel_ops.blendRows(P, srcs[0..taps], ctx.y_taps.weightsAt(r), ctx.dst[r * ctx.dst_stride ..][0..row_len]);
+            }
         }
     };
 }


### PR DESCRIPTION
The separable resize built a `src_rows x dst_cols` accumulator plane, ran the horizontal pass over every source row in bands, then the vertical pass in bands. Each output-row band now resamples only the source rows its taps touch into a ring of `2·taps` rows and blends from there.

- The accumulator plane is gone; scratch is `bands × 2·taps × dst_cols × channels` accumulators (about 1 MB per band at 8K wide).
- On a downscale, source rows no tap reads are never resampled.
- The two banded passes become one, so the pool no longer syncs between them.
- A window that slides forward extends the ring; a gap (steep downscale) or the mirrored bottom edge folding back restarts it, so each band recomputes at most one window of halo.

Output is byte-identical (hashed against the old build on every case below).

Best of 10 on random Rgb, old = 95777ea; serial pinned on one core, pool on 8 cores:

| case | serial | pool | peak RSS |
|---|---|---|---|
| 1080p → 4K bicubic | 1.18x | 1.31x | 80 → 32 MB |
| 4K → 1080p bilinear | 1.31x | 1.83x | 80 → 32 MB |
| 4K → 256x144 lanczos | 3.4x | 1.12x | |
| 4K → 256x144 bilinear | 11x | 3.4x | |
| 1080p → 720p bicubic | 1.19x | 1.37x | 26 → 10 MB |
| 1080p → 8K bilinear | 1.25x | 1.59x | 202 → 105 MB |

RSS includes the input and output images themselves.