### PR TITLE
refactor(image): make HoughTransform unmanaged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **Python `Font` replaces `BitmapFont`**: `Font.load` detects the format and `Canvas.draw_text` takes a pixel `size`. ([#403](https://github.com/arrufat/zignal/pull/403))
 - **JPEG encodes write a restart marker per MCU row by default** (`EncodeOptions.restart_interval`, about 0.1 % larger files) so they decode in parallel; `.none` restores the old bytes. ([#466](https://github.com/arrufat/zignal/pull/466))
 - **`ImagePyramid.init(io, allocator, source, options)`**: `build` is renamed `init` and takes an `Options` struct (`n_levels`, `scale_factor`, `blur_sigma`, `min_size`, `.default` is the ORB preset) in place of three positional parameters; the pyramid no longer stores its allocator, so `deinit(allocator)` takes it like `Image`; `buildDefault` and the write-only `blur_sigma` field are gone.
+- **`HoughTransform.deinit(allocator)`**: the transform no longer stores its allocator, matching `Image`.
 - **Minimum Zig version is 0.17.0-dev.1970.**
 
 ### Features

--- a/examples/src/hough_animation.zig
+++ b/examples/src/hough_animation.zig
@@ -55,7 +55,7 @@ pub export fn init() void {
 pub export fn deinit() void {
     if (!initialized) return;
     const allocator = std.heap.wasm_allocator;
-    hough.deinit();
+    hough.deinit(allocator);
     img.deinit(allocator);
     accumulator.deinit(allocator);
     initialized = false;

--- a/src/image/hough.zig
+++ b/src/image/hough.zig
@@ -29,7 +29,6 @@ pub const HoughTransform = struct {
     cos_table: []i32,
     sin_table: []i32,
     y_cache: []i32,
-    allocator: Allocator,
 
     const Self = @This();
 
@@ -61,14 +60,13 @@ pub const HoughTransform = struct {
             .cos_table = cos_table,
             .sin_table = sin_table,
             .y_cache = y_cache,
-            .allocator = allocator,
         };
     }
 
-    pub fn deinit(self: *Self) void {
-        self.allocator.free(self.cos_table);
-        self.allocator.free(self.sin_table);
-        self.allocator.free(self.y_cache);
+    pub fn deinit(self: *Self, allocator: Allocator) void {
+        allocator.free(self.cos_table);
+        allocator.free(self.sin_table);
+        allocator.free(self.y_cache);
     }
 
     /// Performs the Hough Transform on a binary edge image, adding votes to `accumulator`,
@@ -266,7 +264,7 @@ test "HoughTransform: detect horizontal line" {
     for (0..size) |c| edges.at(32, c).* = 255;
 
     var hough: HoughTransform = try .init(allocator, size);
-    defer hough.deinit();
+    defer hough.deinit(allocator);
     var accumulator: Image(u32) = try .init(allocator, size, size);
     defer accumulator.deinit(allocator);
     accumulator.fill(0);


### PR DESCRIPTION
## Summary
- `HoughTransform` no longer stores its allocator; `deinit(allocator)` takes it like `Image`. The caller already holds it to free the accumulator and edge image.
- Updated the in-file test and the `hough_animation` wasm example.
- Follows the same change to `ImagePyramid` in #474; `Tracer` and `JpegState` are handled in separate PRs.