### PR TITLE
perf(image): gather nearest resize rows through a column table

### DIFF
--- a/src/image/channel_ops.zig
+++ b/src/image/channel_ops.zig
@@ -233,10 +233,18 @@ pub fn resizePlaneNearest(
     const x_ratio = @as(f32, @floatFromInt(src_cols)) / @as(f32, @floatFromInt(dst_cols));
     const y_ratio = @as(f32, @floatFromInt(src_rows)) / @as(f32, @floatFromInt(dst_rows));
 
+    var prev_y: ?u32 = null;
     for (r_start..r_end) |r| {
         const src_y = nearestIndex(r, src_rows, y_ratio);
         const src_row = src[src_y * src_stride ..][0 .. @as(usize, src_cols) * channels];
         const dst_row = dst[r * dst_stride ..][0 .. @as(usize, dst_cols) * channels];
+
+        // Upscales repeat source rows; the previous output row is already that gather.
+        if (prev_y == src_y) {
+            @memcpy(dst_row, dst[(r - 1) * dst_stride ..][0..dst_row.len]);
+            continue;
+        }
+        prev_y = src_y;
 
         if (col_idx) |cols| {
             for (cols, 0..) |src_x, c| {

--- a/src/image/channel_ops.zig
+++ b/src/image/channel_ops.zig
@@ -206,8 +206,15 @@ fn PlaneBands(comptime T: type, comptime Plane: type) type {
 // Direct plane resize: output rows [r_start, r_end) of a dst_rows x dst_cols plane
 // ============================================================================
 
+/// Source index nearest to output position `i` along an axis of `src_len` resampled to `dst_len`.
+pub fn nearestIndex(i: usize, src_len: u32, ratio: f32) u32 {
+    const center = (@as(f32, @floatFromInt(i)) + 0.5) * ratio - 0.5;
+    return @max(0, @min(src_len - 1, @as(u32, @round(center))));
+}
+
 /// Nearest neighbor resize of a contiguous plane; `channels` > 1 means interleaved pixels
-/// of `channels` elements each (dimensions count pixels).
+/// of `channels` elements each (dimensions count pixels). `col_idx`, when given, holds
+/// `nearestIndex` for every output column so rows are pure gathers.
 pub fn resizePlaneNearest(
     comptime P: type,
     comptime channels: usize,
@@ -219,6 +226,7 @@ pub fn resizePlaneNearest(
     src_cols: u32,
     dst_rows: u32,
     dst_cols: u32,
+    col_idx: ?[]const u32,
     r_start: usize,
     r_end: usize,
 ) void {
@@ -226,13 +234,19 @@ pub fn resizePlaneNearest(
     const y_ratio = @as(f32, @floatFromInt(src_rows)) / @as(f32, @floatFromInt(dst_rows));
 
     for (r_start..r_end) |r| {
-        const src_y_f = (@as(f32, @floatFromInt(r)) + 0.5) * y_ratio - 0.5;
-        const src_y = @max(0, @min(src_rows - 1, @as(u32, @round(src_y_f))));
+        const src_y = nearestIndex(r, src_rows, y_ratio);
+        const src_row = src[src_y * src_stride ..][0 .. @as(usize, src_cols) * channels];
+        const dst_row = dst[r * dst_stride ..][0 .. @as(usize, dst_cols) * channels];
 
-        for (0..dst_cols) |c| {
-            const src_x_f = (@as(f32, @floatFromInt(c)) + 0.5) * x_ratio - 0.5;
-            const src_x = @max(0, @min(src_cols - 1, @as(u32, @round(src_x_f))));
-            dst[r * dst_stride + c * channels ..][0..channels].* = src[src_y * src_stride + src_x * channels ..][0..channels].*;
+        if (col_idx) |cols| {
+            for (cols, 0..) |src_x, c| {
+                dst_row[c * channels ..][0..channels].* = src_row[src_x * channels ..][0..channels].*;
+            }
+        } else {
+            for (0..dst_cols) |c| {
+                const src_x = nearestIndex(c, src_cols, x_ratio);
+                dst_row[c * channels ..][0..channels].* = src_row[src_x * channels ..][0..channels].*;
+            }
         }
     }
 }

--- a/src/image/interpolation.zig
+++ b/src/image/interpolation.zig
@@ -103,7 +103,14 @@ fn resizePlane(comptime P: type, comptime channels: usize, io: Io, src: Image(P)
     const dst_cols = dst.cols / ch;
     switch (method) {
         .nearest => {
-            const ctx: DirectPlane(P, channels) = .{ .src = src, .dst = dst };
+            // One column table for every row; without it each row recomputes its columns.
+            const col_idx: ?[]u32 = allocator.alloc(u32, dst_cols) catch null;
+            defer if (col_idx) |cols| allocator.free(cols);
+            if (col_idx) |cols| {
+                const x_ratio = @as(f32, @floatFromInt(src_cols)) / @as(f32, @floatFromInt(dst_cols));
+                for (cols, 0..) |*src_x, c| src_x.* = channel_ops.nearestIndex(c, src_cols, x_ratio);
+            }
+            const ctx: DirectPlane(P, channels) = .{ .src = src, .dst = dst, .col_idx = col_idx };
             parallel.forRowBands(io, dst.rows, parallel.bandCount(dst.rows, dst_cols), &ctx, DirectPlane(P, channels).band);
         },
         .bilinear, .bicubic, .catmull_rom, .mitchell, .lanczos => {
@@ -128,12 +135,13 @@ fn DirectPlane(comptime P: type, comptime channels: usize) type {
     return struct {
         src: Image(P),
         dst: Image(P),
+        col_idx: ?[]const u32,
 
         fn band(ctx: *const @This(), _: usize, r0: usize, r1: usize) void {
             const src = ctx.src;
             const dst = ctx.dst;
             const ch: u32 = channels;
-            channel_ops.resizePlaneNearest(P, channels, src.data, src.stride, dst.data, dst.stride, src.rows, src.cols / ch, dst.rows, dst.cols / ch, r0, r1);
+            channel_ops.resizePlaneNearest(P, channels, src.data, src.stride, dst.data, dst.stride, src.rows, src.cols / ch, dst.rows, dst.cols / ch, ctx.col_idx, r0, r1);
         }
     };
 }


### PR DESCRIPTION
## Summary

`resizePlaneNearest` recomputed the per-column source index (float multiply-add, round, clamp) for every output row, and on upscales re-gathered rows that map to the same source row.

- First commit: `resizePlane`'s nearest arm builds one `u32` column table so every row is a pure gather; the duplicated round/clamp expression becomes `nearestIndex`. The per-pixel loop stays as the fallback when the table cannot be allocated, like the separable arm.
- Second commit: within a band, an output row whose source row matches the previous one is a `memcpy` of the previous output row.

Output is byte-identical (same rounding) for every shape measured.

## Measurements

Pinned (`taskset -c 0 perf stat`), cycles old / new, 10 reps each; the bench includes a fixed fill and hash cost so the resize-only gain is larger (about 4.4 to 0.5 cycles per u8 output pixel).

| Workload | Column table | Plus row memcpy |
|---|---|---|
| u8 1280x720 to 1920x1080 | 3.95x | 4.80x |
| u8 960x540 to 1920x1080 (exact 2x) | 4.46x | 6.48x |
| u8 1920x1080 to 640x360 | 1.37x | 1.37x |
| Rgb(u8) 1280x720 to 1920x1080 | 1.93x | 2.27x |
| Rgba(u8) 1280x720 to 1920x1080 | 2.34x | 2.42x |
| u8 lanczos + bicubic resize (reference) | 1.00x | 0.99x |