### PR TITLE
refactor(image): take an Options struct in ImagePyramid.init and reuse the blur scratch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - **Python draws antialiased by default**: canvas methods default to `DrawMode.SOFT` and an omitted `blending` follows the mode's preset; pass `mode=DrawMode.FAST, blending=Blending.NORMAL` for the old output. ([#424](https://github.com/arrufat/zignal/pull/424))
 - **Python `Font` replaces `BitmapFont`**: `Font.load` detects the format and `Canvas.draw_text` takes a pixel `size`. ([#403](https://github.com/arrufat/zignal/pull/403))
 - **JPEG encodes write a restart marker per MCU row by default** (`EncodeOptions.restart_interval`, about 0.1 % larger files) so they decode in parallel; `.none` restores the old bytes. ([#466](https://github.com/arrufat/zignal/pull/466))
-- **`ImagePyramid.init(io, allocator, source, options)`**: `build` is renamed `init` and takes an `Options` struct (`n_levels`, `scale_factor`, `blur_sigma`, `min_size`, `.default` is the ORB preset) in place of three positional parameters; `buildDefault` and the write-only `blur_sigma` field are gone.
+- **`ImagePyramid.init(io, allocator, source, options)`**: `build` is renamed `init` and takes an `Options` struct (`n_levels`, `scale_factor`, `blur_sigma`, `min_size`, `.default` is the ORB preset) in place of three positional parameters; the pyramid no longer stores its allocator, so `deinit(allocator)` takes it like `Image`; `buildDefault` and the write-only `blur_sigma` field are gone.
 - **Minimum Zig version is 0.17.0-dev.1970.**
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Breaking Changes
-- **`io: Io` parameter**: image filters, resampling transforms, order-statistic filters, `convert`/flips/`insert`, codec `encode`/`loadFromBytes`, `Matrix` products, `Pca`, `ImagePyramid.build` and `Orb.detect` take an `io: Io` after `self` and run in row bands on it; a `process.Init` pool runs them in parallel, `Io.Threaded.global_single_threaded.io()` or `std.Io.failing` runs them serially, output is byte-identical either way. ([#437](https://github.com/arrufat/zignal/pull/437)-[#448](https://github.com/arrufat/zignal/pull/448), [#464](https://github.com/arrufat/zignal/pull/464)-[#468](https://github.com/arrufat/zignal/pull/468))
+- **`io: Io` parameter**: image filters, resampling transforms, order-statistic filters, `convert`/flips/`insert`, codec `encode`/`loadFromBytes`, `Matrix` products, `Pca`, `ImagePyramid.init` and `Orb.detect` take an `io: Io` after `self` and run in row bands on it; a `process.Init` pool runs them in parallel, `Io.Threaded.global_single_threaded.io()` or `std.Io.failing` runs them serially, output is byte-identical either way. ([#437](https://github.com/arrufat/zignal/pull/437)-[#448](https://github.com/arrufat/zignal/pull/448), [#464](https://github.com/arrufat/zignal/pull/464)-[#468](https://github.com/arrufat/zignal/pull/468))
 - **Argument order**: out-param image methods follow `(self, io, allocator, out, ...)`, `diff` takes `(self, other, out, opts)`, ORB helpers take the allocator first. ([#354](https://github.com/arrufat/zignal/pull/354), [#359](https://github.com/arrufat/zignal/pull/359), [#434](https://github.com/arrufat/zignal/pull/434))
 - **`DrawOptions`**: canvas primitives take `opts: DrawOptions { mode, blending }` instead of a `DrawMode`; the `.soft`/`.fast` presets reproduce the old output, every primitive can use any of the 12 blend modes, and `setPixel`/`setPoint` gain a `blending` parameter. ([#400](https://github.com/arrufat/zignal/pull/400))
 - **`Canvas.drawText(font: Font, size: ?f32)`**: takes the `Font` union and a pixel size instead of a `BitmapFont` and a scale (`null` uses `font.defaultSize()`), and returns `!void`. ([#403](https://github.com/arrufat/zignal/pull/403))
@@ -15,6 +15,7 @@
 - **Python draws antialiased by default**: canvas methods default to `DrawMode.SOFT` and an omitted `blending` follows the mode's preset; pass `mode=DrawMode.FAST, blending=Blending.NORMAL` for the old output. ([#424](https://github.com/arrufat/zignal/pull/424))
 - **Python `Font` replaces `BitmapFont`**: `Font.load` detects the format and `Canvas.draw_text` takes a pixel `size`. ([#403](https://github.com/arrufat/zignal/pull/403))
 - **JPEG encodes write a restart marker per MCU row by default** (`EncodeOptions.restart_interval`, about 0.1 % larger files) so they decode in parallel; `.none` restores the old bytes. ([#466](https://github.com/arrufat/zignal/pull/466))
+- **`ImagePyramid.init(io, allocator, source, options)`**: `build` is renamed `init` and takes an `Options` struct (`n_levels`, `scale_factor`, `blur_sigma`, `min_size`, `.default` is the ORB preset) in place of three positional parameters; `buildDefault` and the write-only `blur_sigma` field are gone.
 - **Minimum Zig version is 0.17.0-dev.1970.**
 
 ### Features

--- a/src/features/orb.zig
+++ b/src/features/orb.zig
@@ -119,7 +119,7 @@ pub fn detect(self: Orb, io: Io, allocator: Allocator, image: Image(u8)) ![]KeyP
         .n_levels = self.n_levels,
         .scale_factor = self.scale_factor,
     });
-    defer pyramid.deinit();
+    defer pyramid.deinit(allocator);
 
     return self.detectWithPyramid(allocator, pyramid);
 }
@@ -130,7 +130,7 @@ pub fn compute(self: Orb, io: Io, allocator: Allocator, image: Image(u8), keypoi
         .n_levels = self.n_levels,
         .scale_factor = self.scale_factor,
     });
-    defer pyramid.deinit();
+    defer pyramid.deinit(allocator);
 
     return computeWithPyramid(allocator, pyramid, keypoints);
 }
@@ -250,7 +250,7 @@ pub fn detectAndCompute(
         .n_levels = self.n_levels,
         .scale_factor = self.scale_factor,
     });
-    defer pyramid.deinit();
+    defer pyramid.deinit(allocator);
 
     // Detect keypoints using the pyramid
     const keypoints = try self.detectWithPyramid(allocator, pyramid);

--- a/src/features/orb.zig
+++ b/src/features/orb.zig
@@ -115,14 +115,10 @@ pub const ScoreType = enum {
 
 /// Detect keypoints in the image at multiple scales
 pub fn detect(self: Orb, io: Io, allocator: Allocator, image: Image(u8)) ![]KeyPoint {
-    var pyramid = try ImagePyramid(u8).build(
-        io,
-        allocator,
-        image,
-        self.n_levels,
-        self.scale_factor,
-        1.6, // blur_sigma for anti-aliasing
-    );
+    var pyramid = try ImagePyramid(u8).init(io, allocator, image, .{
+        .n_levels = self.n_levels,
+        .scale_factor = self.scale_factor,
+    });
     defer pyramid.deinit();
 
     return self.detectWithPyramid(allocator, pyramid);
@@ -130,17 +126,13 @@ pub fn detect(self: Orb, io: Io, allocator: Allocator, image: Image(u8)) ![]KeyP
 
 /// Compute descriptors for detected keypoints
 pub fn compute(self: Orb, io: Io, allocator: Allocator, image: Image(u8), keypoints: []const KeyPoint) ![]BinaryDescriptor {
-    var pyramid = try ImagePyramid(u8).build(
-        io,
-        allocator,
-        image,
-        self.n_levels,
-        self.scale_factor,
-        1.6, // blur_sigma for anti-aliasing
-    );
+    var pyramid = try ImagePyramid(u8).init(io, allocator, image, .{
+        .n_levels = self.n_levels,
+        .scale_factor = self.scale_factor,
+    });
     defer pyramid.deinit();
 
-    return self.computeWithPyramid(allocator, pyramid, keypoints);
+    return computeWithPyramid(allocator, pyramid, keypoints);
 }
 
 /// Detect keypoints using a pre-built pyramid
@@ -191,7 +183,7 @@ fn detectWithPyramid(self: Orb, allocator: Allocator, pyramid: ImagePyramid(u8))
 
         // Compute orientation and scale coordinates
         // Scale-aware edge margin: smaller at higher pyramid levels
-        const scale = std.math.pow(f32, self.scale_factor, @as(f32, @floatFromInt(level)));
+        const scale = pyramid.getScale(@intCast(level));
         const edge_margin = @as(f32, self.edge_threshold) / scale;
         const min_margin = 3.0; // Minimum margin for FAST detector
         const actual_margin = @max(min_margin, edge_margin);
@@ -221,7 +213,7 @@ fn detectWithPyramid(self: Orb, allocator: Allocator, pyramid: ImagePyramid(u8))
 }
 
 /// Compute descriptors using a pre-built pyramid
-fn computeWithPyramid(self: Orb, allocator: Allocator, pyramid: ImagePyramid(u8), keypoints: []const KeyPoint) ![]BinaryDescriptor {
+fn computeWithPyramid(allocator: Allocator, pyramid: ImagePyramid(u8), keypoints: []const KeyPoint) ![]BinaryDescriptor {
     var descriptors = try allocator.alloc(BinaryDescriptor, keypoints.len);
 
     for (keypoints, 0..) |kp, i| {
@@ -229,7 +221,7 @@ fn computeWithPyramid(self: Orb, allocator: Allocator, pyramid: ImagePyramid(u8)
         const level_image = pyramid.levels[level];
 
         // Scale keypoint to pyramid level
-        const scale = std.math.pow(f32, self.scale_factor, @as(f32, @floatFromInt(level)));
+        const scale = pyramid.getScale(@intCast(level));
         const level_kp = KeyPoint{
             .x = kp.x / scale,
             .y = kp.y / scale,
@@ -254,14 +246,10 @@ pub fn detectAndCompute(
     image: Image(u8),
 ) !struct { keypoints: []KeyPoint, descriptors: []BinaryDescriptor } {
     // Build pyramid once for both detection and description
-    var pyramid = try ImagePyramid(u8).build(
-        io,
-        allocator,
-        image,
-        self.n_levels,
-        self.scale_factor,
-        1.6, // blur_sigma for anti-aliasing
-    );
+    var pyramid = try ImagePyramid(u8).init(io, allocator, image, .{
+        .n_levels = self.n_levels,
+        .scale_factor = self.scale_factor,
+    });
     defer pyramid.deinit();
 
     // Detect keypoints using the pyramid
@@ -269,7 +257,7 @@ pub fn detectAndCompute(
     errdefer allocator.free(keypoints);
 
     // Compute descriptors using the same pyramid
-    const descriptors = try self.computeWithPyramid(allocator, pyramid, keypoints);
+    const descriptors = try computeWithPyramid(allocator, pyramid, keypoints);
 
     return .{
         .keypoints = keypoints,

--- a/src/image/pyramid.zig
+++ b/src/image/pyramid.zig
@@ -36,9 +36,6 @@ pub fn ImagePyramid(comptime T: type) type {
         /// Number of levels actually built
         n_levels: u8,
 
-        /// Allocator used for the pyramid (needed for cleanup)
-        allocator: Allocator,
-
         /// Build an image pyramid from the source image
         pub fn init(io: Io, allocator: Allocator, source: Image(T), options: Options) !Self {
             const n_levels = options.n_levels;
@@ -87,14 +84,13 @@ pub fn ImagePyramid(comptime T: type) type {
                 .levels = levels,
                 .scale_factor = scale_factor,
                 .n_levels = @intCast(count),
-                .allocator = allocator,
             };
         }
 
         /// Free all owned pyramid levels
-        pub fn deinit(self: *Self) void {
-            for (self.levels[1..]) |*level| level.deinit(self.allocator);
-            self.allocator.free(self.levels);
+        pub fn deinit(self: *Self, allocator: Allocator) void {
+            for (self.levels[1..]) |*level| level.deinit(allocator);
+            allocator.free(self.levels);
         }
 
         /// Get the scale factor for a specific level
@@ -151,7 +147,7 @@ test "ImagePyramid basic construction" {
     }
 
     var pyramid = try ImagePyramid(u8).init(test_io, allocator, image, .{ .n_levels = 5, .scale_factor = 1.5, .blur_sigma = 1.0 });
-    defer pyramid.deinit();
+    defer pyramid.deinit(allocator);
 
     try expectEqual(@as(u8, 5), pyramid.n_levels);
     try expectEqual(@as(f32, 1.5), pyramid.scale_factor);
@@ -180,7 +176,7 @@ test "ImagePyramid scale calculations" {
     defer image.deinit(allocator);
 
     var pyramid = try ImagePyramid(u8).init(test_io, allocator, image, .{ .n_levels = 4, .scale_factor = 1.2, .blur_sigma = 1.0 });
-    defer pyramid.deinit();
+    defer pyramid.deinit(allocator);
 
     try expectApproxEqAbs(@as(f32, 1.0), pyramid.getScale(0), 0.01);
     try expectApproxEqAbs(@as(f32, 1.2), pyramid.getScale(1), 0.01);
@@ -204,7 +200,7 @@ test "ImagePyramid truncation for small images" {
 
     // Request more levels than the 8x8 minimum allows.
     var pyramid = try ImagePyramid(u8).init(test_io, allocator, image, .{ .n_levels = 10, .scale_factor = 2.0, .blur_sigma = 1.0 });
-    defer pyramid.deinit();
+    defer pyramid.deinit(allocator);
 
     try expect(pyramid.n_levels < 10);
     const last_level = pyramid.levels[pyramid.n_levels - 1];
@@ -219,7 +215,7 @@ test "ImagePyramid memory usage" {
     defer image.deinit(allocator);
 
     var pyramid = try ImagePyramid(u8).init(test_io, allocator, image, .{ .n_levels = 4, .scale_factor = 1.5, .blur_sigma = 1.0 });
-    defer pyramid.deinit();
+    defer pyramid.deinit(allocator);
 
     const total_pixels = pyramid.totalPixels();
     const memory = pyramid.memoryUsage();

--- a/src/image/pyramid.zig
+++ b/src/image/pyramid.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Io = std.Io;
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
+const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const expectApproxEqAbs = std.testing.expectApproxEqAbs;
 
@@ -13,131 +14,105 @@ pub fn ImagePyramid(comptime T: type) type {
     return struct {
         const Self = @This();
 
-        /// Array of images at different scales
+        pub const Options = struct {
+            /// Levels requested; the pyramid stops early once a level would fall below `min_size`.
+            n_levels: u8 = 8,
+            /// Scale factor between adjacent levels
+            scale_factor: f32 = 1.2,
+            /// Base sigma of the anti-aliasing blur applied before downsampling
+            blur_sigma: f32 = 1.6,
+            /// Smallest allowed level dimension in pixels
+            min_size: u32 = 8,
+
+            pub const default: Options = .{};
+        };
+
+        /// Level 0 aliases the caller's image and is never freed; the rest are owned.
         levels: []Image(T),
 
-        /// Scale factor between adjacent levels (typically 1.2 for ORB)
+        /// Scale factor between adjacent levels
         scale_factor: f32,
 
-        /// Number of levels in the pyramid
+        /// Number of levels actually built
         n_levels: u8,
-
-        /// Sigma for Gaussian blur before downsampling
-        blur_sigma: f32,
 
         /// Allocator used for the pyramid (needed for cleanup)
         allocator: Allocator,
 
         /// Build an image pyramid from the source image
-        pub fn build(
-            io: Io,
-            allocator: Allocator,
-            source: Image(T),
-            n_levels: u8,
-            scale_factor: f32,
-            blur_sigma: f32,
-        ) !Self {
+        pub fn init(io: Io, allocator: Allocator, source: Image(T), options: Options) !Self {
+            const n_levels = options.n_levels;
+            const scale_factor = options.scale_factor;
             assert(n_levels > 0);
             assert(scale_factor > 1.0);
-            assert(blur_sigma > 0);
+            assert(options.blur_sigma > 0);
 
             var levels = try allocator.alloc(Image(T), n_levels);
             @memset(levels, .empty);
             errdefer {
-                for (levels[1..]) |*level| {
-                    if (level.rows > 0) level.deinit(allocator);
-                }
+                for (levels) |*level| level.deinit(allocator);
                 allocator.free(levels);
             }
 
-            // First level is the original image (no copy, just reference)
-            levels[0] = source;
+            // Full-size blur scratch, allocated on first use and reused across levels.
+            var blurred: Image(T) = .empty;
+            defer blurred.deinit(allocator);
 
-            // Build subsequent levels from original for better quality
+            // Every level is resampled from the original rather than cascaded, for quality.
+            var count: usize = n_levels;
             for (1..n_levels) |i| {
-                // Calculate dimensions for this level
-                const scale = std.math.pow(f32, scale_factor, @as(f32, @floatFromInt(i)));
-                const new_rows: u32 = @max(1, @as(u32, @trunc(@as(f32, @floatFromInt(source.rows)) / scale)));
-                const new_cols: u32 = @max(1, @as(u32, @trunc(@as(f32, @floatFromInt(source.cols)) / scale)));
-
-                // Skip if image becomes too small
-                if (new_rows < 8 or new_cols < 8) {
-                    // Truncate pyramid here
-                    const actual_levels = try allocator.realloc(levels, i);
-                    return .{
-                        .levels = actual_levels,
-                        .scale_factor = scale_factor,
-                        .n_levels = @intCast(i),
-                        .blur_sigma = blur_sigma,
-                        .allocator = allocator,
-                    };
+                const scale = std.math.pow(f32, scale_factor, @floatFromInt(i));
+                const new_rows: u32 = @trunc(@as(f32, @floatFromInt(source.rows)) / scale);
+                const new_cols: u32 = @trunc(@as(f32, @floatFromInt(source.cols)) / scale);
+                if (new_rows < options.min_size or new_cols < options.min_size) {
+                    count = i;
+                    break;
                 }
 
-                // Apply Gaussian blur to original for anti-aliasing
-                // Use adaptive sigma based on scale factor
-                const sigma = blur_sigma * @sqrt(scale * scale - 1.0);
-                var blurred: Image(T) = .empty;
-                defer blurred.deinit(allocator);
-
-                // Apply Gaussian blur if sigma > 0.5
-                if (sigma > 0.5) {
-                    blurred = try .initLike(allocator, source);
+                // Anti-aliasing sigma grows with the downscale ratio.
+                const sigma = options.blur_sigma * @sqrt(scale * scale - 1.0);
+                const src = if (sigma > 0.5) blk: {
+                    if (blurred.rows == 0) blurred = try .initLike(allocator, source);
                     try source.gaussianBlur(io, allocator, blurred, sigma, .default);
-                }
+                    break :blk blurred;
+                } else source;
 
-                // Allocate and resize to create the new level
                 levels[i] = try .init(allocator, new_rows, new_cols);
-
-                // Use bilinear interpolation for downsampling from original or blurred
-                const source_to_use = if (blurred.rows > 0) blurred else source;
-                source_to_use.resize(io, allocator, levels[i], .bilinear);
+                src.resize(io, allocator, levels[i], .bilinear);
             }
+            if (count < n_levels) levels = try allocator.realloc(levels, count);
+            levels[0] = source;
 
             return .{
                 .levels = levels,
                 .scale_factor = scale_factor,
-                .n_levels = n_levels,
-                .blur_sigma = blur_sigma,
+                .n_levels = @intCast(count),
                 .allocator = allocator,
             };
         }
 
-        /// Build a pyramid with default ORB parameters
-        pub fn buildDefault(io: Io, allocator: Allocator, source: Image(T)) !Self {
-            return build(io, allocator, source, 8, 1.2, 1.6);
-        }
-
-        /// Free all allocated pyramid levels (except the first which is not owned)
+        /// Free all owned pyramid levels
         pub fn deinit(self: *Self) void {
-            // Skip first level as it's not owned by the pyramid
-            for (self.levels[1..]) |*level| {
-                level.deinit(self.allocator);
-            }
+            for (self.levels[1..]) |*level| level.deinit(self.allocator);
             self.allocator.free(self.levels);
         }
 
         /// Get the scale factor for a specific level
         pub fn getScale(self: Self, level: u8) f32 {
             assert(level < self.n_levels);
-            return std.math.pow(f32, self.scale_factor, @as(f32, @floatFromInt(level)));
+            return std.math.pow(f32, self.scale_factor, @floatFromInt(level));
         }
 
         /// Convert coordinates from pyramid level to original image coordinates
         pub fn toOriginalCoords(self: Self, level: u8, x: f32, y: f32) struct { x: f32, y: f32 } {
             const scale = self.getScale(level);
-            return .{
-                .x = x * scale,
-                .y = y * scale,
-            };
+            return .{ .x = x * scale, .y = y * scale };
         }
 
         /// Convert coordinates from original image to pyramid level coordinates
         pub fn toPyramidCoords(self: Self, level: u8, x: f32, y: f32) struct { x: f32, y: f32 } {
             const scale = self.getScale(level);
-            return .{
-                .x = x / scale,
-                .y = y / scale,
-            };
+            return .{ .x = x / scale, .y = y / scale };
         }
 
         /// Get the image at a specific pyramid level
@@ -149,9 +124,7 @@ pub fn ImagePyramid(comptime T: type) type {
         /// Calculate the total number of pixels across all pyramid levels
         pub fn totalPixels(self: Self) usize {
             var total: usize = 0;
-            for (self.levels) |level| {
-                total += @as(usize, level.rows) * @as(usize, level.cols);
-            }
+            for (self.levels) |level| total += level.size();
             return total;
         }
 
@@ -164,46 +137,37 @@ pub fn ImagePyramid(comptime T: type) type {
     };
 }
 
-// Tests
+const test_io = std.Io.Threaded.global_single_threaded.io();
+
 test "ImagePyramid basic construction" {
     const allocator = std.testing.allocator;
 
-    // Create a test image
     var image = try Image(u8).init(allocator, 640, 480);
     defer image.deinit(allocator);
-
-    // Fill with test pattern
     for (0..image.rows) |r| {
         for (0..image.cols) |c| {
             image.at(r, c).* = @intCast((r + c) % 256);
         }
     }
 
-    // Build pyramid
-    var pyramid = try ImagePyramid(u8).build(std.Io.Threaded.global_single_threaded.io(), allocator, image, 5, 1.5, 1.0);
+    var pyramid = try ImagePyramid(u8).init(test_io, allocator, image, .{ .n_levels = 5, .scale_factor = 1.5, .blur_sigma = 1.0 });
     defer pyramid.deinit();
 
     try expectEqual(@as(u8, 5), pyramid.n_levels);
     try expectEqual(@as(f32, 1.5), pyramid.scale_factor);
-
-    // Check first level is original size
     try expectEqual(@as(u32, 640), pyramid.levels[0].rows);
     try expectEqual(@as(u32, 480), pyramid.levels[0].cols);
 
-    // Check subsequent levels are smaller
     for (1..pyramid.n_levels) |i| {
         const level = pyramid.levels[i];
         const prev_level = pyramid.levels[i - 1];
+        try expect(level.rows < prev_level.rows);
+        try expect(level.cols < prev_level.cols);
 
-        try expectEqual(true, level.rows < prev_level.rows);
-        try expectEqual(true, level.cols < prev_level.cols);
-
-        // Check approximate scaling
+        // Dimensions are truncated, so the realized scale is only approximate.
         const expected_scale = pyramid.getScale(@intCast(i));
         const actual_row_scale = @as(f32, @floatFromInt(image.rows)) / @as(f32, @floatFromInt(level.rows));
         const actual_col_scale = @as(f32, @floatFromInt(image.cols)) / @as(f32, @floatFromInt(level.cols));
-
-        // Should be approximately correct (within rounding)
         try expectApproxEqAbs(expected_scale, actual_row_scale, 1.0);
         try expectApproxEqAbs(expected_scale, actual_col_scale, 1.0);
     }
@@ -215,16 +179,14 @@ test "ImagePyramid scale calculations" {
     var image = try Image(u8).init(allocator, 100, 100);
     defer image.deinit(allocator);
 
-    var pyramid = try ImagePyramid(u8).build(std.Io.Threaded.global_single_threaded.io(), allocator, image, 4, 1.2, 1.0);
+    var pyramid = try ImagePyramid(u8).init(test_io, allocator, image, .{ .n_levels = 4, .scale_factor = 1.2, .blur_sigma = 1.0 });
     defer pyramid.deinit();
 
-    // Test scale factors
     try expectApproxEqAbs(@as(f32, 1.0), pyramid.getScale(0), 0.01);
     try expectApproxEqAbs(@as(f32, 1.2), pyramid.getScale(1), 0.01);
     try expectApproxEqAbs(@as(f32, 1.44), pyramid.getScale(2), 0.01);
     try expectApproxEqAbs(@as(f32, 1.728), pyramid.getScale(3), 0.01);
 
-    // Test coordinate conversions
     const orig = pyramid.toOriginalCoords(2, 10, 20);
     try expectApproxEqAbs(@as(f32, 14.4), orig.x, 0.01);
     try expectApproxEqAbs(@as(f32, 28.8), orig.y, 0.01);
@@ -237,21 +199,17 @@ test "ImagePyramid scale calculations" {
 test "ImagePyramid truncation for small images" {
     const allocator = std.testing.allocator;
 
-    // Start with a small image
     var image = try Image(u8).init(allocator, 32, 32);
     defer image.deinit(allocator);
 
-    // Request many levels but expect truncation
-    var pyramid = try ImagePyramid(u8).build(std.Io.Threaded.global_single_threaded.io(), allocator, image, 10, 2.0, 1.0);
+    // Request more levels than the 8x8 minimum allows.
+    var pyramid = try ImagePyramid(u8).init(test_io, allocator, image, .{ .n_levels = 10, .scale_factor = 2.0, .blur_sigma = 1.0 });
     defer pyramid.deinit();
 
-    // Should have fewer levels due to minimum size constraint
-    try expectEqual(true, pyramid.n_levels < 10);
-
-    // Last level should be at least 8x8
+    try expect(pyramid.n_levels < 10);
     const last_level = pyramid.levels[pyramid.n_levels - 1];
-    try expectEqual(true, last_level.rows >= 8);
-    try expectEqual(true, last_level.cols >= 8);
+    try expect(last_level.rows >= 8);
+    try expect(last_level.cols >= 8);
 }
 
 test "ImagePyramid memory usage" {
@@ -260,18 +218,15 @@ test "ImagePyramid memory usage" {
     var image = try Image(u8).init(allocator, 256, 256);
     defer image.deinit(allocator);
 
-    var pyramid = try ImagePyramid(u8).build(std.Io.Threaded.global_single_threaded.io(), allocator, image, 4, 1.5, 1.0);
+    var pyramid = try ImagePyramid(u8).init(test_io, allocator, image, .{ .n_levels = 4, .scale_factor = 1.5, .blur_sigma = 1.0 });
     defer pyramid.deinit();
 
     const total_pixels = pyramid.totalPixels();
     const memory = pyramid.memoryUsage();
 
-    // First level has 256*256 = 65536 pixels
-    // Subsequent levels are progressively smaller
-    try expectEqual(true, total_pixels > 65536);
-    try expectEqual(true, total_pixels < 65536 * 2); // Should be less than 2x original
-
-    // Memory should be reasonable
-    try expectEqual(true, memory > total_pixels); // At least pixel data
-    try expectEqual(true, memory < total_pixels * 2); // But not excessive
+    // Level 0 alone is 65536 pixels; the geometric tail stays under one more copy.
+    try expect(total_pixels > 65536);
+    try expect(total_pixels < 65536 * 2);
+    try expect(memory > total_pixels);
+    try expect(memory < total_pixels * 2);
 }


### PR DESCRIPTION
## Summary
- `ImagePyramid.build` is renamed `init` and takes an `Options` struct (`n_levels`, `scale_factor`, `blur_sigma`, `min_size`) with `pub const default` as the ORB preset. This replaces three positional parameters, the ORB-specific `buildDefault`, and the write-only `blur_sigma` field. ORB's three call sites pass only the two knobs it owns.
- The pyramid is now unmanaged: it no longer stores its allocator and `deinit(allocator)` takes it like `Image`. The caller already holds it to free the aliased level 0.
- `init` allocates the full-size blur scratch once and reuses it across levels (one allocation instead of `n_levels - 1`, byte-identical output), returns through a single path, makes the blur decision once, and drops the dead `@max(1, …)` clamp and the redundant deinit guard.
- ORB computes its per-level scale through `pyramid.getScale` instead of re-deriving the power from its own copy of the scale factor. `computeWithPyramid` no longer needs `self`.
- `totalPixels` uses `Image.size()`, and the tests use `expect` and a shared single-threaded `Io`.