### PR TITLE
perf(image): resize any pixel type through the axis tap tables

### DIFF
--- a/src/image/interpolation.zig
+++ b/src/image/interpolation.zig
@@ -77,19 +77,20 @@ pub fn interpolate(comptime T: type, self: Image(T), x: f32, y: f32, method: Int
 
 /// Resizes `self` into the pre-allocated `out` image using the given interpolation `method`,
 /// in row bands on `io`. u8, f32 and u8-struct images (views included) take the separable
-/// passes and use `allocator` for the tap tables and the row rings, sampling per pixel if
-/// that allocation fails; other pixel types sample per pixel and do not allocate.
+/// passes and use `allocator` for the tap tables and the row rings; other pixel types gather
+/// the `taps x taps` window per pixel through the same tap tables. Every path samples per
+/// pixel, without allocating, when the tables cannot be allocated.
 pub fn resize(comptime T: type, io: Io, self: Image(T), out: Image(T), allocator: Allocator, method: Interpolation) void {
     if (self.rows == out.rows and self.cols == out.cols) return self.copy(out);
 
     // Planes take the separable resizers; u8 struct pixels run through them interleaved.
     const P = comptime if (T == u8 or T == f32) T else if (@typeInfo(T) == .@"struct" and meta.allFieldsAreU8(T)) u8 else void;
     if (P == void) {
-        resizeGeneric(T, io, self, out, method);
+        resizeGeneric(T, io, self, out, allocator, method);
     } else {
         const src = if (P == T) self else elementView(T, self);
         const dst = if (P == T) out else elementView(T, out);
-        resizePlane(P, comptime Image(T).channels(), io, src, dst, allocator, method) catch resizeGeneric(T, io, self, out, method);
+        resizePlane(P, comptime Image(T).channels(), io, src, dst, allocator, method) catch resizePerPixel(T, io, self, out, method);
     }
 }
 
@@ -183,13 +184,71 @@ fn SeparablePlane(comptime P: type, comptime channels: usize) type {
     };
 }
 
