### PR TITLE
ci: run the test workflow once per pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: test
 
 on:
   push:
+    branches: [master]
     paths:
       - ".github/workflows/test.yml"
       - "**.zig"


### PR DESCRIPTION
## Summary
- The test workflow's push trigger had no branch filter, so every push to a PR branch ran the suite twice, once as a push and once as a pull request.
- Pushes now only trigger it on master, so a PR gets one run and the merged result gets one.