-/// Generic per-pixel resize fallback, in output-row bands.
-fn resizeGeneric(comptime T: type, io: Io, self: Image(T), out: Image(T), method: Interpolation) void {
-    const ctx: GenericResize(T) = .{ .src = self, .out = out, .method = method };
-    parallel.forRowBands(io, out.rows, parallel.bandCount(out.rows, out.cols), &ctx, GenericResize(T).band);
+/// Any pixel type, in output-row bands: the x and y tap tables are built once and every
+/// output pixel gathers its `taps x taps` source window directly (no per-pixel kernel
+/// evaluation, index mirroring or normalization). Nearest, empty sources and table
+/// allocation failure sample per pixel instead.
+fn resizeGeneric(comptime T: type, io: Io, self: Image(T), out: Image(T), allocator: Allocator, method: Interpolation) void {
+    if (method != .nearest and self.rows > 0 and self.cols > 0) tapped: {
+        const x_taps = channel_ops.AxisTaps(f32).init(allocator, self.cols, out.cols, method) catch break :tapped;
+        defer x_taps.deinit(allocator);
+        const y_taps = channel_ops.AxisTaps(f32).init(allocator, self.rows, out.rows, method) catch break :tapped;
+        defer y_taps.deinit(allocator);
+        const ctx: TappedResize(T) = .{ .src = self, .out = out, .x_taps = x_taps, .y_taps = y_taps };
+        parallel.forRowBands(io, out.rows, parallel.bandCount(out.rows, out.cols), &ctx, TappedResize(T).band);
+        return;
+    }
+    resizePerPixel(T, io, self, out, method);
 }
 
-fn GenericResize(comptime T: type) type {
+fn TappedResize(comptime T: type) type {
+    return struct {
+        src: Image(T),
+        out: Image(T),
+        x_taps: channel_ops.AxisTaps(f32),
+        y_taps: channel_ops.AxisTaps(f32),
+
+        fn band(ctx: *const @This(), _: usize, r0: usize, r1: usize) void {
+            switch (ctx.x_taps.taps) {
+                inline 2, 4, 6 => |taps| ctx.rows(taps, r0, r1),
+                else => unreachable,
+            }
+        }
+
+        fn rows(ctx: *const @This(), comptime taps: usize, r0: usize, r1: usize) void {
+            const src = ctx.src;
+            const out = ctx.out;
+            for (r0..r1) |r| {
+                const wy = ctx.y_taps.weights[r * taps ..][0..taps];
+                var src_rows: [taps][*]const T = undefined;
+                for (ctx.y_taps.indices[r * taps ..][0..taps], &src_rows) |y, *row| row.* = src.data[y * src.stride ..].ptr;
+                for (out.data[r * out.stride ..][0..out.cols], 0..) |*px, c| {
+                    const xs = ctx.x_taps.indices[c * taps ..][0..taps];
+                    const wx = ctx.x_taps.weights[c * taps ..][0..taps];
+                    const n = comptime Image(T).channels();
+                    var sums: [n]f32 = @splat(0);
+                    inline for (0..taps) |j| {
+                        var row_sums: [n]f32 = @splat(0);
+                        inline for (0..taps) |i| {
+                            const pixel = src_rows[j][xs[i]];
+                            inline for (0..n) |ch| row_sums[ch] += channelOf(pixel, ch) * wx[i];
+                        }
+                        inline for (0..n) |ch| sums[ch] += row_sums[ch] * wy[j];
+                    }
+                    px.* = fromChannels(T, sums);
+                }
+            }
+        }
+    };
+}
+
+/// Per-pixel `interpolate` resize, in output-row bands; allocation-free.
+fn resizePerPixel(comptime T: type, io: Io, self: Image(T), out: Image(T), method: Interpolation) void {
+    const ctx: PerPixelResize(T) = .{ .src = self, .out = out, .method = method };
+    parallel.forRowBands(io, out.rows, parallel.bandCount(out.rows, out.cols), &ctx, PerPixelResize(T).band);
+}
+
+fn PerPixelResize(comptime T: type) type {
     return struct {
         src: Image(T),
         out: Image(T),

--- a/src/image/tests/resize.zig
+++ b/src/image/tests/resize.zig
@@ -395,3 +395,67 @@ test "interleaved struct resize matches per-channel planes" {
         }
     }
 }
+
+// Other pixel types gather the taps x taps window through the same tap tables as the planes;
+// against per-pixel `interpolate` (mirror-normalized over the same window) the difference
+// is float summation order, the exact Lanczos kernel against the per-pixel LUT, and integer
+// rounding. Bilinear u16 is checked against the f32 plane instead: `interpolate` quantizes
+// the bilinear fraction to 1/256, which is coarser than a 16-bit sample.
+test "tapped generic resize matches the per-pixel kernel" {
+    const allocator = std.testing.allocator;
+    const interpolation = @import("../interpolation.zig");
+    const Rgbf = color.Rgb(f32);
+    var prng = std.Random.DefaultPrng.init(0x7a95);
+    const random = prng.random();
+    const methods = [_]Interpolation{ .bilinear, .bicubic, .catmull_rom, .{ .mitchell = .default }, .lanczos };
+
+    inline for ([_]type{ u16, Rgbf }) |T| {
+        // Odd sources (one row, one column) exercise the mirrored window on tiny extents.
+        for ([_][2]u32{ .{ 97, 131 }, .{ 1, 131 }, .{ 97, 1 } }) |src_shape| {
+            var src: Image(T) = try .init(allocator, src_shape[0], src_shape[1]);
+            defer src.deinit(allocator);
+            for (src.data) |*px| px.* = if (T == u16) random.int(u16) else .{ .r = 255 * random.float(f32), .g = 255 * random.float(f32), .b = 255 * random.float(f32) };
+
+            for (methods) |method| {
+                for ([_][2]u32{ .{ 61, 47 }, .{ 200, 150 } }) |shape| {
+                    var out: Image(T) = try .init(allocator, shape[0], shape[1]);
+                    defer out.deinit(allocator);
+                    src.resize(io, allocator, out, method);
+                    const scale_x = @as(f32, @floatFromInt(src.cols)) / @as(f32, @floatFromInt(out.cols));
+                    const scale_y = @as(f32, @floatFromInt(src.rows)) / @as(f32, @floatFromInt(out.rows));
+                    for (0..out.rows) |r| {
+                        for (0..out.cols) |c| {
+                            const x = (@as(f32, @floatFromInt(c)) + 0.5) * scale_x - 0.5;
+                            const y = (@as(f32, @floatFromInt(r)) + 0.5) * scale_y - 0.5;
+                            const got = out.at(r, c).*;
+                            const expected = interpolation.interpolate(T, src, x, y, method, .mirror).?;
+                            if (T == u16) {
+                                if (method == .bilinear) continue;
+                                try std.testing.expect(@abs(@as(i32, got) - @as(i32, expected)) <= 1);
+                            } else {
+                                inline for (.{ "r", "g", "b" }) |f| try std.testing.expect(@abs(@field(got, f) - @field(expected, f)) <= 2e-3);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Bilinear u16 against the separable f32 plane of the same samples: within rounding.
+    var src: Image(u16) = try .init(allocator, 97, 131);
+    defer src.deinit(allocator);
+    for (src.data) |*px| px.* = random.int(u16);
+    var src_f: Image(f32) = try .init(allocator, src.rows, src.cols);
+    defer src_f.deinit(allocator);
+    for (src_f.data, src.data) |*f, v| f.* = @as(f32, v);
+    for ([_][2]u32{ .{ 61, 47 }, .{ 200, 150 } }) |shape| {
+        var out: Image(u16) = try .init(allocator, shape[0], shape[1]);
+        defer out.deinit(allocator);
+        var out_f: Image(f32) = try .init(allocator, shape[0], shape[1]);
+        defer out_f.deinit(allocator);
+        src.resize(io, allocator, out, .bilinear);
+        src_f.resize(io, allocator, out_f, .bilinear);
+        for (out.data, out_f.data) |v, f| try std.testing.expect(@abs(@as(f32, v) - f) <= 1);
+    }
+}


### PR DESCRIPTION
## Summary

`resizeGeneric`, the resize path for pixel types that are not u8, f32 or all-u8 structs (`Image(u16)`, `Image(i32)`, `Image(Rgb(f32))`, ...), called `interpolate` per output pixel and so recomputed the kernel, the mirrored indices and the normalisation for every pixel, although the x taps depend only on the column and the y taps only on the row.

- Build the two `channel_ops.AxisTaps(f32)` tables once and gather the `taps x taps` window per pixel with direct row-pointer indexing, on the shared `channelOf`/`fromChannels` helpers.
- The allocation-free per-pixel loop stays as `resizePerPixel` for nearest, empty sources and table allocation failure, so `resize` keeps its `void` signature and its OOM behaviour.
- New test pins `u16` and `Rgb(f32)` (including 1-row and 1-col sources) against per-pixel `interpolate` for all five kernels, and u16 bilinear against the separable f32 plane.

Behaviour note: u16 bilinear output changes. The old path quantised the fraction to 1/256, which is up to 128 LSB per axis at 16 bits; the new float path is within 1 LSB of the f32 plane reference. Every other kernel and type is within rounding of the old result.

## Measurements

Pinned (`taskset -c 0 perf stat`), old / new; u8 plane paths have identical checksums.

| Workload | Instructions | Cycles |
|---|---|---|
| u16 300x400 to 450x600, lanczos + bicubic + bilinear | 4.64x | 3.69x |
| u16 1280x720 to 400x225 lanczos | 3.69x | 3.00x |
| Rgb(f32) 640x360 to 1280x720 bicubic | 4.58x | 4.12x |
| u8 lanczos + bicubic resize (reference) | 1.00x | 1.00x |